### PR TITLE
Install account deps first as other containers depend on it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ help:
 
 setup:
 	@docker-compose build
+	@docker-compose run accounts pip install --user -r requirements.txt -r requirements-dev.txt
 	@docker-compose run script npm install
 	@docker-compose run vault npm install
 	@docker-compose run auditorium npm install
 	@docker-compose run server go mod download
 	@docker-compose run kms go mod download
-	@docker-compose run accounts pip install --user -r requirements.txt -r requirements-dev.txt
 	@echo "Successfully built containers and installed dependencies."
 	@echo "If this is your initial setup, you can run 'make bootstrap' next"
 	@echo "to create the needed local keys and seed the database."


### PR DESCRIPTION
`server` depends on the `accounts` container (which means its `command` should be runnable), so it needs to install its dependencies first.