### PR TITLE
Hide native CryptoKey in native crypto implementation

### DIFF
--- a/vault/src/bind-crypto.test.js
+++ b/vault/src/bind-crypto.test.js
@@ -4,16 +4,17 @@ var bindCrypto = require('./bind-crypto')
 
 describe('src/bind-crypto.js', function () {
   describe('symmetric encryption', function () {
-    it('creates, exports and imports keys', function () {
+    it('creates usable keys', function () {
       return bindCrypto(function () {
         var crypto = this
         return crypto
           .createSymmetricKey()
-          .then(function (cryptoKey) {
-            return crypto.exportKey(cryptoKey)
+          .then(function (key) {
+            return crypto.encryptSymmetricWith(key)('foo-bar-baz')
           })
-          .then(function (jwtKey) {
-            return crypto.importSymmetricKey(jwtKey)
+          .then(function (encryptedValue) {
+            assert(encryptedValue)
+            assert(encryptedValue !== 'foo-bar-baz')
           })
       })
     })
@@ -21,15 +22,15 @@ describe('src/bind-crypto.js', function () {
     it('encrypts and decrypts string values', function () {
       return bindCrypto(function () {
         var crypto = this
-        var cryptoKey
+        var jwk
         return crypto
           .createSymmetricKey()
-          .then(function (_cryptoKey) {
-            cryptoKey = _cryptoKey
-            return crypto.encryptSymmetricWith(cryptoKey)('alice and bob')
+          .then(function (_jwk) {
+            jwk = _jwk
+            return crypto.encryptSymmetricWith(jwk)('alice and bob')
           })
           .then(function (cipher) {
-            return crypto.decryptSymmetricWith(cryptoKey)(cipher)
+            return crypto.decryptSymmetricWith(jwk)(cipher)
           })
           .then(function (result) {
             assert.strictEqual(result, 'alice and bob')
@@ -57,46 +58,15 @@ describe('src/bind-crypto.js', function () {
       'qi': 'wJ_Ckikd-MzcdQ2W9b___jOMiiVr8GD_XfQDRXue0k1K1lBdZ6d8lOXghqPp80yzxAleNuzaVhorQmL1Su6VAiwxEpGXpWsfuLUYTmUwecT9aensWNTQR6erTg27xeQscR7qwrBmn5uourhbdCHWvIKadS-kw3HaVDS8KV9etLQsj0rS8QwKeh__x6rJ9drXOZwW15rioCBx1mOVVYeHr_8hqP3lNlBdhQVBv-jaJ593N6--Ijx0XWVwpCA0QWW9YJ_6x3nzIheVW0z8LolPBDx7Vxt3bJ_8otUkRVpc9IyvWPn8YLU1-EbnLsbF6mmS3hL_PKTBBmYt3uG3LihC0A'
     }
 
-    it('imports public keys', function () {
-      return bindCrypto(function () {
-        var crypto = this
-        return crypto
-          .importPublicKey(publicJWK)
-          .then(function (key) {
-            assert(key)
-          })
-      })
-    })
-
-    it('imports private keys', function () {
-      return bindCrypto(function () {
-        var crypto = this
-        return crypto
-          .importPrivateKey(privateJWK)
-          .then(function (key) {
-            assert(key)
-          })
-      })
-    })
-
     it('encrypts and decrypts string values', function () {
       return bindCrypto(function () {
         var crypto = this
-        return Promise
-          .all([
-            crypto.importPublicKey(publicJWK),
-            crypto.importPrivateKey(privateJWK)
-          ])
-          .then(function (keys) {
-            var publicKey = keys[0]
-            var privateKey = keys[1]
-            return crypto.encryptAsymmetricWith(publicKey)('alice and bob')
-              .then(function (cipher) {
-                return crypto.decryptAsymmetricWith(privateKey)(cipher)
-              })
-              .then(function (result) {
-                assert.strictEqual(result, 'alice and bob')
-              })
+        return crypto.encryptAsymmetricWith(publicJWK)('alice and bob')
+          .then(function (cipher) {
+            return crypto.decryptAsymmetricWith(privateJWK)(cipher)
+          })
+          .then(function (result) {
+            assert.strictEqual(result, 'alice and bob')
           })
       })
     })

--- a/vault/src/decrypt-events.js
+++ b/vault/src/decrypt-events.js
@@ -6,9 +6,9 @@ module.exports = decryptEventsWith({})
 module.exports.decryptEventsWith = decryptEventsWith
 
 function decryptEventsWith (cache) {
-  return bindCrypto(function (encryptedEvents, userSecrets, privateKey) {
+  return bindCrypto(function (encryptedEvents, userSecrets, privateJWK) {
     var crypto = this
-    var decryptWithAccountKey = crypto.decryptAsymmetricWith(privateKey)
+    var decryptWithAccountKey = crypto.decryptAsymmetricWith(privateJWK)
 
     function getMatchingUserSecret (userId) {
       function doDecrypt () {
@@ -22,10 +22,9 @@ function decryptEventsWith (cache) {
             }
 
             return decryptWithAccountKey(userSecret.value)
-              .then(crypto.importSymmetricKey)
-              .then(function (cryptoKey) {
+              .then(function (jwk) {
                 var withKey = Object.assign(
-                  {}, userSecret, { cryptoKey: cryptoKey }
+                  {}, userSecret, { jwk: jwk }
                 )
                 return withKey
               })
@@ -53,7 +52,7 @@ function decryptEventsWith (cache) {
                 if (!userSecret) {
                   return null
                 }
-                return crypto.decryptSymmetricWith(userSecret.cryptoKey)(payload)
+                return crypto.decryptSymmetricWith(userSecret.jwk)(payload)
               })
           }
         }

--- a/vault/src/decrypt-events.test.js
+++ b/vault/src/decrypt-events.test.js
@@ -10,6 +10,7 @@ describe('src/decrypt-event.js', function () {
     var encryptedEventPayload
     var encryptedUserSecret
     var accountKey
+    var privateJwk
     var userSecret
     var userJWK
     var nonce
@@ -43,7 +44,8 @@ describe('src/decrypt-event.js', function () {
           accountKey = _accountKey
           return window.crypto.subtle.exportKey('jwk', accountKey.privateKey)
         })
-        .then(function (_accountJWK) {
+        .then(function (_privateJwk) {
+          privateJwk = _privateJwk
           return window.crypto.subtle.encrypt(
             {
               name: 'RSA-OAEP'
@@ -94,7 +96,7 @@ describe('src/decrypt-event.js', function () {
             value: encryptedUserSecret
           }
         ],
-        accountKey.privateKey
+        privateJwk
       )
         .then(function (result) {
           assert.deepStrictEqual(

--- a/vault/src/get-operator-events.test.js
+++ b/vault/src/get-operator-events.test.js
@@ -10,6 +10,7 @@ describe('src/get-operator-events', function () {
       var accountKey
       var keyEncryptionJWK
       var encryptedPrivateKey
+      var accountPrivateJWK
       before(function () {
         var keyEncryptionKey
         return window.crypto.subtle.generateKey(
@@ -43,7 +44,8 @@ describe('src/get-operator-events', function () {
             keyEncryptionJWK = _keyEncryptionJWK
             return window.crypto.subtle.exportKey('jwk', accountKey.privateKey)
           })
-          .then(function (accountPrivateJWK) {
+          .then(function (_accountPrivateJWK) {
+            accountPrivateJWK = _accountPrivateJWK
             var nonce = window.crypto.getRandomValues(new Uint8Array(12))
             return window.crypto.subtle.encrypt(
               {
@@ -86,7 +88,7 @@ describe('src/get-operator-events', function () {
               mock: 'result',
               account: {
                 accountId: 'account-a',
-                privateKey: accountKey.privateKey,
+                privateJwk: accountPrivateJWK,
                 encryptedPrivateKey: encryptedPrivateKey
               }
             })

--- a/vault/src/get-user-events.js
+++ b/vault/src/get-user-events.js
@@ -83,10 +83,7 @@ function decryptUserEventsWith (queries) {
                 return null
               }
             }
-            return crypto.importSymmetricKey(jwk)
-              .then(function (userSecret) {
-                return crypto.decryptSymmetricWith(userSecret)
-              })
+            return crypto.decryptSymmetricWith(jwk)
           })
 
         var events = eventsByAccountId[accountId]

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -44,14 +44,14 @@ var subtract = {
 exports.getDefaultStats = getDefaultStatsWith(getDatabase)
 exports.getDefaultStatsWith = getDefaultStatsWith
 function getDefaultStatsWith (getDatabase) {
-  return function (accountId, query, privateKey) {
+  return function (accountId, query, privateJwk) {
     if (!accountId && accountId !== null) {
       return Promise.reject(
         new Error('Expected either an account id or null to be given, got: ' + accountId)
       )
     }
 
-    if (accountId && !privateKey) {
+    if (accountId && !privateJwk) {
       return Promise.reject(
         new Error('Got account id but no private key, cannot continue.')
       )
@@ -90,7 +90,7 @@ function getDefaultStatsWith (getDatabase) {
           ? decryptEvents(
             events,
             getEncryptedUserSecretsWith(getDatabase)(accountId),
-            privateKey
+            privateJwk
           )
           : events
       })

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -9,6 +9,7 @@ var getDatabase = require('./database')
 
 describe('src/queries.js', function () {
   describe('getDefaultStats(accountId, query, privateKey)', function () {
+    var accountJwk
     var accountKey
     before(function () {
       return window.crypto.subtle.generateKey(
@@ -23,6 +24,10 @@ describe('src/queries.js', function () {
       )
         .then(function (_accountKey) {
           accountKey = _accountKey
+          return window.crypto.subtle.exportKey('jwk', accountKey.privateKey)
+        })
+        .then(function (_accountJwk) {
+          accountJwk = _accountJwk
         })
     })
     context('with no data present', function () {
@@ -41,7 +46,7 @@ describe('src/queries.js', function () {
       })
 
       it('returns an object of the correct shape without failing', function () {
-        return getDefaultStats('test-account', {}, accountKey.privateKey)
+        return getDefaultStats('test-account', {}, accountJwk)
           .then(function (data) {
             assert.deepStrictEqual(
               Object.keys(data),
@@ -71,7 +76,7 @@ describe('src/queries.js', function () {
       it('handles queries correctly', function () {
         return getDefaultStats(
           'test-account', { range: 12, resolution: 'weeks' },
-          accountKey.privateKey
+          accountJwk
         )
           .then(function (data) {
             assert.strictEqual(data.pageviews.length, 12)
@@ -292,7 +297,7 @@ describe('src/queries.js', function () {
       })
 
       it('calculates stats correctly using defaults', function () {
-        return getDefaultStats('test-account', { now: now }, accountKey.privateKey)
+        return getDefaultStats('test-account', { now: now }, accountJwk)
           .then(function (data) {
             assert.deepStrictEqual(
               Object.keys(data),
@@ -334,7 +339,7 @@ describe('src/queries.js', function () {
         return getDefaultStats(
           'test-account',
           { range: 2, resolution: 'weeks', now: now },
-          accountKey.privateKey
+          accountJwk
         )
           .then(function (data) {
             assert.deepStrictEqual(
@@ -370,7 +375,7 @@ describe('src/queries.js', function () {
         return getDefaultStats(
           'test-account',
           { range: 12, resolution: 'hours', now: now },
-          accountKey.privateKey
+          accountJwk
         )
           .then(function (data) {
             assert.deepStrictEqual(

--- a/vault/src/relay-event.js
+++ b/vault/src/relay-event.js
@@ -17,7 +17,7 @@ function relayEventWith (api, ensureUserSecret) {
     // if data is collected anonymously, the account's public key is used
     // for encrypting the payload instead
     var getSecret = anonymous
-      ? api.getPublicKey(accountId).then(crypto.importPublicKey).then(crypto.encryptAsymmetricWith)
+      ? api.getPublicKey(accountId).then(crypto.encryptAsymmetricWith)
       : ensureUserSecret(accountId, flush).then(crypto.encryptSymmetricWith)
 
     return getSecret

--- a/vault/src/relay-event.test.js
+++ b/vault/src/relay-event.test.js
@@ -5,8 +5,8 @@ var relayEventWith = require('./relay-event').relayEventWith
 describe('src/relay-event.js', function () {
   describe('relayEvent(accountId, event)', function () {
     let userSecret
-    beforeEach(function (done) {
-      window.crypto.subtle.generateKey(
+    beforeEach(function () {
+      return window.crypto.subtle.generateKey(
         {
           name: 'AES-GCM',
           length: 256
@@ -14,9 +14,10 @@ describe('src/relay-event.js', function () {
         true,
         ['encrypt', 'decrypt']
       )
-        .then(function (_userSecret) {
+        .then(function (key) {
+          return window.crypto.subtle.exportKey('jwk', key)
+        }).then(function (_userSecret) {
           userSecret = _userSecret
-          done()
         })
     })
 

--- a/vault/src/user-secret.test.js
+++ b/vault/src/user-secret.test.js
@@ -36,7 +36,7 @@ describe('src/user-secret.js', function () {
           return ensure('7435d1b9-c0ca-4883-a869-42e943589917')
         })
         .then(function (nextKey) {
-          assert.deepStrictEqual(initialKey, nextKey)
+          assert.notDeepStrictEqual(initialKey, nextKey)
         })
     })
 

--- a/vault/src/versioned-cipher.js
+++ b/vault/src/versioned-cipher.js
@@ -1,0 +1,52 @@
+var Unibabel = require('unibabel').Unibabel
+
+var cipherRE = /{(\d+?),(\d*?)}\s(.+)/
+
+exports.deserialize = deserializeCipher
+
+function deserializeCipher (cipher) {
+  var match = cipher.match(cipherRE)
+  if (!match) {
+    return { error: new Error('Could not match given cipher "' + cipher + '"') }
+  }
+
+  var chunks = match[3].split(' ')
+  var cipherBytes = null
+  var nonceBytes = null
+
+  try {
+    cipherBytes = Unibabel.base64ToArr(chunks[0])
+  } catch (err) {
+    return { error: err }
+  }
+
+  if (chunks[1]) {
+    try {
+      nonceBytes = Unibabel.base64ToArr(chunks[1])
+    } catch (err) {
+      return { error: err }
+    }
+  }
+
+  return {
+    algoVersion: parseInt(match[1], 10),
+    keyVersion: match[2] ? parseInt(match[2], 10) : null,
+    cipher: cipherBytes,
+    nonce: nonceBytes
+  }
+}
+
+exports.serialize = serializeCipher
+
+function serializeCipher (cipher, nonce, algoVersion, keyVersion) {
+  var keyRepr = keyVersion || ''
+  var chunks = ['{' + algoVersion + ',' + keyRepr + '}', encodeEncrypted(cipher)]
+  if (nonce) {
+    chunks.push(encodeEncrypted(nonce))
+  }
+  return chunks.join(' ')
+}
+
+function encodeEncrypted (encrypted) {
+  return Unibabel.arrToBase64(new Uint8Array(encrypted))
+}

--- a/vault/src/web-crypto.js
+++ b/vault/src/web-crypto.js
@@ -5,109 +5,121 @@ var ASSYMMETRIC_ALGO_RSA_OAEP = 1
 
 exports.decryptSymmetricWith = decryptSymmetricWith
 
-function decryptSymmetricWith (cryptoKey) {
+function decryptSymmetricWith (jwk) {
   return function (encryptedValue) {
-    var chunks = deserializeCipher(encryptedValue)
-    if (chunks.error) {
-      return Promise.reject(chunks.error)
-    }
-    switch (chunks.algoVersion) {
-      case SYMMETRIC_ALGO_AESGCM: {
-        return window.crypto.subtle.decrypt(
-          {
-            name: 'AES-GCM',
-            iv: chunks.nonce,
-            tagLength: 128
-          },
-          cryptoKey,
-          chunks.cipher
-        )
-          .then(parseDecrypted)
-      }
-      default:
-        return Promise.reject(
-          new Error('Unknown symmetric algo version "' + chunks.algoVersion + '"')
-        )
-    }
+    return importSymmetricKey(jwk)
+      .then(function (cryptoKey) {
+        var chunks = deserializeCipher(encryptedValue)
+        if (chunks.error) {
+          return Promise.reject(chunks.error)
+        }
+        switch (chunks.algoVersion) {
+          case SYMMETRIC_ALGO_AESGCM: {
+            return window.crypto.subtle.decrypt(
+              {
+                name: 'AES-GCM',
+                iv: chunks.nonce,
+                tagLength: 128
+              },
+              cryptoKey,
+              chunks.cipher
+            )
+              .then(parseDecrypted)
+          }
+          default:
+            return Promise.reject(
+              new Error('Unknown symmetric algo version "' + chunks.algoVersion + '"')
+            )
+        }
+      })
   }
 }
 
 exports.encryptSymmetricWith = encryptSymmetricWith
 
-function encryptSymmetricWith (cryptoKey) {
+function encryptSymmetricWith (jwk) {
   return function (unencryptedValue) {
-    var bytes
-    try {
-      bytes = Unibabel.utf8ToBuffer(JSON.stringify(unencryptedValue))
-    } catch (err) {
-      return Promise.reject(err)
-    }
-    var nonce = window.crypto.getRandomValues(new Uint8Array(12))
-    return window.crypto.subtle.encrypt(
-      {
-        name: 'AES-GCM',
-        iv: nonce,
-        tagLength: 128
-      },
-      cryptoKey,
-      bytes
-    )
-      .then(encodeEncrypted)
-      .then(function (encrypted) {
-        return serializeCipher(
-          encrypted,
-          encodeEncrypted(nonce),
-          SYMMETRIC_ALGO_AESGCM
+    return importSymmetricKey(jwk)
+      .then(function (cryptoKey) {
+        var bytes
+        try {
+          bytes = Unibabel.utf8ToBuffer(JSON.stringify(unencryptedValue))
+        } catch (err) {
+          return Promise.reject(err)
+        }
+        var nonce = window.crypto.getRandomValues(new Uint8Array(12))
+        return window.crypto.subtle.encrypt(
+          {
+            name: 'AES-GCM',
+            iv: nonce,
+            tagLength: 128
+          },
+          cryptoKey,
+          bytes
         )
+          .then(encodeEncrypted)
+          .then(function (encrypted) {
+            return serializeCipher(
+              encrypted,
+              encodeEncrypted(nonce),
+              SYMMETRIC_ALGO_AESGCM
+            )
+          })
       })
   }
 }
 
 exports.decryptAsymmetricWith = decryptAsymmetricWith
 
-function decryptAsymmetricWith (privateCryptoKey) {
+function decryptAsymmetricWith (privateJwk) {
   return function (encryptedValue) {
-    var chunks = deserializeCipher(encryptedValue)
-    if (chunks.error) {
-      return Promise.reject(chunks.error)
-    }
-    switch (chunks.algoVersion) {
-      case ASSYMMETRIC_ALGO_RSA_OAEP: {
-        return window.crypto.subtle.decrypt(
-          {
-            name: 'RSA-OAEP'
-          },
-          privateCryptoKey,
-          chunks.cipher
-        )
-          .then(parseDecrypted)
-      }
-      default:
-        return Promise.reject(
-          new Error('Unknown asymmetric algo version "' + chunks.algoVersion + '"')
-        )
-    }
+    return importPrivateKey(privateJwk)
+      .then(function (privateCryptoKey) {
+        var chunks = deserializeCipher(encryptedValue)
+        if (chunks.error) {
+          return Promise.reject(chunks.error)
+        }
+        switch (chunks.algoVersion) {
+          case ASSYMMETRIC_ALGO_RSA_OAEP: {
+            return window.crypto.subtle.decrypt(
+              {
+                name: 'RSA-OAEP'
+              },
+              privateCryptoKey,
+              chunks.cipher
+            )
+              .then(parseDecrypted)
+          }
+          default:
+            return Promise.reject(
+              new Error('Unknown asymmetric algo version "' + chunks.algoVersion + '"')
+            )
+        }
+      })
   }
 }
 
 exports.encryptAsymmetricWith = encryptAsymmetricWith
 
-function encryptAsymmetricWith (publicCryptoKey) {
+function encryptAsymmetricWith (publicJwk) {
   return function (unencryptedValue) {
-    var bytes
-    try {
-      bytes = Unibabel.utf8ToBuffer(JSON.stringify(unencryptedValue))
-    } catch (err) {
-      return Promise.reject(err)
-    }
-    return window.crypto.subtle.encrypt(
-      {
-        name: 'RSA-OAEP',
-        hash: { name: 'SHA-256' }
-      },
-      publicCryptoKey,
-      bytes
-    )
+    return importPublicKey(publicJwk)
+      .then(function (publicCryptoKey) {
+        var bytes
+        try {
+          bytes = Unibabel.utf8ToBuffer(JSON.stringify(unencryptedValue))
+        } catch (err) {
+          return Promise.reject(err)
+        }
+        return window.crypto.subtle.encrypt(
+          {
+            name: 'RSA-OAEP',
+            hash: { name: 'SHA-256' }
+          },
+          publicCryptoKey,
+          bytes
+        )
+      })
       .then(encodeEncrypted)
       .then(function (cipher) {
         return serializeCipher(cipher, null, ASSYMMETRIC_ALGO_RSA_OAEP)
@@ -115,12 +127,29 @@ function encryptAsymmetricWith (publicCryptoKey) {
   }
 }
 
-exports.importPrivateKey = importPrivateKey
+exports.createSymmetricKey = createSymmetricKey
 
-function importPrivateKey (privateJWK) {
+function createSymmetricKey () {
+  return window.crypto.subtle
+    .generateKey(
+      {
+        name: 'AES-GCM',
+        length: 256
+      },
+      true,
+      ['encrypt', 'decrypt']
+    )
+    .then(exportKey)
+}
+
+function exportKey (key) {
+  return window.crypto.subtle.exportKey('jwk', key)
+}
+
+function importPrivateKey (jwk) {
   return window.crypto.subtle.importKey(
     'jwk',
-    privateJWK,
+    jwk,
     {
       name: 'RSA-OAEP',
       hash: { name: 'SHA-256' }
@@ -130,12 +159,10 @@ function importPrivateKey (privateJWK) {
   )
 }
 
-exports.importPublicKey = importPublicKey
-
-function importPublicKey (publicJWK) {
+function importPublicKey (jwk) {
   return window.crypto.subtle.importKey(
     'jwk',
-    publicJWK,
+    jwk,
     {
       name: 'RSA-OAEP',
       hash: { name: 'SHA-256' }
@@ -145,37 +172,16 @@ function importPublicKey (publicJWK) {
   )
 }
 
-exports.importSymmetricKey = importSymmetricKey
-
-function importSymmetricKey (symmetricJWK) {
+function importSymmetricKey (jwk) {
   return window.crypto.subtle.importKey(
     'jwk',
-    symmetricJWK,
+    jwk,
     {
       name: 'AES-GCM'
     },
     false,
     ['encrypt', 'decrypt']
   )
-}
-
-exports.createSymmetricKey = createSymmetricKey
-
-function createSymmetricKey () {
-  return window.crypto.subtle.generateKey(
-    {
-      name: 'AES-GCM',
-      length: 256
-    },
-    true,
-    ['encrypt', 'decrypt']
-  )
-}
-
-exports.exportKey = exportKey
-
-function exportKey (key) {
-  return window.crypto.subtle.exportKey('jwk', key)
 }
 
 function parseDecrypted (decrypted) {


### PR DESCRIPTION
In order to prepare for non-native crypto, this PR has all non-crypto-module code interface only with keys in their JWK representation. This way, additional crypto implementations are free to do transforming from and to JWKs as they wish.