### PR TITLE
Do not expose account data during key exchange

### DIFF
--- a/server/persistence/accounts.go
+++ b/server/persistence/accounts.go
@@ -21,15 +21,15 @@ func (p *persistenceLayer) GetAccount(accountID string, includeEvents bool, even
 		Created:   account.Created,
 	}
 
-	if includeEvents {
-		result.EncryptedPrivateKey = account.EncryptedPrivateKey
-	} else {
+	if !includeEvents {
 		key, err := account.WrapPublicKey()
 		if err != nil {
 			return AccountResult{}, fmt.Errorf("persistence: error wrapping account public key: %v", err)
 		}
 		result.PublicKey = key
+		return result, nil
 	}
+	result.EncryptedPrivateKey = account.EncryptedPrivateKey
 
 	eventResults := EventsByAccountID{}
 	userSecrets := SecretsByUserID{}

--- a/server/persistence/accounts_test.go
+++ b/server/persistence/accounts_test.go
@@ -139,17 +139,6 @@ func TestPersistenceLayer_GetAccount(t *testing.T) {
 			AccountResult{
 				AccountID: "account-id",
 				Name:      "name",
-				Events: &EventsByAccountID{
-					"account-id": []EventResult{
-						{EventID: "event-a", UserID: strptr("user-a"), AccountID: "account-id", Payload: "payload-a"},
-						{EventID: "event-b", UserID: strptr("user-b"), AccountID: "account-id", Payload: "payload-b"},
-						{EventID: "event-c", AccountID: "account-id", Payload: "payload-c"},
-					},
-				},
-				UserSecrets: &SecretsByUserID{
-					"user-a": "aaaaa",
-					"user-b": "bbbbb",
-				},
 				PublicKey: (func() jwk.Key {
 					s, _ := jwk.ParseString(publicKey)
 					return s.Keys[0]


### PR DESCRIPTION
This fixes a regression likely introduced in #179 where account data would not be withheld during key exchange.

As all of this data is encrypted, it's not a disaster to leak this, yet it's still a lot cleaner if we hide it again.