### PR TITLE
Scope token auth to specific action

### DIFF
--- a/server/keys/authentication.go
+++ b/server/keys/authentication.go
@@ -19,9 +19,9 @@ type Authentication struct {
 
 // Validate checks if the authentication is valid against the given secret and
 // if it hasn't expired yet.
-func (a *Authentication) Validate(secret []byte) error {
+func (a *Authentication) Validate(scope string, secret []byte) error {
 	mac := hmac.New(sha256.New, secret)
-	_, writeErr := mac.Write([]byte(fmt.Sprintf("%s-%d", a.Token, a.Expires)))
+	_, writeErr := mac.Write([]byte(fmt.Sprintf("%s-%s-%d", scope, a.Token, a.Expires)))
 	if writeErr != nil {
 		return fmt.Errorf("authentication: error decoding signature: %v", writeErr)
 	}
@@ -41,7 +41,7 @@ func (a *Authentication) Validate(secret []byte) error {
 
 // NewAuthentication generates a new set of credentials using the given secret.
 // The credentials are considered valid until the given deadline has passed.
-func NewAuthentication(secret []byte, deadline time.Duration) (*Authentication, error) {
+func NewAuthentication(scope string, secret []byte, deadline time.Duration) (*Authentication, error) {
 	if len(secret) == 0 {
 		return nil, errors.New("authentication: received empty secret, cannot continue")
 	}
@@ -52,7 +52,7 @@ func NewAuthentication(secret []byte, deadline time.Duration) (*Authentication, 
 	expires := time.Now().Add(deadline).Unix()
 
 	mac := hmac.New(sha256.New, secret)
-	_, writeErr := mac.Write([]byte(fmt.Sprintf("%s-%d", token, expires)))
+	_, writeErr := mac.Write([]byte(fmt.Sprintf("%s-%s-%d", scope, token, expires)))
 	if writeErr != nil {
 		return nil, fmt.Errorf("authentication: error writing signature: %v", writeErr)
 	}

--- a/server/keys/authentication_test.go
+++ b/server/keys/authentication_test.go
@@ -7,31 +7,42 @@ import (
 
 func TestAuthentication(t *testing.T) {
 	t.Run("empty secret", func(t *testing.T) {
-		_, err := NewAuthentication(nil, time.Second)
+		_, err := NewAuthentication("test", nil, time.Second)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
 	})
 
 	t.Run("expired", func(t *testing.T) {
-		a, err := NewAuthentication([]byte("ABC123"), time.Millisecond)
+		a, err := NewAuthentication("test", []byte("ABC123"), time.Millisecond)
 		if err != nil {
 			t.Fatalf("Unexpected error %v", err)
 		}
 		time.Sleep(2 * time.Millisecond)
-		if err := a.Validate([]byte("ABC123")); err == nil {
+		if err := a.Validate("test", []byte("ABC123")); err == nil {
 			t.Error("Expected error, got nil")
 		}
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		a, err := NewAuthentication([]byte("ABC123"), time.Second)
+		a, err := NewAuthentication("test", []byte("ABC123"), time.Second)
 		if err != nil {
 			t.Fatalf("Unexpected error %v", err)
 		}
 		time.Sleep(2 * time.Millisecond)
-		if err := a.Validate([]byte("ABC123")); err != nil {
+		if err := a.Validate("test", []byte("ABC123")); err != nil {
 			t.Errorf("Unexpected error %v", err)
+		}
+	})
+
+	t.Run("bad scope", func(t *testing.T) {
+		a, err := NewAuthentication("test", []byte("ABC123"), time.Second)
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		if err := a.Validate("other", []byte("ABC123")); err == nil {
+			t.Error("Expected error, got nil")
 		}
 	})
 
@@ -42,7 +53,7 @@ func TestAuthentication(t *testing.T) {
 			Signature: "c29tZXRoaW5nLXNvbWV0aGluZw==",
 		}
 		time.Sleep(2 * time.Millisecond)
-		if err := a.Validate([]byte("ABC123")); err == nil {
+		if err := a.Validate("test", []byte("ABC123")); err == nil {
 			t.Error("Expected error, got nil")
 		}
 	})

--- a/server/router/optout.go
+++ b/server/router/optout.go
@@ -20,17 +20,32 @@ func serveCookie(cookie *http.Cookie, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (rt *router) postOptoutOptin(w http.ResponseWriter, r *http.Request) {
-	authentication, err := keys.NewAuthentication(rt.cookieExchangeSecret, time.Second*30)
-	if err != nil {
-		httputil.RespondWithJSONError(w, fmt.Errorf("error initiating authentication exchange: %v", err), http.StatusInternalServerError)
-		return
+const (
+	scopeOptin  = "optin"
+	scopeOptout = "optout"
+)
+
+func (rt *router) generateOneTimeAuth(scope string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authentication, err := keys.NewAuthentication(scope, rt.cookieExchangeSecret, time.Second*30)
+		if err != nil {
+			httputil.RespondWithJSONError(w, fmt.Errorf("error initiating authentication exchange: %v", err), http.StatusInternalServerError)
+			return
+		}
+		b, _ := json.Marshal(authentication)
+		w.Write(b)
 	}
-	b, _ := json.Marshal(authentication)
-	w.Write(b)
 }
 
-func (rt *router) validateOnetimeAuth(v url.Values) error {
+func (rt *router) postOptout(w http.ResponseWriter, r *http.Request) {
+	rt.generateOneTimeAuth(scopeOptout)(w, r)
+}
+
+func (rt *router) postOptin(w http.ResponseWriter, r *http.Request) {
+	rt.generateOneTimeAuth(scopeOptin)(w, r)
+}
+
+func (rt *router) validateOnetimeAuth(scope string, v url.Values) error {
 	expires, expiresErr := strconv.ParseInt(v.Get("expires"), 10, 0)
 	if expiresErr != nil {
 		return expiresErr
@@ -40,11 +55,11 @@ func (rt *router) validateOnetimeAuth(v url.Values) error {
 		Token:     v.Get("token"),
 		Signature: v.Get("signature"),
 	}
-	return requestAuth.Validate(rt.cookieExchangeSecret)
+	return requestAuth.Validate(scope, rt.cookieExchangeSecret)
 }
 
 func (rt *router) getOptout(w http.ResponseWriter, r *http.Request) {
-	if err := rt.validateOnetimeAuth(r.URL.Query()); err != nil {
+	if err := rt.validateOnetimeAuth(scopeOptout, r.URL.Query()); err != nil {
 		httputil.RespondWithJSONError(w, fmt.Errorf("credentials not valid: %v", err), http.StatusForbidden)
 		return
 	}
@@ -52,7 +67,7 @@ func (rt *router) getOptout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rt *router) getOptin(w http.ResponseWriter, r *http.Request) {
-	if err := rt.validateOnetimeAuth(r.URL.Query()); err != nil {
+	if err := rt.validateOnetimeAuth(scopeOptin, r.URL.Query()); err != nil {
 		httputil.RespondWithJSONError(w, fmt.Errorf("credentials not valid: %v", err), http.StatusForbidden)
 		return
 	}

--- a/server/router/optout_test.go
+++ b/server/router/optout_test.go
@@ -16,7 +16,7 @@ func TestRouter_optout(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/", nil)
-	rt.postOptoutOptin(w, r)
+	rt.postOptout(w, r)
 
 	cookies := w.Result().Cookies()
 	if len(cookies) != 0 {

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -147,11 +147,11 @@ func New(opts ...Config) http.Handler {
 	m.Use(recovery, cors, json)
 
 	optout := m.PathPrefix("/opt-out").Subrouter()
-	optout.HandleFunc("", rt.postOptoutOptin).Methods(http.MethodPost)
+	optout.HandleFunc("", rt.postOptout).Methods(http.MethodPost)
 	optout.HandleFunc("", rt.getOptout).Methods(http.MethodGet)
 
 	optin := m.PathPrefix("/opt-in").Subrouter()
-	optin.HandleFunc("", rt.postOptoutOptin).Methods(http.MethodPost)
+	optin.HandleFunc("", rt.postOptin).Methods(http.MethodPost)
 	optin.HandleFunc("", rt.getOptin).Methods(http.MethodGet)
 
 	exchange := m.PathPrefix("/exchange").Subrouter()


### PR DESCRIPTION
This allows token auth for optin / optout to be scoped to a specification (i.e. prevent token reuse for the reverse action).