### PR TITLE
Add SRI values to auditorium, add custom headers to cloudfront distributions

### DIFF
--- a/auditorium/gulpfile.js
+++ b/auditorium/gulpfile.js
@@ -7,6 +7,7 @@ var rev = require('gulp-rev')
 var runSequence = require('run-sequence')
 var buffer = require('vinyl-buffer')
 var revReplace = require('gulp-rev-replace')
+var sriHash = require('gulp-sri-hash')
 
 gulp.task('clean:pre', function () {
   return gulp
@@ -55,6 +56,8 @@ gulp.task('bundle:vendor', function () {
 gulp.task('revreplace', function () {
   return gulp.src('./index.html')
     .pipe(revReplace({ manifest: gulp.src('./dist/rev-manifest.json') }))
+    .pipe(gulp.dest('./dist/'))
+    .pipe(sriHash({ relative: true }))
     .pipe(gulp.dest('./dist/'))
 })
 

--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -34,6 +34,7 @@
     "gulp-clean": "^0.4.0",
     "gulp-rev": "^9.0.0",
     "gulp-rev-replace": "^0.4.4",
+    "gulp-sri-hash": "^2.2.0",
     "gulp-uglify": "^3.0.2",
     "html-inline": "^1.2.0",
     "http-server": "^0.11.1",

--- a/auditorium/serverless.yml
+++ b/auditorium/serverless.yml
@@ -103,6 +103,9 @@ resources:
           Enabled: true
           DefaultRootObject: index.html
           DefaultCacheBehavior:
+            LambdaFunctionAssociations:
+              - EventType: 'viewer-request'
+                LambdaFunctionARN: ${ssm:/aws/reference/secretsmanager/${self:custom.stage}/all/securityHeadersLambdaARN~true}
             Compress: true
             AllowedMethods:
               - GET

--- a/vault/serverless.yml
+++ b/vault/serverless.yml
@@ -101,6 +101,9 @@ resources:
           Enabled: true
           DefaultRootObject: index.html
           DefaultCacheBehavior:
+            LambdaFunctionAssociations:
+              - EventType: 'viewer-request'
+                LambdaFunctionARN: ${ssm:/aws/reference/secretsmanager/${self:custom.stage}/all/securityHeadersLambdaARN~true}
             Compress: true
             AllowedMethods:
               - GET


### PR DESCRIPTION
Following up on: https://www.pivotaltracker.com/story/show/167253128

Cloudfront does not pass through security-related headers from the S3 configuration, so this uses the Lambda@Edge function defined in https://github.com/offen/cloudfront-custom-headers insteadto add these.

X-Frame-Options are missing on purpose as the `vault` requires to be iframed by arbitrary hosts.