### PR TITLE
Add realtime stats to operator auditorium

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -200,7 +200,7 @@ function view (state, emit) {
   if (isOperator) {
     live = html`
       <div class="w-100 pa3 mb2 mr2-ns ba b--black-10 br2 bg-white flex flex-column">
-        <div class="flex-ns flex-row">
+        <div class="flex flex-column flex-row-ns">
           <div class="w-100 w-30-ns">
             <h4 class="f5 normal mt0 mb3">
               ${__('Right now')}
@@ -208,7 +208,7 @@ function view (state, emit) {
             ${keyMetric('Unique users', state.model.liveUsers)}
           </div>
           <div class="w-100 w-70-ns">
-            ${urlTable('Currently active pages', 'URL', 'Visitors', state.model.livePages)}
+            ${urlTable(__('Currently active pages'), __('URL'), __('Visitors'), state.model.livePages)}
           </div>
         </div>
       </div>

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -6,6 +6,43 @@ var BarChart = require('./../components/bar-chart')
 
 module.exports = view
 
+function urlTable (headline, col1Label, col2Label, rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return null
+  }
+  var data = rows.map(function (row) {
+    return html`
+        <tr>
+          <td class="pv2 bt b--black-10">${row.url}</td>
+          <td class="pv2 bt b--black-10">${row.pageviews}</td>
+        </tr>
+      `
+  })
+  return html`
+      <h4 class ="f5 normal mt0 mb3">${headline}</h4>
+      <table class="w-100 collapse mb3 dt--fixed">
+        <thead>
+          <tr>
+            <td class="pv2 b">${col1Label}</td>
+            <td class="pv2 b">${col2Label}</td>
+          </tr>
+        </thead>
+        <tbody>
+          ${data}
+        </tbody>
+      </table>
+    `
+}
+
+function keyMetric (name, value) {
+  return html`
+      <div class="w-50 w-100-ns mb3 mb4-ns">
+        <p class="mv0 f2">${value}</p>
+        <p class="mv0 normal">${name}</p>
+      </div>
+    `
+}
+
 function formatPercentage (value) {
   return (value * 100).toLocaleString(undefined, {
     maximumFractionDigits: 1,
@@ -159,6 +196,25 @@ function view (state, emit) {
       </div>
     `
 
+  var live = null
+  if (isOperator) {
+    live = html`
+      <div class="w-100 pa3 mb2 mr2-ns ba b--black-10 br2 bg-white flex flex-column">
+        <div class="flex-ns flex-row">
+          <div class="w-100 w-30-ns">
+            <h4 class="f5 normal mt0 mb3">
+              ${__('Right now')}
+            </h4>
+            ${keyMetric('Unique users', state.model.liveUsers)}
+          </div>
+          <div class="w-100 w-70-ns">
+            ${urlTable('Currently active pages', 'URL', 'Visitors', state.model.livePages)}
+          </div>
+        </div>
+      </div>
+    `
+  }
+
   var chartData = {
     data: state.model.pageviews,
     isOperator: isOperator,
@@ -180,15 +236,6 @@ function view (state, emit) {
   var entityName = isOperator
     ? __('Users')
     : __('Accounts')
-
-  function keyMetric (name, value) {
-    return html`
-      <div class="w-50 w-100-ns mb3 mb4-ns">
-        <p class="mv0 f2">${value}</p>
-        <p class="mv0 normal">${name}</p>
-      </div>
-    `
-  }
 
   var uniqueSessions = state.model.uniqueSessions
   var keyMetrics = html`
@@ -214,34 +261,6 @@ function view (state, emit) {
       ${keyMetrics}
     </div>
   `
-
-  function urlTable (headline, col1Label, col2Label, rows) {
-    if (!Array.isArray(rows) || rows.length === 0) {
-      return null
-    }
-    var data = rows.map(function (row) {
-      return html`
-        <tr>
-          <td class="pv2 bt b--black-10">${row.url}</td>
-          <td class="pv2 bt b--black-10">${row.pageviews}</td>
-        </tr>
-      `
-    })
-    return html`
-      <h4 class ="f5 normal mt0 mb3">${headline}</h4>
-      <table class="w-100 collapse mb3 dt--fixed">
-        <thead>
-          <tr>
-            <td class="pv2 b">${col1Label}</td>
-            <td class="pv2 b">${col2Label}</td>
-          </tr>
-        </thead>
-        <tbody>
-          ${data}
-        </tbody>
-      </table>
-    `
-  }
 
   var urlTables = html`
     <div class="w-100 pa3 mb2 ba b--black-10 br2 bg-white">
@@ -274,6 +293,7 @@ function view (state, emit) {
       <div>
         ${accountHeader}
         ${rowRangeManage}
+        ${live}
         ${rowUsersSessionsChart}
         ${urlTables}
         ${goSettings}

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -19,6 +19,11 @@ function view (state, emit) {
   }
 
   var isOperator = !!(state.params && state.params.accountId)
+
+  if (isOperator) {
+    emit('offen:schedule-refresh', 15000)
+  }
+
   var accountHeader = null
   var pageTitle
   if (isOperator) {

--- a/auditorium/views/main.test.js
+++ b/auditorium/views/main.test.js
@@ -45,7 +45,7 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 7)
+      assert.strictEqual(headlines.length, 8)
 
       var chart = result.querySelector('.chart')
       assert(chart)

--- a/vault/src/get-operator-events.js
+++ b/vault/src/get-operator-events.js
@@ -5,7 +5,7 @@ var queries = require('./queries')
 var bindCrypto = require('./bind-crypto')
 var decryptEvents = require('./decrypt-events')
 
-module.exports = getOperatorEventsWith(queries, api, {})
+module.exports = getOperatorEventsWith(queries, api)
 module.exports.getOperatorEventsWith = getOperatorEventsWith
 
 function getOperatorEventsWith (queries, api) {

--- a/vault/src/get-operator-events.js
+++ b/vault/src/get-operator-events.js
@@ -8,13 +8,13 @@ var decryptEvents = require('./decrypt-events')
 module.exports = getOperatorEventsWith(queries, api, {})
 module.exports.getOperatorEventsWith = getOperatorEventsWith
 
-function getOperatorEventsWith (queries, api, cache) {
+function getOperatorEventsWith (queries, api) {
   return function (query, authenticatedUser) {
     var matchingAccount = _.findWhere(authenticatedUser.accounts, { accountId: query.accountId })
     if (!matchingAccount) {
       return Promise.reject(new Error('No matching key found for account with id ' + query.accountId))
     }
-    return ensureSyncWith(queries, api, cache)(query.accountId, matchingAccount.keyEncryptionKey)
+    return ensureSyncWith(queries, api)(query.accountId, matchingAccount.keyEncryptionKey)
       .then(function (account) {
         return queries.getDefaultStats(query.accountId, query, account.privateJwk)
           .then(function (stats) {
@@ -45,12 +45,9 @@ function fetchOperatorEventsWith (api, queries) {
   }
 }
 
-function ensureSyncWith (queries, api, cache) {
+function ensureSyncWith (queries, api) {
   return bindCrypto(function (accountId, keyEncryptionJWK) {
     var crypto = this
-    if (cache && cache[accountId]) {
-      return Promise.resolve(cache[accountId])
-    }
     return queries.getAllEventIds(accountId)
       .then(function (knownEventIds) {
         var fetchNewEvents = queries.getLatestEvent(accountId)
@@ -110,9 +107,6 @@ function ensureSyncWith (queries, api, cache) {
                     var result = Object.assign(payload.account, {
                       privateJwk: privateJwk
                     })
-                    if (cache) {
-                      cache[accountId] = result
-                    }
                     return result
                   })
               })

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -162,8 +162,8 @@ function getDefaultStatsWith (getDatabase) {
     var mobileShare = stats.mobileShare(decryptedEvents)
 
     var realtime = decryptions[1]
+    var livePages = stats.activePages(realtime)
     var liveUsers = stats.visitors(realtime)
-    var livePages = stats.pages(realtime)
 
     return Promise
       .all([
@@ -180,8 +180,8 @@ function getDefaultStatsWith (getDatabase) {
         landingPages,
         exitPages,
         mobileShare,
-        liveUsers,
-        livePages
+        livePages,
+        liveUsers
       ])
       .then(function (results) {
         return {
@@ -198,8 +198,8 @@ function getDefaultStatsWith (getDatabase) {
           landingPages: results[10],
           exitPages: results[11],
           mobileShare: results[12],
-          liveUsers: results[13],
-          livePages: results[14],
+          livePages: results[13],
+          liveUsers: results[14],
           resolution: resolution,
           range: range
         }

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -54,7 +54,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
@@ -317,7 +317,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
               ]
             )
 
@@ -366,7 +366,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
               ]
             )
 
@@ -408,7 +408,7 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
               ]
             )
 

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -234,7 +234,7 @@ describe('src/stats.js', function () {
       return stats.pages([
         {},
         { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo') } },
-        { accountId: 'account-a', userId: 'user-b', payload: { href: new window.URL('https://www.example.net/foo?param=bar') } },
+        { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo?param=bar') } },
         { accountId: 'account-b', userId: 'user-z', payload: { href: new window.URL('https://beep.boop/site#!/foo') } },
         { accountId: 'account-a', userId: null, payload: { } }
       ])
@@ -242,6 +242,30 @@ describe('src/stats.js', function () {
           assert.deepStrictEqual(result, [
             { url: 'https://www.example.net/foo', pageviews: 2 },
             { url: 'https://beep.boop/site', pageviews: 1 }
+          ])
+        })
+    })
+    it('returns an empty array when given no events', function () {
+      return stats.pages([])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
+
+  describe('stats.activePages(events)', function () {
+    it('returns a sorted list of active pages grouped by a clean URL', function () {
+      return stats.activePages([
+        {},
+        { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo') } },
+        { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo?param=bar') } },
+        { accountId: 'account-b', userId: 'user-z', payload: { href: new window.URL('https://beep.boop/site#!/foo') } },
+        { accountId: 'account-a', userId: null, payload: { } }
+      ])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [
+            { url: 'https://beep.boop/site', pageviews: 1 },
+            { url: 'https://www.example.net/foo', pageviews: 1 }
           ])
         })
     })


### PR DESCRIPTION
This adds a section with realtime stats containing data from the last 15 minutes to the auditorium, displayed to operators only. Data is being refreshed every 15 seconds.

![image](https://user-images.githubusercontent.com/1662740/70809519-321f6280-1dc2-11ea-9154-fd1033f5a641.png)
