### PR TITLE
Collect time to interactive, display average pageload time

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -184,26 +184,26 @@ function view (state, emit) {
       <h4 class ="f5 normal mt0 mb3 mb5-ns">Key metrics</h4>
       <div class="flex flex-wrap">
         <div class="w-50 w-100-ns mb3 mb4-ns">
-          <p class="mt0 mb0 f2">${uniqueEntities}</p>
-          <p class="mt0 mb0 normal">${__('Unique %s', entityName)}</p>
+          <p class="mv0 f2">${uniqueEntities}</p>
+          <p class="mv0 normal">${__('Unique %s', entityName)}</p>
         </div>
         <div class="w-50 w-100-ns mb3 mb4-ns">
-          <p class="mt0 mb0 f2">${uniqueSessions}</p>
-          <p class="mt0 mb0 normal">${__('Unique sessions')}</p>
+          <p class="mv0 f2">${uniqueSessions}</p>
+          <p class="mv0 normal">${__('Unique sessions')}</p>
         </div>
         <div class="w-50 w-100-ns mb3 mb4-ns">
-          <p class="mt0 mb0 f2">${formatPercentage(state.model.bounceRate)} %</p>
-          <p class="mt0 mb0 normal">${__('Bounce rate')}</p>
+          <p class="mv0 f2">${formatPercentage(state.model.bounceRate)} %</p>
+          <p class="mv0 normal">${__('Bounce rate')}</p>
         </div>
         ${isOperator ? html`
           <div class="w-50 w-100-ns mb3 mb4-ns">
-            <p class="mt0 mb0 f2">${formatPercentage(state.model.loss)} %</p>
-            <p class="mt0 mb0 normal">${__('Plus')}</p>
+            <p class="mv0 f2">${formatPercentage(state.model.loss)} %</p>
+            <p class="mv0 normal">${__('Plus')}</p>
           </div>` : null}
         ${state.model.avgPageload ? html`
           <div class="w-50 w-100-ns mb3 mb4-ns">
-            <p class="mt0 mb0 f2">${state.model.avgPageload}ms</p>
-          <p class="mt0 mb0 normal">${__('Average pageload')}</p>
+            <p class="mv0 f2">${state.model.avgPageload}ms</p>
+          <p class="mv0 normal">${__('Average pageload')}</p>
           </div>` : null}
       </div>
     </div>

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -177,8 +177,9 @@ function view (state, emit) {
   var entityName = isOperator
     ? __('users')
     : __('accounts')
+
   var uniqueSessions = state.model.uniqueSessions
-  var usersAndSessions = html`
+  var keyMetrics = html`
     <div class="w-100 w-25-m w-20-ns pa3 mb2 ba b--black-10 br2 bg-white">
       <h4 class ="f5 normal mt0 mb3 mb5-ns">Key metrics</h4>
       <div class="flex flex-wrap">
@@ -194,12 +195,16 @@ function view (state, emit) {
           <p class="mt0 mb0 f2">${formatPercentage(state.model.bounceRate)} %</p>
           <p class="mt0 mb0 normal">${__('Bounce rate')}</p>
         </div>
-        <div class="w-50 w-100-ns mb3 mb4-ns">
-          ${isOperator ? html`
+        ${isOperator ? html`
+          <div class="w-50 w-100-ns mb3 mb4-ns">
             <p class="mt0 mb0 f2">${formatPercentage(state.model.loss)} %</p>
             <p class="mt0 mb0 normal">${__('Plus')}</p>
-          ` : null}
-        </div>
+          </div>` : null}
+        ${state.model.avgPageload ? html`
+          <div class="w-50 w-100-ns mb3 mb4-ns">
+            <p class="mt0 mb0 f2">${state.model.avgPageload}ms</p>
+          <p class="mt0 mb0 normal">${__('Average pageload')}</p>
+          </div>` : null}
       </div>
     </div>
   `
@@ -207,7 +212,7 @@ function view (state, emit) {
   var rowUsersSessionsChart = html`
     <div class="flex flex-column flex-row-ns">
       ${chart}
-      ${usersAndSessions}
+      ${keyMetrics}
     </div>
   `
 

--- a/script/index.js
+++ b/script/index.js
@@ -20,13 +20,13 @@ app.on('PAGEVIEW', supportMiddleware, function (context, send, next) {
     type: 'EVENT',
     payload: {
       accountId: accountId,
-      event: events.pageview()
+      event: events.pageview(context === 'initial')
     }
   }
   send(message)
 })
 
-app.dispatch('PAGEVIEW')
+app.dispatch('PAGEVIEW', 'initial')
 
 historyEvents.addEventListener(window, 'changestate', function () {
   app.dispatch('PAGEVIEW')

--- a/script/src/events.js
+++ b/script/src/events.js
@@ -5,6 +5,14 @@ function pageview () {
     type: 'PAGEVIEW',
     href: window.location.href,
     title: document.title,
-    referrer: document.referrer
+    referrer: document.referrer,
+    pageload: (function () {
+      if (window.performance && window.performance.timing) {
+        return Math.round(
+          window.performance.timing.domInteractive - (window.performance.timeOrigin || window.performance.timing.navigationStart)
+        )
+      }
+      return null
+    })()
   }
 }

--- a/script/src/events.js
+++ b/script/src/events.js
@@ -1,13 +1,13 @@
 exports.pageview = pageview
 
-function pageview () {
+function pageview (initial) {
   return {
     type: 'PAGEVIEW',
     href: window.location.href,
     title: document.title,
     referrer: document.referrer,
     pageload: (function () {
-      if (window.performance && window.performance.timing) {
+      if (initial && window.performance && window.performance.timing) {
         return Math.round(
           window.performance.timing.domInteractive - (window.performance.timeOrigin || window.performance.timing.navigationStart)
         )

--- a/script/src/events.test.js
+++ b/script/src/events.test.js
@@ -5,7 +5,7 @@ describe('src/events.js', function () {
   describe('pageview()', function () {
     it('creates a pageview event', function () {
       var event = events.pageview()
-      assert.deepStrictEqual(Object.keys(event), ['type', 'href', 'title', 'referrer'])
+      assert.deepStrictEqual(Object.keys(event), ['type', 'href', 'title', 'referrer', 'pageload'])
       assert.strictEqual(event.type, 'PAGEVIEW')
       assert.strictEqual(typeof event.href, 'string')
       assert.strictEqual(typeof event.title, 'string')

--- a/script/src/events.test.js
+++ b/script/src/events.test.js
@@ -4,12 +4,17 @@ var events = require('./events')
 describe('src/events.js', function () {
   describe('pageview()', function () {
     it('creates a pageview event', function () {
-      var event = events.pageview()
+      var event = events.pageview(true)
       assert.deepStrictEqual(Object.keys(event), ['type', 'href', 'title', 'referrer', 'pageload'])
       assert.strictEqual(event.type, 'PAGEVIEW')
       assert.strictEqual(typeof event.href, 'string')
       assert.strictEqual(typeof event.title, 'string')
       assert.strictEqual(typeof event.referrer, 'string')
+      assert.strictEqual(typeof event.pageload, 'number')
+
+      var event2 = events.pageview(false)
+      assert.deepStrictEqual(Object.keys(event2), ['type', 'href', 'title', 'referrer', 'pageload'])
+      assert.strictEqual(event2.pageload, null)
     })
   })
 })

--- a/vault/package.json
+++ b/vault/package.json
@@ -57,7 +57,8 @@
       "__"
     ],
     "ignore": [
-      "dist/**/*.*"
+      "dist/**/*.*",
+      "bundle.*.js"
     ],
     "env": [
       "mocha"

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -272,6 +272,23 @@ function getDefaultStatsWith (getDatabase) {
           .value()
       })
 
+    var avgPageload = decryptedEvents
+      .then(function (events) {
+        var applicable = _.chain(events)
+          .pluck('payload')
+          .pluck('pageload')
+          .compact()
+          .value()
+        if (applicable.length === 0) {
+          return null
+        }
+
+        var total = applicable.reduce(function (acc, next) {
+          return acc + next
+        }, 0)
+        return Math.round(total / applicable.length)
+      })
+
     return Promise
       .all([
         uniqueUsers,
@@ -281,7 +298,8 @@ function getDefaultStatsWith (getDatabase) {
         pages,
         pageviews,
         bounceRate,
-        loss
+        loss,
+        avgPageload
       ])
       .then(function (results) {
         return {
@@ -293,6 +311,7 @@ function getDefaultStatsWith (getDatabase) {
           pageviews: results[5],
           bounceRate: results[6],
           loss: results[7],
+          avgPageload: results[8],
           resolution: resolution,
           range: range
         }

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -53,7 +53,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'resolution', 'range'
+                'avgPageload', 'resolution', 'range'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
@@ -151,7 +151,8 @@ describe('src/queries.js', function () {
                   title: 'Transparent web analytics',
                   sessionId: 'session-id-1',
                   referrer: '',
-                  timestamp: minuteAgo.toJSON()
+                  timestamp: minuteAgo.toJSON(),
+                  pageload: null
                 }
               },
               {
@@ -165,7 +166,8 @@ describe('src/queries.js', function () {
                   title: 'Contact',
                   sessionId: 'session-id-1',
                   referrer: '',
-                  timestamp: minuteAgo.toJSON()
+                  timestamp: minuteAgo.toJSON(),
+                  pageload: 200
                 }
               },
               {
@@ -179,7 +181,8 @@ describe('src/queries.js', function () {
                   title: 'Deep dive',
                   sessionId: 'session-id-2',
                   referrer: 'https://www.offen.dev',
-                  timestamp: subDays(now, 1).toJSON()
+                  timestamp: subDays(now, 1).toJSON(),
+                  pageload: 100
                 }
               },
               {
@@ -193,7 +196,8 @@ describe('src/queries.js', function () {
                   title: 'Deep dive',
                   sessionId: 'session-id-3',
                   referrer: '',
-                  timestamp: subDays(now, 1).toJSON()
+                  timestamp: subDays(now, 1).toJSON(),
+                  pageload: 200
                 }
               },
               {
@@ -207,7 +211,8 @@ describe('src/queries.js', function () {
                   title: 'Very cute',
                   sessionId: 'session-id-4',
                   referrer: 'https://www.cute.com',
-                  timestamp: subDays(now, 2).toJSON()
+                  timestamp: subDays(now, 2).toJSON(),
+                  pageload: null
                 }
               },
               {
@@ -221,7 +226,8 @@ describe('src/queries.js', function () {
                   title: 'Very cute',
                   sessionId: 'session-id-5',
                   referrer: '',
-                  timestamp: subDays(now, 12).toJSON()
+                  timestamp: subDays(now, 12).toJSON(),
+                  pageload: 100
                 }
               },
               {
@@ -231,7 +237,8 @@ describe('src/queries.js', function () {
                 timestamp: minuteAgo.toJSON(),
                 payload: {
                   type: 'PAGEVIEW',
-                  timestamp: minuteAgo.toJSON()
+                  timestamp: minuteAgo.toJSON(),
+                  pageload: 150
                 }
               },
               {
@@ -241,7 +248,8 @@ describe('src/queries.js', function () {
                 timestamp: subDays(now, 12).toJSON(),
                 payload: {
                   type: 'PAGEVIEW',
-                  timestamp: subDays(now, 12).toJSON()
+                  timestamp: subDays(now, 12).toJSON(),
+                  pageload: null
                 }
               },
               {
@@ -251,7 +259,8 @@ describe('src/queries.js', function () {
                 timestamp: subDays(now, 4).toJSON(),
                 payload: {
                   type: 'PAGEVIEW',
-                  timestamp: subDays(now, 4).toJSON()
+                  timestamp: subDays(now, 4).toJSON(),
+                  pageload: 150
                 }
               }
             ].map(function (event) {
@@ -304,7 +313,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'resolution', 'range'
+                'avgPageload', 'resolution', 'range'
               ]
             )
 
@@ -313,6 +322,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.uniqueSessions, 4)
             assert.strictEqual(data.pages.length, 4)
             assert.strictEqual(data.referrers.length, 1)
+            assert.strictEqual(data.avgPageload, 160)
 
             assert.strictEqual(data.pageviews[6].accounts, 1)
             assert.strictEqual(data.pageviews[6].pageviews, 2)
@@ -347,7 +357,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'resolution', 'range'
+                'avgPageload', 'resolution', 'range'
               ]
             )
 
@@ -356,6 +366,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.uniqueSessions, 5)
             assert.strictEqual(data.pages.length, 4)
             assert.strictEqual(data.referrers.length, 1)
+            assert.strictEqual(data.avgPageload, 150)
 
             assert.strictEqual(data.pageviews[1].accounts, 2)
             assert.strictEqual(data.pageviews[1].pageviews, 5)
@@ -383,7 +394,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'resolution', 'range'
+                'avgPageload', 'resolution', 'range'
               ]
             )
 
@@ -392,6 +403,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.uniqueSessions, 1)
             assert.strictEqual(data.pages.length, 2)
             assert.strictEqual(data.referrers.length, 0)
+            assert.strictEqual(data.avgPageload, 175)
 
             assert.strictEqual(data.pageviews[11].accounts, 1)
             assert.strictEqual(data.pageviews[11].pageviews, 2)


### PR DESCRIPTION
This adds a "Average Page Load" metric to the key metrics section.

The Page Load actually is defined as the time to DOM `interactive`, yet labeling it as page load is probably more approachable while the actual metric is more relevant than the time to `load` event.