### PR TITLE
Refer to real world .dev domain

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at frederik.ring@gmail.com. All
+reported by contacting the project team at mail@offen.dev. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ Project planning and issue tracking is done using [Pivotal Tracker](https://www.
 
 #### Local cookies and SSL
 
-In local development __offen__ requires to be served both via SSL (in order to use window.crypto) as well as a `local.offen.org` host.
+In local development __offen__ requires to be served both via SSL (in order to use window.crypto) as well as a `local.offen.dev` host.
 
 This requires the following steps to be taken:
 
 1. Edit your `/etc/hosts` to include the following line:
   ```
-  127.0.0.1       local.offen.org
+  127.0.0.1       local.offen.dev
   ```
 2. Install and setup [mkcert](https://github.com/FiloSottile/mkcert). Assuming you have Go installed, this looks like:
   ```
   $ go get -u github.com/FiloSottile/mkcert
   $ mkcert -install
   ```
-3. Navigate into the repository root and create a local certificate and key for the `local.offen.org` host:
+3. Navigate into the repository root and create a local certificate and key for the `local.offen.dev` host:
   ```
-  $ mkcert local.offen.org
+  $ mkcert local.offen.dev
   ```
 
 You can test setup by starting the application:
@@ -42,7 +42,7 @@ You can test setup by starting the application:
 $ docker-compose up
 ```
 
-Now you should be able to access <https://local.offen.org:8080/status> in your browser without any security warnings.
+Now you should be able to access <https://local.offen.dev:8080/status> in your browser without any security warnings.
 
 #### `server`
 
@@ -93,4 +93,4 @@ npm test
 
 ### License
 
-MIT © offen
+MIT © [offen](https://www.offen.dev)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ server:
   working_dir: /server
   volumes:
     - ./server:/server
-    - ./local.offen.org.pem:/server/local.offen.org.pem
-    - ./local.offen.org-key.pem:/server/local.offen.org-key.pem
+    - ./local.offen.dev.pem:/server/local.offen.dev.pem
+    - ./local.offen.dev-key.pem:/server/local.offen.dev-key.pem
     - $GOPATH/pkg/mod:/go/pkg/mod
   environment:
     - GOPATH=/go
     - POSTGRES_CONNECTION_STRING=postgres://postgres:develop@database:5432/postgres?sslmode=disable
   ports:
     - 8080:8080
-  command: go run cmd/server/main.go -conn postgres://postgres:develop@database:5432/postgres?sslmode=disable -key local.offen.org-key.pem -cert local.offen.org.pem
+  command: go run cmd/server/main.go -conn postgres://postgres:develop@database:5432/postgres?sslmode=disable -key local.offen.dev-key.pem -cert local.offen.dev.pem
   links:
     - database
 
@@ -25,8 +25,8 @@ vault:
   working_dir: /vault
   volumes:
     - ./vault:/vault
-    - ./local.offen.org.pem:/vault/local.offen.org.pem
-    - ./local.offen.org-key.pem:/vault/local.offen.org-key.pem
+    - ./local.offen.dev.pem:/vault/local.offen.dev.pem
+    - ./local.offen.dev-key.pem:/vault/local.offen.dev-key.pem
   command: npm start -- --port 9977
   ports:
     - 9977:9977

--- a/server/router/exchange.go
+++ b/server/router/exchange.go
@@ -63,7 +63,7 @@ func (rt *router) postUserSecret(w http.ResponseWriter, r *http.Request) {
 		Value:    userID,
 		Expires:  time.Now().Add(time.Hour * 24 * 365),
 		HttpOnly: true,
-		Domain:   ".offen.org",
+		Domain:   ".offen.dev",
 	})
 
 	w.WriteHeader(http.StatusCreated)

--- a/vault/index.js
+++ b/vault/index.js
@@ -1,6 +1,6 @@
 const ensureUserSecret = require('./src/user-secret')
 
-ensureUserSecret('9b63c4d8-65c0-438c-9d30-cc4b01173393', 'https://local.offen.org:8080')
+ensureUserSecret('9b63c4d8-65c0-438c-9d30-cc4b01173393', 'https://local.offen.dev:8080')
   .then(function (userSecret) {
     console.log(userSecret)
   })

--- a/vault/package.json
+++ b/vault/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "budo index.js --live --ssl --cert local.offen.org.pem --key local.offen.org-key.pem",
+    "start": "budo index.js --live --ssl --cert local.offen.dev.pem --key local.offen.dev-key.pem",
     "test": "mochify --allow-chrome-as-root ./**/*.test.js",
     "posttest": "standard",
     "fix": "standard --fix"

--- a/vault/src/user-secret.test.js
+++ b/vault/src/user-secret.test.js
@@ -16,8 +16,8 @@ describe('src/user-secret.js', function () {
   describe('ensureUserSecret(accountId: string, host: string)', function () {
     context('with server responding', function () {
       beforeEach(function () {
-        fetchMock.get('https://server.offen.org/exchange?account_id=7435d1b9-c0ca-4883-a869-42e943589917', response)
-        fetchMock.post('https://server.offen.org/exchange', 201)
+        fetchMock.get('https://server.offen.dev/exchange?account_id=7435d1b9-c0ca-4883-a869-42e943589917', response)
+        fetchMock.post('https://server.offen.dev/exchange', 201)
       })
 
       afterEach(function () {
@@ -26,10 +26,10 @@ describe('src/user-secret.js', function () {
 
       it('handles the key exchange', function () {
         let initialKey
-        return ensureUserSecret('7435d1b9-c0ca-4883-a869-42e943589917', 'https://server.offen.org')
+        return ensureUserSecret('7435d1b9-c0ca-4883-a869-42e943589917', 'https://server.offen.dev')
           .then(function (_initialKey) {
             initialKey = _initialKey
-            return ensureUserSecret('7435d1b9-c0ca-4883-a869-42e943589917', 'https://server.offen.org')
+            return ensureUserSecret('7435d1b9-c0ca-4883-a869-42e943589917', 'https://server.offen.dev')
           })
           .then(function (nextKey) {
             assert.deepStrictEqual(initialKey, nextKey)
@@ -39,8 +39,8 @@ describe('src/user-secret.js', function () {
 
     context('with server failing', function () {
       beforeEach(function () {
-        fetchMock.get('https://server.offen.org/exchange?account_id=8435d1b9-c0ca-4883-a869-42e943589917', 500)
-        fetchMock.post('https://server.offen.org/exchange', 500)
+        fetchMock.get('https://server.offen.dev/exchange?account_id=8435d1b9-c0ca-4883-a869-42e943589917', 500)
+        fetchMock.post('https://server.offen.dev/exchange', 500)
       })
 
       afterEach(function () {
@@ -48,7 +48,7 @@ describe('src/user-secret.js', function () {
       })
 
       it('rejects', function () {
-        return ensureUserSecret('8435d1b9-c0ca-4883-a869-42e943589917', 'https://server.offen.org')
+        return ensureUserSecret('8435d1b9-c0ca-4883-a869-42e943589917', 'https://server.offen.dev')
           .catch(function (err) {
             assert(err)
             return 'SKIP'


### PR DESCRIPTION
`offen.dev` is now the registered domain in use, so this swaps all hypothetical domain references to use real ones.