### PR TITLE
Load bootstrap.css from CDN

### DIFF
--- a/accounts/accounts/__init__.py
+++ b/accounts/accounts/__init__.py
@@ -15,7 +15,7 @@ import accounts.api
 
 app.config["FLASK_ADMIN_SWATCH"] = "flatly"
 
-admin = Admin(app, name="offen admin", template_mode="bootstrap3")
+admin = Admin(app, name="offen admin", template_mode="bootstrap3", base_template="index.html")
 
 admin.add_view(AccountView(Account, db.session))
 admin.add_view(UserView(User, db.session))

--- a/accounts/accounts/templates/index.html
+++ b/accounts/accounts/templates/index.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>offen accounts</title>
-</head>
-<body>
-  <h1>Welcome to offen accounts</h1>
-</body>
-</html>
+{% extends 'admin/base.html' %}
+
+{% block head_css %}
+    <link href="https://stackpath.bootstrapcdn.com/bootswatch/3.3.5/flatly/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ admin_static.url(filename='admin/css/bootstrap3/admin.css', v='1.1.1') }}" rel="stylesheet">
+    <link href="{{ admin_static.url(filename='admin/css/bootstrap3/submenu.css') }}" rel="stylesheet">
+    {% if admin_view.extra_css %}
+      {% for css_url in admin_view.extra_css %}
+        <link href="{{ css_url }}" rel="stylesheet">
+      {% endfor %}
+    {% endif %}
+    <style>
+    body {
+        padding-top: 4px;
+    }
+    </style>
+{% endblock %}


### PR DESCRIPTION
Solves: https://www.pivotaltracker.com/story/show/167340920

There seems to be no easy way of having AWS API Gateway serve the font files as binary as the delivery in a proxy integration is based on Accept-Headers for which browsers send `*/*` here, meaning the choice is to either send all responses as binary or none.

This PR just replaces the local version of Bootstrap with a CDN one.