### PR TITLE
Ensure chart fills up entire parent

### DIFF
--- a/auditorium/components/bar-chart.js
+++ b/auditorium/components/bar-chart.js
@@ -35,7 +35,7 @@ BarChart.prototype.createElement = function (params) {
   params = params || {}
   Object.assign(this.local, params)
   return html`
-    <div class="chart"></div>
+    <div class="mb4 chart flex-auto"></div>
   `
 }
 
@@ -106,6 +106,7 @@ BarChart.prototype.getChartData = function () {
   ]
 
   var layout = {
+    autosize: true,
     yaxis: {
       fixedrange: true,
       dtick: 1,

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -161,13 +161,11 @@ function view (state, emit) {
   }
 
   var chart = html`
-    <div class="w-100 w-75-m w-80-ns pa3 mb2 mr2-ns ba b--black-10 br2 bg-white">
+    <div class="w-100 w-75-m w-80-ns pa3 mb2 mr2-ns ba b--black-10 br2 bg-white flex flex-column">
       <h4 class="f5 normal mt0 mb3">
         ${__('Page views and %s', isOperator ? __('visitors') : __('accounts'))}
       </h4>
-      <div class="mb4">
-        ${state.cache(BarChart, 'bar-chart').render(chartData)}
-      </div>
+      ${state.cache(BarChart, 'bar-chart').render(chartData)}
     </div>
   `
 


### PR DESCRIPTION
This makes sure the bar chart always takes up the entire height of its parent container (previously it was locked to 450px).

Now:

![image](https://user-images.githubusercontent.com/1662740/70374875-f2ef9e00-18f7-11ea-8452-f8029ad59749.png)

Before:

![image](https://user-images.githubusercontent.com/1662740/70374887-131f5d00-18f8-11ea-9514-a943f6af126b.png)
