### PR TITLE
Move functions for deriving stats into separate module

### DIFF
--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -138,29 +138,12 @@ function getDefaultStatsWith (getDatabase) {
         return _.sortBy(days, 'date')
       })
 
-    // `uniqueUsers` is the number of unique user ids for the given
-    //  timerange.
     var uniqueUsers = stats.visitors(eventsInBounds)
-    // `loss` is the percentage of anonymous events (i.e. events without a
-    // user identifier) in the given timeframe.
-    // indexed DB does not index on `null` (which maps to an anonymous event)
-    // so the loss rate can simply be calculated by comparing the count
-    // in an index with and one without userId
     var loss = stats.loss(decryptedEvents)
-    // This is the number of unique accounts for the given timeframe
     var uniqueAccounts = stats.accounts(eventsInBounds)
-    // This is the number of unique sessions for the given timeframe
     var uniqueSessions = stats.uniqueSessions(decryptedEvents)
-    // The bounce rate is calculated as the percentage of session identifiers
-    // in the timerange that are associated with one event only, i.e. there
-    // has been no follow-up event.
     var bounceRate = stats.bounceRate(decryptedEvents)
-    // `referrers` is the list of referrer values, grouped by host name. Common
-    // referrers (i.e. search engines or apps) will replaced with a human-friendly
-    // name assigned to their bucket.
     var referrers = stats.referrers(decryptedEvents)
-    // `pages` contains all pages visited sorted by the number of pageviews.
-    // URLs are stripped off potential query strings before grouping.
     var pages = stats.pages(decryptedEvents)
     var avgPageload = stats.avgPageload(decryptedEvents)
     var avgPageDepth = stats.avgPageDepth(decryptedEvents)

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -13,8 +13,8 @@ var subWeeks = require('date-fns/sub_weeks')
 var subMonths = require('date-fns/sub_months')
 
 var getDatabase = require('./database')
-var placeInBucket = require('./buckets')
 var decryptEvents = require('./decrypt-events')
