### PR TITLE
Calculate average page depth

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -175,13 +175,13 @@ function view (state, emit) {
     ? state.model.uniqueUsers
     : state.model.uniqueAccounts
   var entityName = isOperator
-    ? __('users')
-    : __('accounts')
+    ? __('Users')
+    : __('Accounts')
 
   var uniqueSessions = state.model.uniqueSessions
   var keyMetrics = html`
     <div class="w-100 w-25-m w-20-ns pa3 mb2 ba b--black-10 br2 bg-white">
-      <h4 class ="f5 normal mt0 mb3 mb5-ns">Key metrics</h4>
+      <h4 class ="f5 normal mt0 mb3 mb4-ns">Key metrics</h4>
       <div class="flex flex-wrap">
         <div class="w-50 w-100-ns mb3 mb4-ns">
           <p class="mv0 f2">${uniqueEntities}</p>
@@ -189,11 +189,11 @@ function view (state, emit) {
         </div>
         <div class="w-50 w-100-ns mb3 mb4-ns">
           <p class="mv0 f2">${uniqueSessions}</p>
-          <p class="mv0 normal">${__('Unique sessions')}</p>
+          <p class="mv0 normal">${__('Unique Sessions')}</p>
         </div>
         <div class="w-50 w-100-ns mb3 mb4-ns">
           <p class="mv0 f2">${formatPercentage(state.model.bounceRate)} %</p>
-          <p class="mv0 normal">${__('Bounce rate')}</p>
+          <p class="mv0 normal">${__('Bounce Rate')}</p>
         </div>
         ${isOperator ? html`
           <div class="w-50 w-100-ns mb3 mb4-ns">
@@ -202,8 +202,13 @@ function view (state, emit) {
           </div>` : null}
         ${state.model.avgPageload ? html`
           <div class="w-50 w-100-ns mb3 mb4-ns">
-            <p class="mv0 f2">${state.model.avgPageload}ms</p>
-          <p class="mv0 normal">${__('Average pageload')}</p>
+            <p class="mv0 f2">${Math.round(state.model.avgPageload)} ms</p>
+            <p class="mv0 normal">${__('Avg. Page Load time')}</p>
+          </div>` : null}
+        ${state.model.avgPageDepth ? html`
+          <div class="w-50 w-100-ns mb3 mb4-ns">
+            <p class="mv0 f2">${state.model.avgPageDepth.toFixed(1)}</p>
+            <p class="mv0 normal">${__('Avg. Page Depth')}</p>
           </div>` : null}
       </div>
     </div>

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -282,11 +282,30 @@ function getDefaultStatsWith (getDatabase) {
         if (applicable.length === 0) {
           return null
         }
-
         var total = applicable.reduce(function (acc, next) {
           return acc + next
         }, 0)
-        return Math.round(total / applicable.length)
+        return total / applicable.length
+      })
+
+    var avgPageDepth = decryptedEvents
+      .then(function (events) {
+        var views
+        var uniqueSessions = _.chain(events)
+          .pluck('payload')
+          .pluck('sessionId')
+          .compact()
+          .tap(function (collection) {
+            views = collection.length
+          })
+          .uniq()
+          .size()
+          .value()
+
+        if (uniqueSessions === 0) {
+          return null
+        }
+        return views / uniqueSessions
       })
 
     return Promise
@@ -299,7 +318,8 @@ function getDefaultStatsWith (getDatabase) {
         pageviews,
         bounceRate,
         loss,
-        avgPageload
+        avgPageload,
+        avgPageDepth
       ])
       .then(function (results) {
         return {
@@ -312,6 +332,7 @@ function getDefaultStatsWith (getDatabase) {
           bounceRate: results[6],
           loss: results[7],
           avgPageload: results[8],
+          avgPageDepth: results[9],
           resolution: resolution,
           range: range
         }

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -53,7 +53,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'avgPageload', 'resolution', 'range'
+                'avgPageload', 'avgPageDepth', 'resolution', 'range'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
@@ -313,7 +313,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'avgPageload', 'resolution', 'range'
+                'avgPageload', 'avgPageDepth', 'resolution', 'range'
               ]
             )
 
@@ -323,6 +323,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.pages.length, 4)
             assert.strictEqual(data.referrers.length, 1)
             assert.strictEqual(data.avgPageload, 160)
+            assert.strictEqual(data.avgPageDepth, 1.25)
 
             assert.strictEqual(data.pageviews[6].accounts, 1)
             assert.strictEqual(data.pageviews[6].pageviews, 2)
@@ -357,7 +358,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'avgPageload', 'resolution', 'range'
+                'avgPageload', 'avgPageDepth', 'resolution', 'range'
               ]
             )
 
@@ -367,6 +368,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.pages.length, 4)
             assert.strictEqual(data.referrers.length, 1)
             assert.strictEqual(data.avgPageload, 150)
+            assert.strictEqual(data.avgPageDepth, 1.2)
 
             assert.strictEqual(data.pageviews[1].accounts, 2)
             assert.strictEqual(data.pageviews[1].pageviews, 5)
@@ -394,7 +396,7 @@ describe('src/queries.js', function () {
               [
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
-                'avgPageload', 'resolution', 'range'
+                'avgPageload', 'avgPageDepth', 'resolution', 'range'
               ]
             )
 
@@ -404,6 +406,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.pages.length, 2)
             assert.strictEqual(data.referrers.length, 0)
             assert.strictEqual(data.avgPageload, 175)
+            assert.strictEqual(data.avgPageDepth, 2)
 
             assert.strictEqual(data.pageviews[11].accounts, 1)
             assert.strictEqual(data.pageviews[11].pageviews, 2)


### PR DESCRIPTION
Calculates the average page depth by counting total visits and dividing them by the number of unique sessions.