### PR TITLE
Improve HTTP caching behavior

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,9 @@ http {
 	server {
 		listen 80;
 		absolute_redirect off;
+		# in development, all caching is disabled
+		proxy_set_header "Cache-Control" "";
+		add_header "Cache-Control" "no-store";
 
 		location /vault/ {
 			proxy_pass http://vault;

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,7 +21,8 @@ http {
 		listen 80;
 		absolute_redirect off;
 		# in development, all caching is disabled
-		proxy_set_header "Cache-Control" "";
+		proxy_hide_header "Cache-Control";
+		proxy_hide_header "Etag";
 		add_header "Cache-Control" "no-store";
 
 		location /vault/ {

--- a/server/router/headers.go
+++ b/server/router/headers.go
@@ -24,7 +24,7 @@ func (w *bufferingRw) Write(p []byte) (int, error) {
 
 var (
 	revisionedJSRe         = regexp.MustCompile("-[0-9a-z]{10}\\.js$")
-	webfontRe              = regexp.MustCompile("\\.(woff|woff2|ttf|eot)$")
+	webfontRe              = regexp.MustCompile("\\.(woff|woff2|ttf)$")
 	defaultResponseHeaders = map[string]string{
 		"Referrer-Policy":        "origin-when-cross-origin",
 		"X-Content-Type-Options": "no-sniff",

--- a/server/router/middleware.go
+++ b/server/router/middleware.go
@@ -67,9 +67,11 @@ func (rt *router) accountUserMiddleware(cookieKey, contextKey string) gin.Handle
 	}
 }
 
-func cacheControlMiddleware(valueProvider func() string) gin.HandlerFunc {
+func headerMiddleware(valueProvider map[string]func() string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Header("Cache-Control", valueProvider())
+		for key, provider := range valueProvider {
+			c.Header(key, provider())
+		}
 		c.Next()
 	}
 }
@@ -86,21 +88,20 @@ func (g *bufferingGinWriter) Write(data []byte) (int, error) {
 func etagMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		bw := &bufferingGinWriter{c.Writer, bytes.Buffer{}}
+		defer bw.ResponseWriter.Flush()
 		c.Writer = bw
-		defer func() {
-			data := bw.buf.Bytes()
-			etag := fmt.Sprintf("%x", md5.Sum(data))
-			c.Header("Etag", etag)
-			c.Header("Cache-Control", "no-cache")
-			if match := c.GetHeader("If-None-Match"); match != "" {
-				if strings.Contains(match, etag) {
-					c.Status(http.StatusNotModified)
-					return
-				}
-			}
-			bw.ResponseWriter.Write(data)
-			bw.ResponseWriter.Flush()
-		}()
 		c.Next()
+
+		data := bw.buf.Bytes()
+		etag := fmt.Sprintf("%x", md5.Sum(data))
+		c.Header("Etag", etag)
+		c.Header("Cache-Control", "no-cache")
+		if match := c.GetHeader("If-None-Match"); match != "" {
+			if strings.Contains(match, etag) {
+				c.Status(http.StatusNotModified)
+				return
+			}
+		}
+		bw.ResponseWriter.Write(data)
 	}
 }

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -156,8 +156,10 @@ func New(opts ...Config) http.Handler {
 
 	userCookie := userCookieMiddleware(cookieKey, contextKeyCookie)
 	accountAuth := rt.accountUserMiddleware(authKey, contextKeyAuth)
-	noStore := cacheControlMiddleware(func() string {
-		return "no-store"
+	noStore := headerMiddleware(map[string]func() string{
+		"Cache-Control": func() string {
+			return "no-store"
+		},
 	})
 	etag := etagMiddleware()
 


### PR DESCRIPTION
The major caching strategies implemented in this PR are:

- in development, prevent all caching using `Cache-Control: no-store`
- in production, use a far-future Expires header for revisioned JS assets and webfonts
- in production, use Last-Modified for caching all other static assets
- in production, add `Cache-Control: no-store` to all API responses
- in production, use Etag digests for server side rendered HTML (like the index page)