+var stats = require('./stats')
 
 var startOf = {
   hours: startOfHour,
@@ -73,6 +73,7 @@ function getDefaultStatsWith (getDatabase) {
     var eventsInBounds = table
       .where('timestamp')
       .between(lowerBound, upperBound)
+      .toArray()
 
     // There are two types of queries happening here: those that rely solely
     // on the IndexedDB indices, and those that require the event payload
@@ -81,7 +82,7 @@ function getDefaultStatsWith (getDatabase) {
     // encryption, yet it seems using the IndexedDB API where possible makes
     // more sense and performs better.
     var decryptedEvents = eventsInBounds
-      .toArray(function (events) {
+      .then(function (events) {
         // User events are already decrypted, so there is no need to proceed
         // further. This may seem counterintuitive at first, but it'd be
         // relatively pointless to store the encrypted events alongside a
@@ -117,15 +118,11 @@ function getDefaultStatsWith (getDatabase) {
         var eventsInBounds = table
           .where('timestamp')
           .between(lowerBound, upperBound)
+          .toArray()
 
-        var pageviews = eventsInBounds
-          .toArray(countKeys('userId', false))
-
-        var visitors = eventsInBounds
-          .toArray(countKeys('userId', true))
-
-        var accounts = eventsInBounds
-          .toArray(countKeys('accountId', true))
+        var pageviews = stats.pageviews(eventsInBounds)
+        var visitors = stats.visitors(eventsInBounds)
+        var accounts = stats.accounts(eventsInBounds)
 
         return Promise.all([pageviews, visitors, accounts])
           .then(function (values) {
@@ -143,258 +140,33 @@ function getDefaultStatsWith (getDatabase) {
 
     // `uniqueUsers` is the number of unique user ids for the given
     //  timerange.
-    var uniqueUsers = eventsInBounds
-      .toArray(countKeys('userId', true))
-
+    var uniqueUsers = stats.visitors(eventsInBounds)
     // `loss` is the percentage of anonymous events (i.e. events without a
     // user identifier) in the given timeframe.
     // indexed DB does not index on `null` (which maps to an anonymous event)
     // so the loss rate can simply be calculated by comparing the count
     // in an index with and one without userId
-    var loss = eventsInBounds
-      .toArray(function (allEvents) {
-        if (allEvents.length === 0) {
-          return 0
-        }
-        var notNull = allEvents.filter(function (event) {
-          return event.userId !== null
-        })
-        return 1 - (notNull.length / allEvents.length)
-      })
-
+    var loss = stats.loss(decryptedEvents)
     // This is the number of unique accounts for the given timeframe
-    var uniqueAccounts = eventsInBounds
-      .toArray(countKeys('accountId', true))
-
+    var uniqueAccounts = stats.accounts(eventsInBounds)
     // This is the number of unique sessions for the given timeframe
-    var uniqueSessions = decryptedEvents
-      .then(function (events) {
-        return _.chain(events)
-          .pluck('payload')
-          .pluck('sessionId')
-          // anonymous events do not have a sessionId prop
-          .compact()
-          .unique()
-          .size()
-          .value()
-      })
-
+    var uniqueSessions = stats.uniqueSessions(decryptedEvents)
     // The bounce rate is calculated as the percentage of session identifiers
     // in the timerange that are associated with one event only, i.e. there
     // has been no follow-up event.
-    var bounceRate = decryptedEvents
-      .then(function (events) {
-        var sessionCounts = _.chain(events)
-          .pluck('payload')
-          .pluck('sessionId')
-          .compact()
-          .countBy(_.identity)
-          .values()
-          .value()
-
-        if (sessionCounts.length === 0) {
-          return 0
-        }
-
-        // The bounce rate is the percentage of sessions where there is only
-        // one event with the respective identifier in the given se
-        var bounces = sessionCounts
-          .filter(function (viewsInSession) {
-            return viewsInSession === 1
-          })
-        return bounces.length / sessionCounts.length
-      })
-
+    var bounceRate = stats.bounceRate(decryptedEvents)
     // `referrers` is the list of referrer values, grouped by host name. Common
     // referrers (i.e. search engines or apps) will replaced with a human-friendly
     // name assigned to their bucket.
-    var referrers = decryptedEvents
-      .then(function (events) {
-        var perHost = events
-          .filter(function (event) {
-            if (event.userId === null || !event.payload || !event.payload.referrer) {
-              return false
-            }
-            return event.payload.referrer.host !== event.payload.href.host
-          })
-          .map(function (event) {
-            return event.payload.referrer.host || event.payload.referrer.href
-          })
-          .filter(_.identity)
-          .map(placeInBucket)
-          .reduce(function (acc, referrerValue) {
-            acc[referrerValue] = acc[referrerValue] || 0
-            acc[referrerValue]++
-            return acc
-          }, {})
-        var unique = Object.keys(perHost)
-          .map(function (host) {
-            return { host: host, pageviews: perHost[host] }
-          })
-        return _.sortBy(unique, 'pageviews').reverse()
-      })
-
+    var referrers = stats.referrers(decryptedEvents)
     // `pages` contains all pages visited sorted by the number of pageviews.
     // URLs are stripped off potential query strings before grouping.
-    var pages = decryptedEvents
-      .then(function (events) {
-        return events
-          .filter(function (event) {
-            return event.userId !== null && event.payload.href
-          })
-          .map(function (event) {
-            return [event.accountId, event.payload.href]
-          })
-      })
-      .then(function (keys) {
-        var cleanedKeys = keys.map(function (pair) {
-          var accountId = pair[0]
-          var url = pair[1]
-          var strippedHref = url.origin + url.pathname
-          return [accountId, strippedHref]
-        })
-
-        var byAccount = cleanedKeys.reduce(function (acc, next) {
-          acc[next[0]] = acc[next[0]] || []
-          acc[next[0]].push(next)
-          return acc
-        }, {})
-
-        return _.chain(byAccount)
-          .values()
-          .map(function (pageviews) {
-            var counts = _.countBy(pageviews, function (pageview) {
-              return pageview[1]
-            })
-            return Object.keys(counts).map(function (url) {
-              return { url: url, pageviews: counts[url] }
-            })
-          })
-          .flatten(true)
-          .sortBy('pageviews')
-          .reverse()
-          .value()
-      })
-
-    var avgPageload = decryptedEvents
-      .then(function (events) {
-        var count
-        var total = _.chain(events)
-          .pluck('payload')
-          .pluck('pageload')
-          .compact()
-          .tap(function (entries) {
-            count = entries.length
-          })
-          .reduce(function (acc, next) {
-            return acc + next
-          }, 0)
-          .value()
-
-        if (count === 0) {
-          return null
-        }
-
-        return total / count
-      })
-
-    var avgPageDepth = decryptedEvents
-      .then(function (events) {
-        var views
-        var uniqueSessions = _.chain(events)
-          .pluck('payload')
-          .pluck('sessionId')
-          .compact()
-          .tap(function (collection) {
-            views = collection.length
-          })
-          .uniq()
-          .size()
-          .value()
-
-        if (uniqueSessions === 0) {
-          return null
-        }
-        return views / uniqueSessions
-      })
-
-    var landingPages = decryptedEvents
-      .then(function (events) {
-        return _.chain(events)
-          .filter(function (e) {
-            return e.userId !== null && e.payload.sessionId && e.payload.href
-          })
-          .groupBy(function (e) {
-            return e.payload.sessionId
-          })
-          .map(function (events, key) {
-            // for each session, we are only interested in the first
-            // event and its href value
-            var landing = _.chain(events)
-              .sortBy('timestamp')
-              .first()
-              .value()
-            return landing.payload.href.origin + landing.payload.href.pathname
-          })
-          .countBy(_.identity)
-          .pairs()
-          .map(function (pair) {
-            return { url: pair[0], pageviews: pair[1] }
-          })
-          .sortBy('pageviews')
-          .reverse()
-          .value()
-      })
-
-    var exitPages = decryptedEvents
-      .then(function (events) {
-        return _.chain(events)
-          .filter(function (e) {
-            return e.userId !== null && e.payload.sessionId && e.payload.href
-          })
-          .groupBy(function (e) {
-            return e.payload.sessionId
-          })
-          .map(function (events, key) {
-            if (events.length < 2) {
-              return null
-            }
-            // for each session, we are only interested in the first
-            // event and its href value
-            var landing = _.chain(events)
-              .sortBy('timestamp')
-              .last()
-              .value()
-            return landing.payload.href.origin + landing.payload.href.pathname
-          })
-          .compact()
-          .countBy(_.identity)
-          .pairs()
-          .map(function (pair) {
-            return { url: pair[0], pageviews: pair[1] }
-          })
-          .sortBy('pageviews')
-          .reverse()
-          .value()
-      })
-
-    var mobileShare = decryptedEvents
-      .then(function (events) {
-        var allEvents
-        var mobileEvents = _.chain(events)
-          .filter('userId')
-          .tap(function (events) {
-            allEvents = events.length
-          })
-          .filter(_.property(['payload', 'isMobile']))
-          .size()
-          .value()
-
-        if (allEvents === 0) {
-          return null
-        }
-        return mobileEvents / allEvents
-      })
+    var pages = stats.pages(decryptedEvents)
+    var avgPageload = stats.avgPageload(decryptedEvents)
+    var avgPageDepth = stats.avgPageDepth(decryptedEvents)
+    var landingPages = stats.landingPages(decryptedEvents)
+    var exitPages = stats.exitPages(decryptedEvents)
+    var mobileShare = stats.mobileShare(decryptedEvents)
 
     return Promise
       .all([
@@ -560,22 +332,5 @@ function getEncryptedUserSecretsWith (getDatabase) {
       .where('type')
       .equals(TYPE_ENCRYPTED_USER_SECRET)
       .toArray()
-  }
-}
-
-function countKeys (keys, unique) {
-  return function (elements) {
-    var list = _.chain(elements)
-    if (!Array.isArray(keys)) {
-      keys = [keys]
-    }
-    keys.forEach(function (key) {
-      list = list.pluck(key)
-    })
-    list = list.compact()
-    if (unique) {
-      list = list.uniq()
-    }
-    return list.size().value()
   }
 }

--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -267,7 +267,8 @@ function countKeys (keys, unique) {
 // `consumeAsync` ensures the given function can be called with both
 // synchronous and asynchronous values as arguments. The return value
 // will be wrapped in a Promise.
-function consumeAsync (fn, ctx = null) {
+function consumeAsync (fn, ctx) {
+  ctx = ctx || null
   return function () {
     var args = [].slice.call(arguments)
     return Promise.all(args)

--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -1,0 +1,279 @@
+var _ = require('underscore')
+
+var placeInBucket = require('./buckets')
+
+exports.loss = consumeAsync(loss)
+
+function loss (events) {
+  var totalCount = events.length
+  var nonNullCount = _.chain(events)
+    .pluck('userId')
+    .compact()
+    .size()
+    .value()
+
+  if (totalCount === 0) {
+    return 0
+  }
+
+  return 1 - (nonNullCount / totalCount)
+}
+
+exports.uniqueSessions = consumeAsync(uniqueSessions)
+
+function uniqueSessions (events) {
+  return _.chain(events)
+    .map(_.property(['payload', 'sessionId']))
+    // anonymous events do not have a sessionId prop
+    .compact()
+    .unique()
+    .size()
+    .value()
+}
+
+exports.bounceRate = consumeAsync(bounceRate)
+
+function bounceRate (events) {
+  var sessionCounts = 0
+  var bounces = _.chain(events)
+    .map(_.property(['payload', 'sessionId']))
+    .compact()
+    .countBy(_.identity)
+    .values()
+    .tap(function (sessions) {
+      sessionCounts = sessions.length
+    })
+    .filter(function (pagesInSession) {
+      return pagesInSession === 1
+    })
+    .size()
+    .value()
+
+  if (sessionCounts === 0) {
+    return 0
+  }
+
+  // The bounce rate is the percentage of sessions where there is only
+  // one event with the respective identifier in the given se
+  return bounces / sessionCounts
+}
+
+exports.referrers = consumeAsync(referrers)
+
+function referrers (events) {
+  var perHost = _.chain(events)
+    .filter(function (event) {
+      if (event.userId === null || !event.payload || !event.payload.referrer) {
+        return false
+      }
+      return event.payload.referrer.host !== event.payload.href.host
+    })
+    .map(function (event) {
+      return event.payload.referrer.host || event.payload.referrer.href
+    })
+    .compact()
+    .map(placeInBucket)
+    .reduce(function (acc, referrerValue) {
+      acc[referrerValue] = acc[referrerValue] || 0
+      acc[referrerValue]++
+      return acc
+    }, {})
+    .value()
+
+  var unique = Object.keys(perHost)
+    .map(function (host) {
+      return { host: host, pageviews: perHost[host] }
+    })
+  return _.sortBy(unique, 'pageviews').reverse()
+}
+
+exports.pages = consumeAsync(pages)
+
+function pages (events) {
+  var keys = events
+    .filter(function (event) {
+      return event.userId !== null && event.payload.href
+    })
+    .map(function (event) {
+      return [event.accountId, event.payload.href]
+    })
+
+  var cleanedKeys = keys.map(function (pair) {
+    var accountId = pair[0]
+    var url = pair[1]
+    var strippedHref = url.origin + url.pathname
+    return [accountId, strippedHref]
+  })
+
+  var byAccount = cleanedKeys.reduce(function (acc, next) {
+    acc[next[0]] = acc[next[0]] || []
+    acc[next[0]].push(next)
+    return acc
+  }, {})
+
+  return _.chain(byAccount)
+    .values()
+    .map(function (pageviews) {
+      var counts = _.countBy(pageviews, function (pageview) {
+        return pageview[1]
+      })
+      return Object.keys(counts).map(function (url) {
+        return { url: url, pageviews: counts[url] }
+      })
+    })
+    .flatten(true)
+    .sortBy('pageviews')
+    .reverse()
+    .value()
+}
+
+exports.avgPageload = consumeAsync(avgPageload)
+
+function avgPageload (events) {
+  var count
+  var total = _.chain(events)
+    .map(_.property(['payload', 'pageload']))
+    .compact()
+    .tap(function (entries) {
+      count = entries.length
+    })
+    .reduce(function (acc, next) {
+      return acc + next
+    }, 0)
+    .value()
+
+  if (count === 0) {
+    return null
+  }
+
+  return total / count
+}
+
+exports.avgPageDepth = consumeAsync(avgPageDepth)
+
+function avgPageDepth (events) {
+  var views
+  var uniqueSessions = _.chain(events)
+    .map(_.property(['payload', 'sessionId']))
+    .compact()
+    .tap(function (collection) {
+      views = collection.length
+    })
+    .uniq()
+    .size()
+    .value()
+
+  if (uniqueSessions === 0) {
+    return null
+  }
+  return views / uniqueSessions
+}
+
+exports.exitPages = consumeAsync(exitPages)
+
+function exitPages (events) {
+  return _.chain(events)
+    .filter(function (e) {
+      return e.userId !== null && e.payload.sessionId && e.payload.href
+    })
+    .groupBy(function (e) {
+      return e.payload.sessionId
+    })
+    .map(function (events, key) {
+      if (events.length < 2) {
+        return null
+      }
+      // for each session, we are only interested in the first
+      // event and its href value
+      var landing = _.chain(events)
+        .sortBy('timestamp')
+        .last()
+        .value()
+      return landing.payload.href.origin + landing.payload.href.pathname
+    })
+    .compact()
+    .countBy(_.identity)
+    .pairs()
+    .map(function (pair) {
+      return { url: pair[0], pageviews: pair[1] }
+    })
+    .sortBy('pageviews')
+    .reverse()
+    .value()
+}
+
+exports.landingPages = consumeAsync(landingPages)
+
+function landingPages (events) {
+  return _.chain(events)
+    .filter(function (e) {
+      return e.userId !== null && e.payload.sessionId && e.payload.href
+    })
+    .groupBy(function (e) {
+      return e.payload.sessionId
+    })
+    .map(function (events, key) {
+      // for each session, we are only interested in the first
+      // event and its href value
+      var landing = _.chain(events)
+        .sortBy('timestamp')
+        .first()
+        .value()
+      return landing.payload.href.origin + landing.payload.href.pathname
+    })
+    .countBy(_.identity)
+    .pairs()
+    .map(function (pair) {
+      return { url: pair[0], pageviews: pair[1] }
+    })
+    .sortBy('pageviews')
+    .reverse()
+    .value()
+}
+
+exports.mobileShare = consumeAsync(mobileShare)
+
+function mobileShare (events) {
+  var allEvents
+  var mobileEvents = _.chain(events)
+    .filter('userId')
+    .tap(function (events) {
+      allEvents = events.length
+    })
+    .filter(_.property(['payload', 'isMobile']))
+    .size()
+    .value()
+
+  if (allEvents === 0) {
+    return null
+  }
+  return mobileEvents / allEvents
+}
+
+exports.pageviews = countKeys('userId', false)
+exports.visitors = countKeys('userId', true)
+exports.accounts = countKeys('accountId', true)
+
+function countKeys (keys, unique) {
+  return consumeAsync(function (elements) {
+    if (!Array.isArray(keys)) {
+      keys = [keys]
+    }
+    var list = _.map(elements, _.property(keys))
+    list = _.compact(list)
+    if (unique) {
+      list = _.uniq(list)
+    }
+    return list.length
+  })
+}
+
+function consumeAsync (fn, ctx = null) {
+  return function () {
+    var args = [].slice.call(arguments)
+    return Promise.all(args)
+      .then(function (resolvedArgs) {
+        return fn.apply(ctx, resolvedArgs)
+      })
+  }
+}

--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -2,6 +2,8 @@ var _ = require('underscore')
 
 var placeInBucket = require('./buckets')
 
+// `loss` is the percentage of anonymous events (i.e. events without a
+// user identifier) in the given set of events.
 exports.loss = consumeAsync(loss)
 
 function loss (events) {
@@ -13,8 +15,9 @@ function loss (events) {
   return 1 - (nonNullCount / totalCount)
 }
 
-exports.uniqueSessions = consumeAsync(countKeys(['payload', 'sessionId'], true))
-
+// The bounce rate is calculated as the percentage of session identifiers
+// in the set of events that are associated with one event only, i.e. there
+// has been no follow-up event.
 exports.bounceRate = consumeAsync(bounceRate)
 
 function bounceRate (events) {
@@ -42,6 +45,9 @@ function bounceRate (events) {
   return bounces / sessionCounts
 }
 
+// `referrers` is the list of referrer values, grouped by host name. Common
+// referrers (i.e. search engines or apps) will replaced with a human-friendly
+// name assigned to their bucket.
 exports.referrers = consumeAsync(referrers)
 
 function referrers (events) {
@@ -67,6 +73,9 @@ function referrers (events) {
     .value()
 }
 
+// `pages` contains all pages visited sorted by the number of pageviews.
+// URLs are stripped off potential query strings and hash parameters
+// before grouping.
 exports.pages = consumeAsync(pages)
 
 function pages (events) {
@@ -108,6 +117,8 @@ function pages (events) {
     .value()
 }
 
+// `avgPageload` calculates the average pageload time of the given
+// set of events
 exports.avgPageload = consumeAsync(avgPageload)
 
 function avgPageload (events) {
@@ -130,6 +141,8 @@ function avgPageload (events) {
   return total / count
 }
 
+// `avgPageDepth` calculates the average session length in the given
+// set of events
 exports.avgPageDepth = consumeAsync(avgPageDepth)
 
 function avgPageDepth (events) {
@@ -143,6 +156,10 @@ function avgPageDepth (events) {
 
 exports.exitPages = consumeAsync(exitPages)
 
+// `exitPages` groups the given events by session identifier and then
+// returns a sorted list of exit pages for these sessions. URLs will be
+// stripped off query and hash parameters. Sessions that only contain
+// a single page will be excluded.
 function exitPages (events) {
   return _.chain(events)
     .filter(function (e) {
@@ -174,6 +191,9 @@ function exitPages (events) {
     .value()
 }
 
+// `landingPages` groups the given events by session identifier and then
+// returns a sorted list of landing pages for these sessions. URLs will be
+// stripped off query and hash parameters.
 exports.landingPages = consumeAsync(landingPages)
 
 function landingPages (events) {
@@ -203,6 +223,8 @@ function landingPages (events) {
     .value()
 }
 
+// `mobileShare` returns the percentage of events flagged as mobile
+// in the given set of events.
 exports.mobileShare = consumeAsync(mobileShare)
 
 function mobileShare (events) {
@@ -223,8 +245,13 @@ function mobileShare (events) {
 }
 
 exports.pageviews = consumeAsync(countKeys('userId', false))
+// `visitors` is the number of unique users for the given
+//  set of events.
 exports.visitors = consumeAsync(countKeys('userId', true))
+// This is the number of unique accounts for the given timeframe
 exports.accounts = consumeAsync(countKeys('accountId', true))
+// This is the number of unique sessions for the given timeframe
+exports.uniqueSessions = consumeAsync(countKeys(['payload', 'sessionId'], true))
 
 function countKeys (keys, unique) {
   return function (elements) {
@@ -237,6 +264,9 @@ function countKeys (keys, unique) {
   }
 }
 
+// `consumeAsync` ensures the given function can be called with both
+// synchronous and asynchronous values as arguments. The return value
+// will be wrapped in a Promise.
 function consumeAsync (fn, ctx = null) {
   return function () {
     var args = [].slice.call(arguments)

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -1,0 +1,309 @@
+var assert = require('assert')
+
+var stats = require('./stats')
+
+describe('src/stats.js', function () {
+  describe('stats.loss(events)', function () {
+    it('calculates the percentage of anoynmous events in the given set', function () {
+      return stats.loss([
+        { userId: 'user-a' },
+        { userId: 'user-b' },
+        { timestamp: new Date().toJSON() },
+        { userId: 'user-d' }
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 0.25)
+        })
+    })
+    it('returns 0 on empty events', function () {
+      return stats.loss([])
+        .then(function (result) {
+          assert.strictEqual(result, 0)
+        })
+    })
+    it('returns 1 on anonymous events only', function () {
+      return stats.loss([
+        { timestamp: new Date().toJSON() },
+        { timestamp: new Date().toJSON() }
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 1)
+        })
+    })
+  })
+
+  describe('stats.uniqueSessions(events)', function () {
+    it('counts the number of unique session identifiers', function () {
+      return stats.uniqueSessions([
+        {},
+        { payload: {} },
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-b' } },
+        { payload: { sessionId: 'session-B' } },
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-B' } }
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 3)
+        })
+    })
+    it('returns 0 when given an empty list', function () {
+      return stats.uniqueSessions([])
+        .then(function (result) {
+          assert.strictEqual(result, 0)
+        })
+    })
+  })
+
+  describe('stats.bounceRate(events)', function () {
+    it('calculates the percentage of session identifiers that occur only once', function () {
+      return stats.bounceRate([
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-b' } },
+        { payload: { sessionId: 'session-B' } },
+        { payload: { sessionId: 'session-c' } },
+        { payload: { sessionId: 'session-B' } },
+        { payload: { sessionId: 'session-B' } },
+        { payload: { sessionId: 'session-B' } },
+        { timestamp: new Date().toJSON() }
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 0.75)
+        })
+    })
+    it('returns 0 on when given an empty list', function () {
+      return stats.bounceRate([])
+        .then(function (result) {
+          assert.strictEqual(result, 0)
+        })
+    })
+    it('returns 1 on a list of unique session id', function () {
+      return stats.bounceRate([
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-b' } },
+        { payload: { sessionId: 'session-B' } },
+        { payload: { sessionId: 'session-c' } },
+        {}
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 1)
+        })
+    })
+  })
+
+  describe('stats.avgPageload(events)', function () {
+    it('calculates the average of the pageload times present in the set of events', function () {
+      return stats.avgPageload([
+        { timestamp: new Date().toJSON() },
+        { payload: { pageload: 200 } },
+        { payload: {} },
+        { payload: { pageload: 200 } },
+        { payload: { pageload: 400 } },
+        { payload: { pageload: 100 } },
+        { payload: { pageload: 100 } }
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 200)
+        })
+    })
+    it('returns null on an empty list of events', function () {
+      return stats.avgPageload([])
+        .then(function (result) {
+          assert.strictEqual(result, null)
+        })
+    })
+  })
+
+  describe('stats.avgPageDepth(events)', function () {
+    it('returns the average session length', function () {
+      return stats.avgPageDepth([
+        {},
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-b' } },
+        { payload: { sessionId: 'session-b' } },
+        { payload: { sessionId: 'session-a' } },
+        { payload: { sessionId: 'session-c' } },
+        { payload: { sessionId: 'session-a' } }
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 2)
+        })
+    })
+    it('returns null when given an empty array of events', function () {
+      return stats.avgPageDepth([])
+        .then(function (result) {
+          assert.strictEqual(result, null)
+        })
+    })
+  })
+
+  describe('stats.pageviews(events)', function () {
+    it('counts the number of events with userId value', function () {
+      return stats.pageviews([
+        { userId: 'user-b' },
+        { userId: 'user-a' },
+        { userId: null },
+        { userId: 'user-b' },
+        { userId: 'user-c' },
+        {}
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 4)
+        })
+    })
+    it('returns 0 when given an empty list', function () {
+      return stats.pageviews([])
+        .then(function (result) {
+          assert.strictEqual(result, 0)
+        })
+    })
+  })
+
+  describe('stats.visitors(events)', function () {
+    it('counts the number of events with distinct userId values', function () {
+      return stats.visitors([
+        { userId: 'user-b' },
+        { userId: 'user-a' },
+        { userId: null },
+        { userId: 'user-b' },
+        { userId: 'user-c' },
+        {}
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 3)
+        })
+    })
+    it('returns 0 when given an empty list', function () {
+      return stats.visitors([])
+        .then(function (result) {
+          assert.strictEqual(result, 0)
+        })
+    })
+  })
+
+  describe('stats.accounts(events)', function () {
+    it('counts the number of events with distinct accountId values', function () {
+      return stats.accounts([
+        { accountId: 'account-b' },
+        { accountId: 'account-a' },
+        { accountId: null },
+        { accountId: 'account-b' },
+        { accountId: 'account-c' },
+        {}
+      ])
+        .then(function (result) {
+          assert.strictEqual(result, 3)
+        })
+    })
+    it('returns 0 when given an empty list', function () {
+      return stats.accounts([])
+        .then(function (result) {
+          assert.strictEqual(result, 0)
+        })
+    })
+  })
+
+  describe('stats.referrers(events)', function () {
+    it('returns sorted referrer values from foreign domains grouped by host', function () {
+      return stats.referrers([
+        {},
+        { payload: { href: new window.URL('https://www.mysite.com/x'), referrer: new window.URL('https://www.example.net/foo') } },
+        { payload: { href: new window.URL('https://www.mysite.com/y'), referrer: new window.URL('https://www.example.net/bar') } },
+        { payload: { href: new window.URL('https://www.mysite.com/z'), referrer: new window.URL('https://www.example.net/baz') } },
+        { payload: { href: new window.URL('https://www.mysite.com/x'), referrer: new window.URL('https://beep.boop/#!foo=bar') } },
+        { payload: { href: new window.URL('https://www.mysite.com/x'), referrer: new window.URL('https://www.mysite.com/a') } }
+      ])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [
+            { host: 'www.example.net', pageviews: 3 },
+            { host: 'beep.boop', pageviews: 1 }
+          ])
+        })
+    })
+    it('returns an empty array when given an empty array', function () {
+      return stats.referrers([])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
+
+  describe('stats.pages(events)', function () {
+    it('returns a sorted list of pages grouped by a clean URL', function () {
+      return stats.pages([
+        {},
+        { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo') } },
+        { accountId: 'account-a', userId: 'user-b', payload: { href: new window.URL('https://www.example.net/foo?param=bar') } },
+        { accountId: 'account-b', userId: 'user-z', payload: { href: new window.URL('https://beep.boop/site#!/foo') } },
+        { accountId: 'account-a', userId: null, payload: { } }
+      ])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [
+            { url: 'https://www.example.net/foo', pageviews: 2 },
+            { url: 'https://beep.boop/site', pageviews: 1 }
+          ])
+        })
+    })
+    it('returns an empty array when given no events', function () {
+      return stats.pages([])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
+
+  describe('stats.landingPages(events)', function () {
+    it('returns a sorted list of landing pages grouped by a clean URL', function () {
+      return stats.landingPages([
+        {},
+        { userId: 'user-a', payload: { timestamp: '0', sessionId: 'session-a', href: new window.URL('https://www.example.net/foo') } },
+        { userId: 'user-a', payload: { timestamp: '1', sessionId: 'session-a', href: new window.URL('https://www.example.net/bar') } },
+        { userId: 'user-a', payload: { timestamp: '2', sessionId: 'session-a', href: new window.URL('https://www.example.net/baz') } },
+        { userId: 'user-b', payload: { timestamp: '247', sessionId: 'session-b', href: new window.URL('https://www.example.net/foo?param=bar') } },
+        { userId: 'user-b', payload: { timestamp: '290', sessionId: 'session-b', href: new window.URL('https://www.example.net/bar?param=foo') } },
+        { userId: 'user-z', payload: { timestamp: '50', sessionId: 'session-c', href: new window.URL('https://beep.boop/site#!/foo') } },
+        { userId: null, payload: { } }
+      ])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [
+            { url: 'https://www.example.net/foo', pageviews: 2 },
+            { url: 'https://beep.boop/site', pageviews: 1 }
+          ])
+        })
+    })
+    it('returns an empty array when given no events', function () {
+      return stats.landingPages([])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
+
+  describe('stats.exitPages(events)', function () {
+    it('returns a sorted list of exit pages grouped by a clean URL', function () {
+      return stats.exitPages([
+        {},
+        { userId: 'user-a', payload: { timestamp: '0', sessionId: 'session-a', href: new window.URL('https://www.example.net/foo') } },
+        { userId: 'user-a', payload: { timestamp: '1', sessionId: 'session-a', href: new window.URL('https://www.example.net/bar') } },
+        { userId: 'user-a', payload: { timestamp: '2', sessionId: 'session-a', href: new window.URL('https://www.example.net/baz') } },
+        { userId: 'user-b', payload: { timestamp: '247', sessionId: 'session-b', href: new window.URL('https://www.example.net/foo?param=bar') } },
+        { userId: 'user-b', payload: { timestamp: '290', sessionId: 'session-b', href: new window.URL('https://www.example.net/bar?param=foo') } },
+        { userId: 'user-z', payload: { timestamp: '50', sessionId: 'session-c', href: new window.URL('https://beep.boop/site#!/foo') } },
+        { userId: null, payload: { } }
+      ])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [
+            { url: 'https://www.example.net/bar', pageviews: 1 },
+            { url: 'https://www.example.net/baz', pageviews: 1 }
+          ])
+        })
+    })
+    it('returns an empty array when given no events', function () {
+      return stats.exitPages([])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
+})


### PR DESCRIPTION
This is a pure maintenance PR that moves the existing functions for calculating metrics into a separate module.

This makes it easier to achieve the following:
- Get higher test coverage. When previously tests needed to be run against encrypted events with lots of setup and teardown, we now can test synchronous functions that map a list to a value.
- This also makes it easier for us to understand and document how the metrics are being calculated as all efforts can refer to a single function body.