### PR TITLE
Enable anonymous events

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -4,6 +4,13 @@ var BarChart = require('./../components/bar-chart')
 
 module.exports = view
 
+function formatPercentage (value) {
+  return (value * 100).toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1
+  })
+}
+
 function view (state, emit) {
   function handleOptoutRequest () {
     state.model.optOut = true
@@ -46,15 +53,12 @@ function view (state, emit) {
     ? 'users'
     : 'accounts'
   var uniqueSessions = state.model.uniqueSessions
-  var bounceRate = (state.model.bounceRate * 100).toLocaleString(undefined, {
-    maximumFractionDigits: 1,
-    minimumFractionDigits: 1
-  })
   var usersAndSessions = html`
     <div class="row">
       <h4><strong>${uniqueEntities}</strong> unique ${entityName} </h4>
       <h4><strong>${uniqueSessions}</strong> unique sessions</h4>
-      <h4><strong>${bounceRate}%</strong> bounce rate</h4>
+      <h4><strong>${formatPercentage(state.model.bounceRate)}%</strong> bounce rate</h4>
+      ${isOperator ? html`<h4><strong>${formatPercentage(state.model.loss)}%</strong> plus</h4>` : null}
     </div>
   `
 

--- a/auditorium/views/main.test.js
+++ b/auditorium/views/main.test.js
@@ -12,7 +12,7 @@ describe('views/main.js', function () {
   })
 
   describe('mainView', function () {
-    it('renders 6 sections for operators', function () {
+    it('renders 7 sections for operators', function () {
       app.state.model = {
         pageviews: [
           { date: '12.12.2019', pageviews: 12 }
@@ -29,6 +29,7 @@ describe('views/main.js', function () {
             origin: 'www.puppies.com'
           }
         ],
+        loss: 0.1234,
         account: {
           name: 'Test Account'
         }
@@ -40,7 +41,7 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 6)
+      assert.strictEqual(headlines.length, 7)
 
       var chart = result.querySelector('.chart')
       assert(chart)
@@ -56,6 +57,7 @@ describe('views/main.js', function () {
         uniqueSessions: 12,
         bounceRate: 0.5412,
         referrers: [{}],
+        loss: 0,
         pages: [
           {
             pathname: '/',

--- a/server/persistence/persistence.go
+++ b/server/persistence/persistence.go
@@ -26,10 +26,10 @@ type UserResult struct {
 // EventResult is an element returned from a query. It contains all data that
 // is stored about an atomic event.
 type EventResult struct {
-	AccountID string `json:"accountId"`
-	UserID    string `json:"userId"`
-	EventID   string `json:"eventId"`
-	Payload   string `json:"payload"`
+	AccountID string  `json:"accountId"`
+	UserID    *string `json:"userId"`
+	EventID   string  `json:"eventId"`
+	Payload   string  `json:"payload"`
 }
 
 // EventsByAccountID groups a list of events by AccountID in a response

--- a/server/persistence/relational/accounts.go
+++ b/server/persistence/relational/accounts.go
@@ -53,7 +53,9 @@ func (r *relationalDatabase) GetAccount(accountID string, events bool, eventsSin
 			Payload:   evt.Payload,
 			AccountID: evt.AccountID,
 		})
-		userSecrets[evt.HashedUserID] = evt.User.EncryptedUserSecret
+		if evt.HashedUserID != nil {
+			userSecrets[*evt.HashedUserID] = evt.User.EncryptedUserSecret
+		}
 	}
 
 	result.Events = &eventResults
@@ -111,7 +113,7 @@ func (r *relationalDatabase) AssociateUserSecret(accountID, userID, encryptedUse
 				return fmt.Errorf("relational: error migrating existing events: %v", err)
 			}
 			ev.EventID = newID
-			ev.HashedUserID = parkedHash
+			ev.HashedUserID = &parkedHash
 			if err := txn.Create(&ev).Error; err != nil {
 				txn.Rollback()
 				return fmt.Errorf("relational: error migrating existing events: %v", err)

--- a/server/persistence/relational/models.go
+++ b/server/persistence/relational/models.go
@@ -15,7 +15,7 @@ import (
 type Event struct {
 	EventID      string `gorm:"primary_key"`
 	AccountID    string
-	HashedUserID string
+	HashedUserID *string
 	Payload      string
 	Account      Account `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
 	User         User    `gorm:"foreignkey:HashedUserID;association_foreignkey:HashedUserID"`

--- a/server/router/events_test.go
+++ b/server/router/events_test.go
@@ -50,14 +50,6 @@ func TestRouter_PostEvents(t *testing.T) {
 			`{"error":"invalid character 'h' in literal true (expecting 'r')","status":400}`,
 		},
 		{
-			"bad request context",
-			&mockInsertDatabase{},
-			nil,
-			[]string{"whoops"},
-			http.StatusInternalServerError,
-			`{"error":"could not use user id in request context","status":500}`,
-		},
-		{
 			"ok",
 			&mockInsertDatabase{},
 			bytes.NewReader([]byte(`{"accountId":"account-identifier","payload":"payload-value"}`)),
@@ -140,8 +132,9 @@ func (m *mockQueryDatabase) Query(q persistence.Query) (map[string][]persistence
 		eventID = q.Since()
 	}
 	for _, id := range q.AccountIDs() {
+		userID := q.UserID()
 		out[id] = append(out[id], persistence.EventResult{
-			UserID:  q.UserID(),
+			UserID:  &userID,
 			Payload: m.payload,
 			EventID: eventID,
 		})

--- a/vault/src/api.js
+++ b/vault/src/api.js
@@ -66,9 +66,13 @@ exports.postEvent = postEventWith(process.env.SERVER_HOST + '/events')
 exports.postEventWith = postEventWith
 
 function postEventWith (eventsUrl) {
-  return function (body) {
+  return function (body, anonymous) {
+    var url = new window.URL(eventsUrl)
+    if (anonymous) {
+      url.search = new window.URLSearchParams({ anonymous: '1' })
+    }
     return window
-      .fetch(eventsUrl, {
+      .fetch(url, {
         method: 'POST',
         credentials: 'include',
         body: JSON.stringify(body)
@@ -109,6 +113,9 @@ function getPublicKeyWith (exchangeUrl) {
         credentials: 'include'
       })
       .then(handleFetchResponse)
+      .then(function (response) {
+        return response.publicKey
+      })
   }
 }
 

--- a/vault/src/handle-anonymous-event.js
+++ b/vault/src/handle-anonymous-event.js
@@ -1,12 +1,12 @@
 var relayEvent = require('./relay-event')
 
-module.exports = handleAnalyticsEvent
+module.exports = handleAnonymousEvent
 
-// handleAnalyticsEvent relays the incoming message to a server.
+// handleAnonymousEvent relays the incoming message to a server.
 // It is **important** that this handler does **not** call the passed
 // response function as this would try responding to untrusted domains and
 // raise an error.
-function handleAnalyticsEvent (message, respond) {
+function handleAnonymousEvent (message, respond) {
   var accountId = message.payload.accountId
-  return relayEvent(accountId, message.payload.event, false)
+  return relayEvent(accountId, message.payload.event, true)
 }

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -29,7 +29,7 @@ describe('src/queries.js', function () {
               Object.keys(data),
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
-                'referrers', 'pages', 'pageviews', 'bounceRate'
+                'referrers', 'pages', 'pageviews', 'bounceRate', 'loss'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
@@ -150,6 +150,33 @@ describe('src/queries.js', function () {
               referrer: '',
               timestamp: subDays(now, 12).toJSON()
             }
+          },
+          {
+            accountId: 'test-account-1',
+            userId: null,
+            eventId: 'test-event-7',
+            payload: {
+              type: 'PAGEVIEW',
+              timestamp: now.toJSON()
+            }
+          },
+          {
+            accountId: 'test-account-1',
+            userId: null,
+            eventId: 'test-event-8',
+            payload: {
+              type: 'PAGEVIEW',
+              timestamp: subDays(now, 12).toJSON()
+            }
+          },
+          {
+            accountId: 'test-account-1',
+            userId: null,
+            eventId: 'test-event-9',
+            payload: {
+              type: 'PAGEVIEW',
+              timestamp: subDays(now, 4).toJSON()
+            }
           }
         ])
       })
@@ -161,7 +188,7 @@ describe('src/queries.js', function () {
               Object.keys(data),
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
-                'referrers', 'pages', 'pageviews', 'bounceRate'
+                'referrers', 'pages', 'pageviews', 'bounceRate', 'loss'
               ]
             )
 
@@ -188,6 +215,8 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.pageviews[3].visitors, 0)
 
             assert.strictEqual(data.bounceRate, 0.75)
+
+            assert.strictEqual(data.loss, 2 / 7)
           })
       })
     })

--- a/vault/src/relay-event.js
+++ b/vault/src/relay-event.js
@@ -11,27 +11,33 @@ module.exports.relayEventWith = relayEventWith
 // the given accountId. It ensures a local user secret exists for the given
 // accountId and uses it to encrypt the event payload before performing the request.
 function relayEventWith (api, ensureUserSecret) {
-  var relayEvent = function (accountId, event) {
+  var relayEvent = function (accountId, event, anonymous) {
   // `flush` is not supposed to be part of the public signature, but will only
   // be used when the function recursively calls itself
-    var flush = arguments[2] || false
-    event = augmentEventData(event, accountId)
-    return ensureUserSecret(accountId, flush)
-      .then(function (userSecret) {
-        var encryptEventPayload = crypto.encryptSymmetricWith(userSecret)
+    var flush = arguments[3] || false
+    event = prepareEventData(event, accountId, anonymous)
+
+    // if data is collected anonymously, the account's public key is used
+    // for encrypting the payload instead
+    var getSecret = anonymous
+      ? api.getPublicKey(accountId).then(crypto.importPublicKey).then(crypto.encryptAsymmetricWith)
+      : ensureUserSecret(accountId, flush).then(crypto.encryptSymmetricWith)
+
+    return getSecret
+      .then(function (encryptEventPayload) {
         return encryptEventPayload(event)
       })
       .then(function (encryptedEventPayload) {
         return api.postEvent({
           accountId: accountId,
           payload: encryptedEventPayload
-        })
+        }, anonymous)
           .catch(function (err) {
             // a 400 response is sent in case no cookie is present in the request.
             // This means the secret exchange can happen one more time
             // before retrying to send the event.
-            if (err.status === 400 && !flush) {
-              return relayEvent(accountId, event, true)
+            if (err.status === 400 && !flush && !anonymous) {
+              return relayEvent(accountId, event, anonymous, true)
             }
             throw err
           })
@@ -40,10 +46,24 @@ function relayEventWith (api, ensureUserSecret) {
   return relayEvent
 }
 
-// augmentEventData adds properties to an event that could be subject to spoofing
+// prepareEventData adds properties to an event that could be subject to spoofing
 // or unwanted access by 3rd parties in "script". For example adding the session id
 // here instead of the script prevents other scripts from reading this value.
-function augmentEventData (inboundPayload, accountId) {
+function prepareEventData (inboundPayload, accountId, anonymous) {
+  var now = new Date()
+  if (anonymous) {
+    return {
+      timestamp: now,
+      type: inboundPayload.type
+    }
+  }
+  return Object.assign({}, inboundPayload, {
+    timestamp: now,
+    sessionId: getSessionId(accountId)
+  })
+}
+
+function getSessionId (accountId) {
   // even though the session identifier will be included in the encrypted part
   // of the event we generate a unique identifier per account so that each session
   // is unique per account and cannot be cross-referenced
@@ -58,8 +78,5 @@ function augmentEventData (inboundPayload, accountId) {
   } catch (err) {
     sessionId = uuid()
   }
-  return Object.assign({}, inboundPayload, {
-    timestamp: new Date(),
-    sessionId: sessionId
-  })
+  return sessionId
 }

--- a/vault/src/user-secret.js
+++ b/vault/src/user-secret.js
@@ -37,9 +37,7 @@ function ensureUserSecretWith (api, queries) {
 
 function exchangeUserSecret (api, accountId) {
   return api.getPublicKey(accountId)
-    .then(function (body) {
-      return generateNewUserSecret(body.publicKey)
-    })
+    .then(generateNewUserSecret)
     .then(function (result) {
       var body = {
         accountId: accountId,

--- a/vault/src/user-secret.test.js
+++ b/vault/src/user-secret.test.js
@@ -3,12 +3,9 @@ var assert = require('assert')
 var ensureUserSecret = require('./user-secret')
 
 var response = {
-  'accountId': '9b63c4d8-65c0-438c-9d30-cc4b01173393',
-  'publicKey': {
-    'kty': 'RSA',
-    'n': 'sWDRHwcAfKv1dykP9-Qu-JeRjbmqiVpgzTHgDGMxqkj0ftGhAURBqxAV0CbYXyNGb8g23Jta5JkskwAZ6iugU4bo19T-hqjrGNTm-hynKhtniuvkoxxyzmxnKMlq27k_gdMR_z2Zdoj3mUveRDaAXyaoPmS0ode-s9jSb030KzPhnjcQpa338Qx9Q5BF7MWuQ6013atmU3dM7ibuJ4kwrh_a2b4dj95onh1tPklGYgS1i1fgGWXP16oW1YlAmUtUUFtdnVnNPfSAyMNy1myV2H7q8ZPcZKOz_IyHgAHuB0D6WuIJ-03OzlinxX9RTAS-4dX_vXh7hP24v9-hxIlVIdd9iCQM65shwmXa2NfHYDEaPFo7M-lz_-jHCqCoZIYP3q88hGW9QeVGxAFL3AIJcUb5JRFhw2XqYUUZhLNBBWHUJEmseYP3k4NZr3gG90WTCfxhOmCTzPnCrr9QBINY-ijcyJgPvGEUK8ucq3NdASBQpkHyVcjmr6tmKBDal6jma5xXVX7IexuRINYImGZIuWKF8KTqvaIECR-yP9GdWjAPChHa29j0lZbkUuZbwgeJO5O2GVlImYazz3pR-xRJMOU8N2wipTcCnXJT4oOEYxe3NAv2ulqQESEvS42tb-l0QPDzah4jns86zMAwLNx7hIXas8C77vu9SaQjEzv1tdE',
-    'e': 'AQAB'
-  }
+  'kty': 'RSA',
+  'n': 'sWDRHwcAfKv1dykP9-Qu-JeRjbmqiVpgzTHgDGMxqkj0ftGhAURBqxAV0CbYXyNGb8g23Jta5JkskwAZ6iugU4bo19T-hqjrGNTm-hynKhtniuvkoxxyzmxnKMlq27k_gdMR_z2Zdoj3mUveRDaAXyaoPmS0ode-s9jSb030KzPhnjcQpa338Qx9Q5BF7MWuQ6013atmU3dM7ibuJ4kwrh_a2b4dj95onh1tPklGYgS1i1fgGWXP16oW1YlAmUtUUFtdnVnNPfSAyMNy1myV2H7q8ZPcZKOz_IyHgAHuB0D6WuIJ-03OzlinxX9RTAS-4dX_vXh7hP24v9-hxIlVIdd9iCQM65shwmXa2NfHYDEaPFo7M-lz_-jHCqCoZIYP3q88hGW9QeVGxAFL3AIJcUb5JRFhw2XqYUUZhLNBBWHUJEmseYP3k4NZr3gG90WTCfxhOmCTzPnCrr9QBINY-ijcyJgPvGEUK8ucq3NdASBQpkHyVcjmr6tmKBDal6jma5xXVX7IexuRINYImGZIuWKF8KTqvaIECR-yP9GdWjAPChHa29j0lZbkUuZbwgeJO5O2GVlImYazz3pR-xRJMOU8N2wipTcCnXJT4oOEYxe3NAv2ulqQESEvS42tb-l0QPDzah4jns86zMAwLNx7hIXas8C77vu9SaQjEzv1tdE',
+  'e': 'AQAB'
 }
 
 describe('src/user-secret.js', function () {


### PR DESCRIPTION
This PR introduces the concept of "anonymous events".

These events are being emitted by users that disallow third-party cookies. Instead of trying to work around this limitation, _offen_ is supposed to behave in the following way:

- an event with a blank user identifier, containing nothing but a timestamp is being sent to the server
- instead of using a user-bound secret for encrypting this event, the account's public key is being used
- the operator can now calculate a "loss" / "plus" rate, which tells them how many anoynmous events have been recorded in the selected timeframe and can extrapolate the actual numbers from this rate

As users that have disabled third-party cookies won't have a user identifier they of course cannot access any of this data in the auditorium.