### PR TITLE
Add metric for determining mobile share

### DIFF
--- a/auditorium/components/bar-chart.js
+++ b/auditorium/components/bar-chart.js
@@ -126,7 +126,8 @@ BarChart.prototype.getChartData = function () {
   }
 
   var config = {
-    displayModeBar: false
+    displayModeBar: false,
+    responsive: true
   }
 
   return [data, layout, config]

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -194,10 +194,13 @@ function view (state, emit) {
       <div class="flex flex-wrap">
         ${keyMetric(__('Unique %s', entityName), uniqueEntities)}
         ${keyMetric(__('Unique Sessions'), uniqueSessions)}
+        <hr class="mt0 mb3 w-100 bb bw1 b--black-10">
+        ${state.model.avgPageDepth ? keyMetric(__('Avg. Page Depth'), state.model.avgPageDepth.toFixed(1)) : null}
         ${keyMetric(__('Bounce Rate'), `${formatPercentage(state.model.bounceRate)} %`)}
         ${isOperator && state.model.loss ? keyMetric(__('Plus'), `${formatPercentage(state.model.loss)} %`) : null}
+        <hr class="mt0 mb3 w-100 bb bw1 b--black-10">
+        ${keyMetric(__('Mobile Users'), `${formatPercentage(state.model.mobileShare)} %`)}
         ${state.model.avgPageload ? keyMetric(__('Avg. Page Load time'), `${Math.round(state.model.avgPageload)} ms`) : null}
-        ${state.model.avgPageDepth ? keyMetric(__('Avg. Page Depth'), state.model.avgPageDepth.toFixed(1)) : null}
       </div>
     </div>
   `

--- a/script/src/events.js
+++ b/script/src/events.js
@@ -13,6 +13,9 @@ function pageview (initial) {
         )
       }
       return null
-    })()
+    })(),
+    // TODO: this works well at the moment, but is likely to be deprecated at
+    // some point in the future. Find a more robust feature detect.
+    isMobile: typeof window.onorientationchange !== 'undefined'
   }
 }

--- a/script/src/events.test.js
+++ b/script/src/events.test.js
@@ -5,15 +5,16 @@ describe('src/events.js', function () {
   describe('pageview()', function () {
     it('creates a pageview event', function () {
       var event = events.pageview(true)
-      assert.deepStrictEqual(Object.keys(event), ['type', 'href', 'title', 'referrer', 'pageload'])
+      assert.deepStrictEqual(Object.keys(event), ['type', 'href', 'title', 'referrer', 'pageload', 'isMobile'])
       assert.strictEqual(event.type, 'PAGEVIEW')
       assert.strictEqual(typeof event.href, 'string')
       assert.strictEqual(typeof event.title, 'string')
       assert.strictEqual(typeof event.referrer, 'string')
       assert.strictEqual(typeof event.pageload, 'number')
+      assert.strictEqual(typeof event.isMobile, 'boolean')
 
       var event2 = events.pageview(false)
-      assert.deepStrictEqual(Object.keys(event2), ['type', 'href', 'title', 'referrer', 'pageload'])
+      assert.deepStrictEqual(Object.keys(event2), ['type', 'href', 'title', 'referrer', 'pageload', 'isMobile'])
       assert.strictEqual(event2.pageload, null)
     })
   })

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -54,12 +54,14 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'resolution', 'range'
+                'mobileShare', 'resolution', 'range'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
             assert.strictEqual(data.uniqueAccounts, 0)
             assert.strictEqual(data.uniqueSessions, 0)
+            assert.strictEqual(data.mobileShare, null)
+
             assert.deepStrictEqual(data.referrers, [])
 
             assert.strictEqual(data.pageviews.length, 7)
@@ -315,7 +317,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'resolution', 'range'
+                'mobileShare', 'resolution', 'range'
               ]
             )
 
@@ -328,6 +330,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.referrers.length, 1)
             assert.strictEqual(data.avgPageload, 160)
             assert.strictEqual(data.avgPageDepth, 1.25)
+            assert.strictEqual(data.mobileShare, 0)
 
             assert.strictEqual(data.pageviews[6].accounts, 1)
             assert.strictEqual(data.pageviews[6].pageviews, 2)
@@ -363,7 +366,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'resolution', 'range'
+                'mobileShare', 'resolution', 'range'
               ]
             )
 
@@ -376,6 +379,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.exitPages.length, 1)
             assert.strictEqual(data.avgPageload, 150)
             assert.strictEqual(data.avgPageDepth, 1.2)
+            assert.strictEqual(data.mobileShare, 0)
 
             assert.strictEqual(data.pageviews[1].accounts, 2)
             assert.strictEqual(data.pageviews[1].pageviews, 5)
@@ -404,7 +408,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'resolution', 'range'
+                'mobileShare', 'resolution', 'range'
               ]
             )
 
@@ -417,6 +421,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.exitPages.length, 1)
             assert.strictEqual(data.avgPageload, 175)
             assert.strictEqual(data.avgPageDepth, 2)
+            assert.strictEqual(data.mobileShare, 0)
 
             assert.strictEqual(data.pageviews[11].accounts, 1)
             assert.strictEqual(data.pageviews[11].pageviews, 2)


### PR DESCRIPTION
This adds a mobile share metric to the key metrics.

It's important to note that this does not rely on storing UA strings anywhere (which we would like to avoid for privacy reasons), but instead uses a feature test performed at runtime. Only the boolean result of this feature test will be included in the event payload.