### PR TITLE
Add unit tests to persistence package

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       KMS_ENCRYPTION_ENDPOINT: http://kms:8081/encrypt
       PORT: 8080
       JWT_PUBLIC_KEY: http://accounts:5000/api/key
+      DEVELOPMENT: '1'
     ports:
       - 8080:8080
     command: refresh run

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -23,6 +23,7 @@ func main() {
 		jwtPublicKey       = flag.String("jwt", os.Getenv("JWT_PUBLIC_KEY"), "the location of the JWT public key")
 		secureCookie       = flag.Bool("secure", false, "use secure cookies")
 		encryptionEndpoint = flag.String("kms", os.Getenv("KMS_ENCRYPTION_ENDPOINT"), "the KMS service's encryption endpoint")
+		development        = flag.Bool("develop", os.Getenv("DEVELOPMENT") != "", "add verbose logging")
 	)
 	flag.Parse()
 
@@ -37,6 +38,7 @@ func main() {
 	db, err := relational.New(
 		relational.WithConnectionString(*connectionString),
 		relational.WithEncryption(encryption),
+		relational.WithLogging(*development),
 	)
 	if err != nil {
 		logger.WithError(err).Fatal("unable to establish database connection")

--- a/server/persistence/relational/accounts.go
+++ b/server/persistence/relational/accounts.go
@@ -163,7 +163,7 @@ func (r *relationalDatabase) CreateAccount(accountID, name string) error {
 	if encryptErr != nil {
 		return fmt.Errorf("relational: error encrypting account private key: %v", encryptErr)
 	}
-	return r.db.Save(&Account{
+	return r.db.Create(&Account{
 		AccountID:          accountID,
 		Name:               name,
 		PublicKey:          string(publicKey),

--- a/server/persistence/relational/accounts_test.go
+++ b/server/persistence/relational/accounts_test.go
@@ -1,0 +1,394 @@
+package relational
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/offen/offen/server/keys"
+	"github.com/offen/offen/server/persistence"
+)
+
+var publicKey = `
+-----BEGIN RSA PUBLIC KEY-----
+MIICCgKCAgEAv3dlQ+5f7GfcJkctx59+Cyoygf+snYdRmU6gdaZ5hoB+mCe4DeEa
+3hl42S6HfMJI/qfotmL3J67eP4r+dCqtRvjzUUMSyBDqbtatSndIZ+M1meIn8676
+2xrm5aSUYO5egyD9QwcxoUiNSgea3+5DWKlA8FeH8ViFFfiPM59n2BlbqB9vh5Ps
+fQldsn2HQzW86UWnvBU3OKKRzVxFEJ3HLIc2C3XifcKGo7aZjthUVcrX2KrHK5Mp
+Vcxh+HicKOGbkjOGlTO6ybEO259n4mPj3mlzgRjZznGY/5c/pNfKBoi/EvZTR5rH
+FmlmSQ6HjqqRa0oEOFjGZqLPsZGtTV6kDVCNGE8iaBNn5cvzeGP8nu+FgVILIvpH
+C0A6iarc5Q3BSOoJFVPfmSQoQrwiLlBRRiMGEl2YVjOJ1YH+uBXJlH8LkT1jFmQ/
+kTEq5D2Ej6W/KW9wVJjGvLkphlmbqhECMsSzz79q2blKD8WwoxQO3xvH/vLLTBUN
+62GDbF2Iozpbly+74Tu4uruLgXRukm30kfaAqPrnOSSNDI5EIMoqPh4n1L9S05vD
+57CJIw83Lr67SuMgCzXnR0CgV/U+8iVO772BqsPilbOA3yRbaW9DOQJWTcDn+gwb
+kkGaifOHQRQyqOSH4cUXORZt8DECJRt69kjg1F5SBfjGed4kVhIp4nUCAwEAAQ==
+-----END RSA PUBLIC KEY-----
+`
+
+func createTestDatabase() (*gorm.DB, func() error) {
+	db, err := gorm.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	if err := db.AutoMigrate(&Event{}, &Account{}, &User{}).Error; err != nil {
+		panic(err)
+	}
+	return db, db.Close
+}
+
+type mockEncrypter struct {
+	result []byte
+	err    error
+}
+
+func (m *mockEncrypter) Encrypt([]byte) ([]byte, error) {
+	return m.result, m.err
+}
+
+func TestRelationalDatabase_CreateAccount(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*gorm.DB) error
+		encryption  keys.Encrypter
+		assertion   func(*gorm.DB) error
+		expectError bool
+	}{
+		{
+			"ok",
+			func(db *gorm.DB) error {
+				return nil
+			},
+			&mockEncrypter{
+				result: []byte("shhhhh,secret"),
+			},
+			func(db *gorm.DB) error {
+				var account Account
+				if err := db.Find(&account).Where("account_id = ?", "account-id").Error; err != nil {
+					return err
+				}
+				if account.Name != "account-name" {
+					return fmt.Errorf("Unexpected account name %v", account.Name)
+				}
+				if account.PublicKey == "" {
+					return errors.New("Unexpected empty public key")
+				}
+				if account.EncryptedSecretKey != "shhhhh,secret" {
+					return fmt.Errorf("Unexpected encrypted secret key %v", account.EncryptedSecretKey)
+				}
+				return nil
+			},
+			false,
+		},
+		{
+			"account exists",
+			func(db *gorm.DB) error {
+				return db.Create(&Account{
+					AccountID: "account-id",
+					Name:      "account-name",
+				}).Error
+			},
+			&mockEncrypter{
+				result: []byte("shhhhh,secret"),
+			},
+			func(db *gorm.DB) error {
+				return nil
+			},
+			true,
+		},
+		{
+			"encryption error",
+			func(db *gorm.DB) error {
+				return nil
+			},
+			&mockEncrypter{
+				err: errors.New("did not work"),
+			},
+			func(db *gorm.DB) error {
+				count := 0
+				db.Find(&Account{}).Where("account_id = ?", "account-id").Count(&count)
+				if count != 0 {
+					return errors.New("Unexpected account creation")
+				}
+				return nil
+			},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, cleanUp := createTestDatabase()
+			defer cleanUp()
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Unexpected error setting up test %v", err)
+			}
+			relational := &relationalDatabase{
+				db:         db,
+				encryption: test.encryption,
+			}
+			err := relational.CreateAccount("account-id", "account-name")
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+			if err := test.assertion(db); err != nil {
+				t.Errorf("Unexpected assertion error %v", err)
+			}
+		})
+	}
+}
+
+func TestRelationalDatabase_GetAccount(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(*gorm.DB) error
+		includeEvents bool
+		eventsSince   string
+		assertion     func(persistence.AccountResult) error
+		expectError   bool
+	}{
+		{
+			"unknown account",
+			func(*gorm.DB) error {
+				return nil
+			},
+			false,
+			"",
+			func(r persistence.AccountResult) error {
+				if !reflect.DeepEqual(r, persistence.AccountResult{}) {
+					return fmt.Errorf("unexpected result %#v\n", r)
+				}
+				return nil
+			},
+			true,
+		},
+		{
+			"without events",
+			func(db *gorm.DB) error {
+				return db.Create(&Account{
+					AccountID:          "account-id",
+					Name:               "test-name",
+					PublicKey:          publicKey,
+					EncryptedSecretKey: "encrypted-secret-key",
+					UserSalt:           "user-salt",
+				}).Error
+			},
+			false,
+			"",
+			func(r persistence.AccountResult) error {
+				if r.AccountID != "account-id" {
+					return fmt.Errorf("unexpected account id %v", r.AccountID)
+				}
+				if r.EncryptedSecretKey != "" {
+					return fmt.Errorf("expected empty secret key, got %v", r.EncryptedSecretKey)
+				}
+				if r.Events != nil {
+					return fmt.Errorf("expected nil events, got %v", r.Events)
+				}
+				if r.UserSecrets != nil {
+					return fmt.Errorf("expected nil user secrets, got %v", r.UserSecrets)
+				}
+				return nil
+			},
+			false,
+		},
+		{
+			"including events",
+			func(db *gorm.DB) error {
+				if err := db.Create(&Account{
+					AccountID:          "account-id",
+					Name:               "test-name",
+					PublicKey:          publicKey,
+					EncryptedSecretKey: "encrypted-secret-key",
+					UserSalt:           "user-salt",
+				}).Error; err != nil {
+					return err
+				}
+				userID := "hashed-user-id"
+				if err := db.Create(&User{
+					HashedUserID:        userID,
+					EncryptedUserSecret: "encrypted-user-secret",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "account-id",
+					HashedUserID: &userID,
+					Payload:      "payload",
+					EventID:      "event-id-1",
+				}).Error; err != nil {
+					return err
+				}
+				return db.Create(&Event{
+					AccountID:    "account-id",
+					HashedUserID: &userID,
+					Payload:      "other-payload",
+					EventID:      "event-id-0",
+				}).Error
+			},
+			true,
+			"event-id-0",
+			func(r persistence.AccountResult) error {
+				if r.AccountID != "account-id" {
+					return fmt.Errorf("unexpected account id %v", r.AccountID)
+				}
+				if r.EncryptedSecretKey != "encrypted-secret-key" {
+					return fmt.Errorf("unexpected secret key %v", r.EncryptedSecretKey)
+				}
+				userID := "hashed-user-id"
+				if !reflect.DeepEqual(r.Events, &persistence.EventsByAccountID{
+					"account-id": []persistence.EventResult{
+						{
+							AccountID: "account-id",
+							UserID:    &userID,
+							Payload:   "payload",
+							EventID:   "event-id-1",
+						},
+					},
+				}) {
+					return fmt.Errorf("unexpected events %v", r.Events)
+				}
+				if !reflect.DeepEqual(r.UserSecrets, &persistence.SecretsByUserID{
+					"hashed-user-id": "encrypted-user-secret",
+				}) {
+					return fmt.Errorf("unexpected user secrets %v", r.UserSecrets)
+				}
+				return nil
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Unexpected error setting up test %v", err)
+			}
+			relational := &relationalDatabase{
+				db: db,
+			}
+			result, err := relational.GetAccount("account-id", test.includeEvents, test.eventsSince)
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+			if err := test.assertion(result); err != nil {
+				t.Errorf("Unexpected assertion error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRelationalDatabase_AssociateUserSecret(t *testing.T) {
+	a1 := Account{
+		AccountID: "account-id",
+		UserSalt:  "user-salt",
+	}
+	tests := []struct {
+		name        string
+		setup       func(*gorm.DB) error
+		assertion   func(*gorm.DB) error
+		expectError bool
+	}{
+		{
+			"empty database",
+			func(db *gorm.DB) error {
+				return nil
+			},
+			func(db *gorm.DB) error {
+				return nil
+			},
+			true,
+		},
+		{
+			"new user",
+			func(db *gorm.DB) error {
+				return db.Create(&a1).Error
+			},
+			func(db *gorm.DB) error {
+				var user User
+				if err := db.Where("hashed_user_id = ?", a1.HashUserID("user-id")).Find(&user).Error; err != nil {
+					return err
+				}
+				if user.EncryptedUserSecret != "encrypted-user-secret" {
+					return fmt.Errorf("Unexpected value for user secret %v", user.EncryptedUserSecret)
+				}
+				return nil
+			},
+			false,
+		},
+		{
+			"migrating existing user",
+			func(db *gorm.DB) error {
+				if err := db.Create(&a1).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&User{
+					HashedUserID:        a1.HashUserID("user-id"),
+					EncryptedUserSecret: "previous-user-secret",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "event-id",
+					AccountID:    "account-id",
+					Payload:      "payload",
+					HashedUserID: str(a1.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			func(db *gorm.DB) error {
+				var user User
+				if err := db.Where("hashed_user_id = ?", a1.HashUserID("user-id")).Find(&user).Error; err != nil {
+					return err
+				}
+				if user.EncryptedUserSecret != "encrypted-user-secret" {
+					return fmt.Errorf("Unexpected value for user secret %v", user.EncryptedUserSecret)
+				}
+
+				var previous User
+				if err := db.Where("encrypted_user_secret = ?", "previous-user-secret").Find(&previous).Error; err != nil {
+					return err
+				}
+				if previous.HashedUserID == a1.HashUserID("user-id") {
+					return errors.New("user not migrated to a new user identifier")
+				}
+
+				var event Event
+				if err := db.Table("events").First(&event).Error; err != nil {
+					return err
+				}
+				if event.EventID == "event-id" {
+					return errors.New("events not migrated to a new id")
+				}
+				if *event.HashedUserID != previous.HashedUserID {
+					return fmt.Errorf("unexpected user identifier on event %v", *event.HashedUserID)
+				}
+				return nil
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Error setting up test: %v", err)
+			}
+			relational := relationalDatabase{db: db}
+
+			err := relational.AssociateUserSecret("account-id", "user-id", "encrypted-user-secret")
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+			if err := test.assertion(db); err != nil {
+				t.Errorf("Unexpected assertion error: %v", err)
+			}
+		})
+	}
+}

--- a/server/persistence/relational/database.go
+++ b/server/persistence/relational/database.go
@@ -26,6 +26,7 @@ func New(configs ...Config) (persistence.Database, error) {
 	}
 
 	db, err := gorm.Open("postgres", opts.connectionString)
+	db.LogMode(opts.logger)
 	if err != nil {
 		return nil, fmt.Errorf("relational: error opening database: %v", err)
 	}
@@ -37,6 +38,7 @@ type dbOptions struct {
 	dialect          string
 	connectionString string
 	encryption       keys.Encrypter
+	logger           bool
 }
 
 // Config is a function that adds a configuration option to the constructor
@@ -55,5 +57,12 @@ func WithConnectionString(connectionString string) Config {
 func WithEncryption(e keys.Encrypter) Config {
 	return func(opts *dbOptions) {
 		opts.encryption = e
+	}
+}
+
+// WithLogging will print additional debug information when set to true
+func WithLogging(l bool) Config {
+	return func(opts *dbOptions) {
+		opts.logger = l
 	}
 }

--- a/server/persistence/relational/events_test.go
+++ b/server/persistence/relational/events_test.go
@@ -1,0 +1,536 @@
+package relational
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/offen/offen/server/persistence"
+
+	"github.com/jinzhu/gorm"
+)
+
+func TestRelationalDatabase_Insert(t *testing.T) {
+	tests := []struct {
+		name        string
+		userID      string
+		setup       func(*gorm.DB) error
+		assertion   func(*gorm.DB) error
+		expectError bool
+	}{
+		{
+			"unknown account",
+			"user-id",
+			func(*gorm.DB) error {
+				return nil
+			},
+			func(*gorm.DB) error {
+				return nil
+			},
+			true,
+		},
+		{
+			"unknown user",
+			"user-id",
+			func(db *gorm.DB) error {
+				return db.Create(&Account{
+					AccountID: "account-id",
+					UserSalt:  "user-salt",
+				}).Error
+			},
+			func(*gorm.DB) error {
+				return nil
+			},
+			true,
+		},
+		{
+			"ok",
+			"user-id",
+			func(db *gorm.DB) error {
+				a := Account{
+					AccountID: "account-id",
+					UserSalt:  "user-salt",
+				}
+				if err := db.Create(&a).Error; err != nil {
+					return err
+				}
+				return db.Create(&User{
+					HashedUserID:        a.HashUserID("user-id"),
+					EncryptedUserSecret: "encrypted-user-secret",
+				}).Error
+			},
+			func(db *gorm.DB) error {
+				count := 0
+				db.Table("events").Count(&count)
+				if count != 1 {
+					return fmt.Errorf("events table contained %d rows", count)
+				}
+				event := Event{}
+				db.Table("events").First(&event)
+				if event.AccountID != "account-id" {
+					return fmt.Errorf("event has account id %v", event.AccountID)
+				}
+				if event.HashedUserID == nil {
+					return errors.New("event had nil user id")
+				}
+				if *event.HashedUserID == "user-id" {
+					return errors.New("event contains unhashed user identifier")
+				}
+				if event.Payload != "payload" {
+					return fmt.Errorf("event had payload %v", event.Payload)
+				}
+				return nil
+			},
+			false,
+		},
+		{
+			"anonymous event",
+			"",
+			func(db *gorm.DB) error {
+				return db.Create(&Account{
+					AccountID: "account-id",
+					UserSalt:  "user-salt",
+				}).Error
+			},
+			func(db *gorm.DB) error {
+				count := 0
+				db.Table("events").Count(&count)
+				if count != 1 {
+					return fmt.Errorf("events table contained %d rows", count)
+				}
+				event := Event{}
+				db.Table("events").First(&event)
+				if event.AccountID != "account-id" {
+					return fmt.Errorf("event has account id %v", event.AccountID)
+				}
+				if event.HashedUserID != nil {
+					return errors.New("event did not have nil user id")
+				}
+				if event.Payload != "payload" {
+					return fmt.Errorf("event had payload %v", event.Payload)
+				}
+				return nil
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Unexpected error setting up test: %v", err)
+			}
+			relational := &relationalDatabase{db: db}
+			err := relational.Insert(test.userID, "account-id", "payload")
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+			if err := test.assertion(db); err != nil {
+				t.Errorf("Unexpected assertion error: %v", err)
+			}
+		})
+	}
+}
+
+func str(s string) *string {
+	return &s
+}
+func TestRelationalDatabase_Purge(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*gorm.DB) error
+		assertion   func(*gorm.DB) error
+		expectError bool
+	}{
+		{
+			"nothing to purge",
+			func(*gorm.DB) error {
+				return nil
+			},
+			func(*gorm.DB) error {
+				return nil
+			},
+			false,
+		},
+		{
+			"ok",
+			func(db *gorm.DB) error {
+				a := Account{
+					AccountID: "account-id",
+					UserSalt:  "user-salt",
+				}
+				a2 := Account{
+					AccountID: "account-id-2",
+					UserSalt:  "user-salt-2",
+				}
+				if err := db.Create(&a).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&a2).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "event-id-1",
+					HashedUserID: str(a.HashUserID("user-id")),
+					Payload:      "payload",
+					AccountID:    "account-1",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "event-id-2",
+					HashedUserID: str(a.HashUserID("other-user")),
+					Payload:      "payload",
+					AccountID:    "account-1",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "event-id-3",
+					HashedUserID: str(a2.HashUserID("user-id")),
+					Payload:      "payload",
+					AccountID:    "account-2",
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			func(db *gorm.DB) error {
+				count := 0
+				db.Table("events").Count(&count)
+				if count != 1 {
+					return fmt.Errorf("unexpected row count %v", count)
+				}
+				if err := db.First(&Event{EventID: "event-id-2"}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+
+			relational := relationalDatabase{db: db}
+
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Error setting up database %v", err)
+			}
+
+			err := relational.Purge("user-id")
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+
+			if err := test.assertion(db); err != nil {
+				t.Errorf("Assertion error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRelationalDatabase_GetDeletedEvents(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*gorm.DB) error
+		userIDArg   string
+		expectedIDs []string
+		expectError bool
+	}{
+		{
+			"account level",
+			func(db *gorm.DB) error {
+				if err := db.Create(&Account{
+					AccountID: "account-id",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID: "a",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID: "c",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID: "e",
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			"",
+			[]string{"b", "d"},
+			false,
+		},
+		{
+			"user level",
+			func(db *gorm.DB) error {
+				a := Account{
+					AccountID: "account-id",
+					UserSalt:  "user-salt",
+				}
+				if err := db.Create(&a).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "a",
+					HashedUserID: str(a.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "b",
+					HashedUserID: str(a.HashUserID("other-user")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "c",
+					HashedUserID: str(a.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					EventID:      "e",
+					HashedUserID: str(a.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			"user-id",
+			[]string{"d", "b"},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+
+			relational := relationalDatabase{db: db}
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Error setting up test: %v", err)
+			}
+			result, err := relational.GetDeletedEvents([]string{"a", "b", "c", "d"}, test.userIDArg)
+
+			if !reflect.DeepEqual(test.expectedIDs, result) {
+				t.Errorf("Expected %v, got %v", test.expectedIDs, result)
+			}
+
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+		})
+	}
+}
+
+type mockQuery struct {
+	accountIDs []string
+	userID     string
+	since      string
+}
+
+func (m *mockQuery) AccountIDs() []string {
+	return m.accountIDs
+}
+
+func (m *mockQuery) UserID() string {
+	return m.userID
+}
+
+func (m *mockQuery) Since() string {
+	return m.since
+}
+func TestRelationalDatabase_Query(t *testing.T) {
+	a1 := Account{
+		AccountID: "account-id",
+		UserSalt:  "user-salt",
+	}
+	a2 := Account{
+		AccountID: "other-account",
+		UserSalt:  "other-salt",
+	}
+
+	tests := []struct {
+		name           string
+		setup          func(*gorm.DB) error
+		query          mockQuery
+		expectedResult map[string][]persistence.EventResult
+		expectError    bool
+	}{
+		{
+			"empty database",
+			func(db *gorm.DB) error {
+				return nil
+			},
+			mockQuery{userID: "user-id"},
+			map[string][]persistence.EventResult{},
+			false,
+		},
+		{
+			"query all",
+			func(db *gorm.DB) error {
+				if err := db.Create(&a1).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&a2).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "account-id",
+					EventID:      "event-id-1",
+					Payload:      "payload-1",
+					HashedUserID: str(a1.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "account-id",
+					EventID:      "event-id-2",
+					Payload:      "payload-2",
+					HashedUserID: str(a1.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "other-account",
+					EventID:      "event-id-3",
+					Payload:      "payload-3",
+					HashedUserID: str(a2.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "other-account",
+					EventID:      "event-id-4",
+					Payload:      "payload-4",
+					HashedUserID: str(a2.HashUserID("other-user")),
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			mockQuery{userID: "user-id"},
+			map[string][]persistence.EventResult{
+				"account-id": []persistence.EventResult{
+					{
+						AccountID: "account-id",
+						UserID:    str(a1.HashUserID("user-id")),
+						Payload:   "payload-1",
+						EventID:   "event-id-1",
+					},
+					{
+						AccountID: "account-id",
+						UserID:    str(a1.HashUserID("user-id")),
+						Payload:   "payload-2",
+						EventID:   "event-id-2",
+					},
+				},
+				"other-account": []persistence.EventResult{
+					{
+						AccountID: "other-account",
+						UserID:    str(a2.HashUserID("user-id")),
+						Payload:   "payload-3",
+						EventID:   "event-id-3",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"using since parameter",
+			func(db *gorm.DB) error {
+				if err := db.Create(&a1).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&a2).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "account-id",
+					EventID:      "event-id-1",
+					Payload:      "payload-1",
+					HashedUserID: str(a1.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "account-id",
+					EventID:      "event-id-2",
+					Payload:      "payload-2",
+					HashedUserID: str(a1.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "other-account",
+					EventID:      "event-id-3",
+					Payload:      "payload-3",
+					HashedUserID: str(a2.HashUserID("user-id")),
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Event{
+					AccountID:    "other-account",
+					EventID:      "event-id-4",
+					Payload:      "payload-4",
+					HashedUserID: str(a2.HashUserID("other-user")),
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			mockQuery{userID: "user-id", since: "event-id-1"},
+			map[string][]persistence.EventResult{
+				"account-id": []persistence.EventResult{
+					{
+						AccountID: "account-id",
+						UserID:    str(a1.HashUserID("user-id")),
+						Payload:   "payload-2",
+						EventID:   "event-id-2",
+					},
+				},
+				"other-account": []persistence.EventResult{
+					{
+						AccountID: "other-account",
+						UserID:    str(a2.HashUserID("user-id")),
+						Payload:   "payload-3",
+						EventID:   "event-id-3",
+					},
+				},
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Error setting up test: %v", err)
+			}
+
+			relational := relationalDatabase{db: db}
+			result, err := relational.Query(&test.query)
+
+			if (err != nil) != test.expectError {
+				t.Errorf("Unexpected error value %v", err)
+			}
+
+			if !reflect.DeepEqual(test.expectedResult, result) {
+				t.Errorf("Expected %v, got %v", test.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds unit tests for the persistence package in `server` using an in-memory SQLite database for easy creation of isolated one-off environments.

Replaces #74 