### PR TITLE
Use session cookies instead of session storage for session identifier

### DIFF
--- a/vault/src/relay-event.js
+++ b/vault/src/relay-event.js
@@ -68,10 +68,23 @@ function getSessionId (accountId) {
   var sessionId
   try {
     var lookupKey = 'session-' + accountId
-    sessionId = window.sessionStorage.getItem(lookupKey)
+    var matches = document.cookie.split(';')
+      .map(function (chunk) {
+        return chunk.trim().split('=')
+      })
+      .filter(function (pair) {
+        return pair[0] === lookupKey
+      })
+      .map(function (pair) {
+        return pair[1]
+      })
+    sessionId = matches.length
+      ? matches[0]
+      : null
+
     if (!sessionId) {
       sessionId = uuid()
-      window.sessionStorage.setItem(lookupKey, sessionId)
+      document.cookie = [lookupKey, sessionId].join('=')
     }
   } catch (err) {
     sessionId = uuid()


### PR DESCRIPTION
This should make the notion of a "session" clearer as it will persist across windows, but still be gone once the browser is closed.