### PR TITLE
Make opt-out cookies same site

### DIFF
--- a/script/index.js
+++ b/script/index.js
@@ -18,7 +18,7 @@ function collectPageview () {
 
 checkSupport(function (err) {
   if (err) {
-    console.log('"offen" does not support this site, or you have opted out: ' + err.message)
+    console.log('"offen" does not support this site: ' + err.message)
     console.log('No data will be collected. Find out more at "https://www.offen.dev".')
     return
   }

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -60,6 +60,7 @@ func (rt *router) optoutCookie(optout bool) *http.Cookie {
 		// this cookie is supposed to be read by the client so it can
 		// stop operating before even sending requests
 		HttpOnly: false,
+		SameSite: http.SameSiteDefaultMode,
 	}
 	if !optout {
 		c.Expires = time.Unix(0, 0)


### PR DESCRIPTION
This prevents 3rd parties from having users involuntarily opt-in or opt-out by loading the pixel on arbitrary sites.

Opting in and out of __offen__ needs to be limited to pages running int the context of the *.offen.dev domain instead.