### PR TITLE
Store user keys as jwk, specify tagLength for Edge support

### DIFF
--- a/vault/src/get-user-events.js
+++ b/vault/src/get-user-events.js
@@ -77,13 +77,16 @@ function decryptUserEventsWith (queries) {
     var decrypted = Object.keys(eventsByAccountId)
       .map(function (accountId) {
         var withSecret = queries.getUserSecret(accountId)
-          .then(function (userSecret) {
-            if (!userSecret) {
+          .then(function (jwk) {
+            if (!jwk) {
               return function () {
                 return null
               }
             }
-            return crypto.decryptSymmetricWith(userSecret)
+            return crypto.importSymmetricKey(jwk)
+              .then(function (userSecret) {
+                return crypto.decryptSymmetricWith(userSecret)
+              })
           })
 
         var events = eventsByAccountId[accountId]

--- a/vault/src/get-user-events.test.js
+++ b/vault/src/get-user-events.test.js
@@ -44,7 +44,7 @@ describe('src/get-user-events', function () {
         deleteEvents: sinon.stub().resolves(true),
         getLatestEvent: sinon.stub().resolves({ eventId: 'c' }),
         putEvents: sinon.stub().resolves(true),
-        getUserSecret: sinon.stub().resolves(userSecret)
+        getUserSecret: sinon.stub().resolves(window.crypto.subtle.exportKey('jwk', userSecret))
       }
       var mockApi = {
         getDeletedEvents: sinon.stub().resolves({ eventIds: ['a'] }),

--- a/vault/src/web-crypto.js
+++ b/vault/src/web-crypto.js
@@ -16,7 +16,8 @@ function decryptSymmetricWith (cryptoKey) {
         return window.crypto.subtle.decrypt(
           {
             name: 'AES-GCM',
-            iv: chunks.nonce
+            iv: chunks.nonce,
+            tagLength: 128
           },
           cryptoKey,
           chunks.cipher
@@ -46,7 +47,7 @@ function encryptSymmetricWith (cryptoKey) {
       {
         name: 'AES-GCM',
         iv: nonce,
-        length: 128
+        tagLength: 128
       },
       cryptoKey,
       bytes


### PR DESCRIPTION
This PR restores Edge and Safari support by fixing the following issues:

- Safari silently fails to generate a structured clone of `CryptoKey` objects, which meant Safari users would regenerate a new key on each visit, thus also meaning they would be unable to access their data. Instead the keys are now saved in their serialized `jwk` form
- Edge requires the (optional per spec) `tagLength` parameter to be passed when performing AES-GCM encryptions decryptions. This parameter is added using the default value of `128`

---

**HEADS UP**: saving user secrets in a different form invalidates all currently stored keys and requires developers to delete their local IndexedDB databases before they can continue working after this has been merged. Considering the current state this is preferrable to introducing a compatibility layer.