### PR TITLE
Do not include user id in user query results, use hardcoded value

### DIFF
--- a/server/persistence/persistence.go
+++ b/server/persistence/persistence.go
@@ -20,6 +20,7 @@ type Query interface {
 	Since() string
 }
 
+// UserResult contains information about a single user entry
 type UserResult struct {
 	HashedUserID        string `json:"hashedUserId"`
 	EncryptedUserSecret string `json:"encryptedUserSecret"`

--- a/server/persistence/relational/events.go
+++ b/server/persistence/relational/events.go
@@ -80,7 +80,6 @@ func (r *relationalDatabase) Query(query persistence.Query) (map[string][]persis
 	for _, match := range result {
 		out[match.AccountID] = append(out[match.AccountID], persistence.EventResult{
 			AccountID: match.AccountID,
-			UserID:    match.HashedUserID,
 			Payload:   match.Payload,
 			EventID:   match.EventID,
 		})

--- a/server/persistence/relational/events_test.go
+++ b/server/persistence/relational/events_test.go
@@ -425,13 +425,11 @@ func TestRelationalDatabase_Query(t *testing.T) {
 				"account-id": []persistence.EventResult{
 					{
 						AccountID: "account-id",
-						UserID:    str(a1.HashUserID("user-id")),
 						Payload:   "payload-1",
 						EventID:   "event-id-1",
 					},
 					{
 						AccountID: "account-id",
-						UserID:    str(a1.HashUserID("user-id")),
 						Payload:   "payload-2",
 						EventID:   "event-id-2",
 					},
@@ -439,7 +437,6 @@ func TestRelationalDatabase_Query(t *testing.T) {
 				"other-account": []persistence.EventResult{
 					{
 						AccountID: "other-account",
-						UserID:    str(a2.HashUserID("user-id")),
 						Payload:   "payload-3",
 						EventID:   "event-id-3",
 					},
@@ -495,7 +492,6 @@ func TestRelationalDatabase_Query(t *testing.T) {
 				"account-id": []persistence.EventResult{
 					{
 						AccountID: "account-id",
-						UserID:    str(a1.HashUserID("user-id")),
 						Payload:   "payload-2",
 						EventID:   "event-id-2",
 					},
@@ -503,7 +499,6 @@ func TestRelationalDatabase_Query(t *testing.T) {
 				"other-account": []persistence.EventResult{
 					{
 						AccountID: "other-account",
-						UserID:    str(a2.HashUserID("user-id")),
 						Payload:   "payload-3",
 						EventID:   "event-id-3",
 					},

--- a/vault/src/get-user-events.js
+++ b/vault/src/get-user-events.js
@@ -56,6 +56,14 @@ function ensureSyncWith (queries, api) {
           })
       })
       .then(function (events) {
+        events = events.map(function (event) {
+          // User events come without any userId attached as it is implicitly
+          // ensured it is always the same value and saving it locally would
+          // just create a possible leak of identifiers. We need to index on
+          // this value in IndexedDB though, so a fixed value is used instead
+          // of using real data.
+          return Object.assign(event, { userId: 'local' })
+        })
         return queries.putEvents.apply(null, [null].concat(events))
       })
   }

--- a/vault/src/get-user-events.test.js
+++ b/vault/src/get-user-events.test.js
@@ -80,6 +80,7 @@ describe('src/get-user-events', function () {
             null,
             {
               eventId: 'z',
+              userId: 'local',
               accountId: 'account-a',
               payload: { type: 'TEST' }
             }


### PR DESCRIPTION
This is related to https://github.com/offen/rfcs/issues/26

When stored locally for users, the actual identifier does not matter at all, so there is no need to store it locally. Instead a hard coded value can be used.