### PR TITLE
Do not tear down DOM when changing filters for the same view

### DIFF
--- a/auditorium/index.js
+++ b/auditorium/index.js
@@ -15,6 +15,7 @@ var withTitle = require('./views/decorators/with-title')
 var withModel = require('./views/decorators/with-model')
 var withError = require('./views/decorators/with-error')
 var withLayout = require('./views/decorators/with-layout')
+var withPreviousRoute = require('./views/decorators/with-previous-route')
 
 var app = choo()
 
@@ -30,7 +31,7 @@ app.use(authStore)
 app.use(bailOutStore)
 
 function decorateWithDefaults (view, title) {
-  var wrapper = _.compose(withLayout(), withError(), withTitle(title))
+  var wrapper = _.compose(withPreviousRoute(), withLayout(), withError(), withTitle(title))
   return wrapper(view)
 }
 

--- a/auditorium/views/decorators/with-model.js
+++ b/auditorium/views/decorators/with-model.js
@@ -7,11 +7,11 @@ function withModel () {
     return function (state, emit) {
       if (!state.model) {
         emit('offen:query', Object.assign({}, state.params, state.query), state.authenticatedUser)
-        var loading = html`
-          <p class="loading dib pa2 br2 bg-black-05 mt0 mb2">${__('Fetching the latest data...')}</p>
-
+        return html`
+          <p class="loading dib pa2 br2 bg-black-05 mt0 mb2">
+            ${__('Fetching the latest data...')}
+          </p>
         `
-        return loading
       }
       return originalView(state, emit)
     }

--- a/auditorium/views/decorators/with-previous-roue.test.js
+++ b/auditorium/views/decorators/with-previous-roue.test.js
@@ -1,0 +1,38 @@
+var assert = require('assert')
+var choo = require('choo')
+var html = require('choo/html')
+
+var withPreviousRoute = require('./with-previous-route')
+
+function testView (state, emit) {
+  return html`
+    <div>
+      <h1 id="test">TEST CONTENT</h1>
+    </div>
+  `
+}
+
+describe('src/decorators/with-previous-route.js', function () {
+  describe('withPreviousRoute()', function () {
+    var app
+    beforeEach(function () {
+      app = choo()
+    })
+
+    it('sets the page title to the given value', function () {
+      var wrappedView = withPreviousRoute()(testView)
+      app.state.route = 'test'
+      app.state.params = { val: 23 }
+      wrappedView(app.state, app.emit)
+      assert.strictEqual(app.state.previousRoute, 'test')
+      assert.deepStrictEqual(app.state.previousParams, { val: 23 })
+
+      app.state.route = 'other'
+      app.state.params = {}
+
+      wrappedView(app.state, app.emit)
+      assert.strictEqual(app.state.previousRoute, 'other')
+      assert.deepStrictEqual(app.state.previousParams, {})
+    })
+  })
+})

--- a/auditorium/views/decorators/with-previous-route.js
+++ b/auditorium/views/decorators/with-previous-route.js
@@ -1,0 +1,11 @@
+module.exports = withPreviousRoute
+
+function withPreviousRoute () {
+  return function (originalView) {
+    return function (state, emit) {
+      state.previousRoute = state.route
+      state.previousParams = state.params
+      return originalView(state, emit)
+    }
+  }
+}

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -264,6 +264,7 @@ function view (state, emit) {
       `
     : null
 
+  // TODO: add properly styled loading overlay
   return html`
       <div>
         ${accountHeader}
@@ -271,6 +272,7 @@ function view (state, emit) {
         ${rowUsersSessionsChart}
         ${urlTables}
         ${goSettings}
+        ${state.stale ? html`<div class="fixed top-0 right-0 bottom-0 left-0 bg-white o-40"></div>` : null}
       </div>
     `
 }


### PR DESCRIPTION
This prepares for displaying live data in the auditorium. Instead of deleting the model each time a parameter changes the app now selectively checks if only query parameters have been changed before rendering, in which case the stale model will be kept until it is overwritten with the requested set.

![Peek 2019-12-12 17-01](https://user-images.githubusercontent.com/1662740/70729009-b1e5f800-1d02-11ea-8c83-4ef89664f20e.gif)

The transparent overlay while displaying stale data is currently just a placeholder and needs to be properly designed.
