### PR TITLE
Add campaign and source metrics grouping by utm params

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -13,8 +13,8 @@ function urlTable (headline, col1Label, col2Label, rows) {
   var data = rows.map(function (row) {
     return html`
         <tr>
-          <td class="pv2 bt b--black-10">${row.url}</td>
-          <td class="pv2 bt b--black-10">${row.pageviews}</td>
+          <td class="pv2 bt b--black-10">${row.key}</td>
+          <td class="pv2 bt b--black-10">${row.count}</td>
         </tr>
       `
   })
@@ -266,6 +266,8 @@ function view (state, emit) {
     <div class="w-100 pa3 mb2 ba b--black-10 br2 bg-white">
       ${urlTable(__('Top pages'), __('URL'), __('Pageviews'), state.model.pages)}
       ${urlTable(__('Top referrers'), __('Host'), __('Pageviews'), state.model.referrers)}
+      ${urlTable(__('Top campaigns'), __('Campaign'), __('Pageviews'), state.model.campaigns)}
+      ${urlTable(__('Top sources'), __('Source'), __('Pageviews'), state.model.sources)}
       ${urlTable(__('Landing pages'), __('URL'), __('Landings'), state.model.landingPages)}
       ${urlTable(__('Exit pages'), __('URL'), __('Exits'), state.model.exitPages)}
     </div>

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -155,6 +155,8 @@ function getDefaultStatsWith (getDatabase) {
     var bounceRate = stats.bounceRate(decryptedEvents)
     var referrers = stats.referrers(decryptedEvents)
     var pages = stats.pages(decryptedEvents)
+    var campaigns = stats.campaigns(decryptedEvents)
+    var sources = stats.sources(decryptedEvents)
     var avgPageload = stats.avgPageload(decryptedEvents)
     var avgPageDepth = stats.avgPageDepth(decryptedEvents)
     var landingPages = stats.landingPages(decryptedEvents)
@@ -181,7 +183,9 @@ function getDefaultStatsWith (getDatabase) {
         exitPages,
         mobileShare,
         livePages,
-        liveUsers
+        liveUsers,
+        campaigns,
+        sources
       ])
       .then(function (results) {
         return {
@@ -200,6 +204,8 @@ function getDefaultStatsWith (getDatabase) {
           mobileShare: results[12],
           livePages: results[13],
           liveUsers: results[14],
+          campaigns: results[15],
+          sources: results[16],
           resolution: resolution,
           range: range
         }

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -54,7 +54,8 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'campaigns',
+                'sources', 'resolution', 'range'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
@@ -317,7 +318,8 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'campaigns',
+                'sources', 'resolution', 'range'
               ]
             )
 
@@ -366,7 +368,8 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'campaigns',
+                'sources', 'resolution', 'range'
               ]
             )
 
@@ -408,7 +411,8 @@ describe('src/queries.js', function () {
                 'uniqueUsers', 'uniqueAccounts', 'uniqueSessions',
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
-                'mobileShare', 'livePages', 'liveUsers', 'resolution', 'range'
+                'mobileShare', 'livePages', 'liveUsers', 'campaigns',
+                'sources', 'resolution', 'range'
               ]
             )
 

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -216,13 +216,38 @@ describe('src/stats.js', function () {
       ])
         .then(function (result) {
           assert.deepStrictEqual(result, [
-            { host: 'www.example.net', pageviews: 3 },
-            { host: 'beep.boop', pageviews: 1 }
+            { key: 'www.example.net', count: 3 },
+            { key: 'beep.boop', count: 1 }
           ])
         })
     })
     it('returns an empty array when given an empty array', function () {
       return stats.referrers([])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
+
+  describe('stats.campaigns(events)', function () {
+    it('returns sorted referrer campaigns from foreign domains grouped by host', function () {
+      return stats.campaigns([
+        {},
+        { payload: { href: new window.URL('https://www.mysite.com/x'), referrer: new window.URL('https://www.example.net/foo?utm_campaign=beep') } },
+        { payload: { href: new window.URL('https://www.mysite.com/y'), referrer: new window.URL('https://www.example.net/bar?something=12&utm_campaign=boop') } },
+        { payload: { href: new window.URL('https://www.mysite.com/z'), referrer: new window.URL('https://www.example.net/baz') } },
+        { payload: { href: new window.URL('https://www.mysite.com/x'), referrer: new window.URL('https://beep.boop/site?utm_campaign=beep') } },
+        { payload: { href: new window.URL('https://www.mysite.com/x'), referrer: new window.URL('https://www.mysite.com/a') } }
+      ])
+        .then(function (result) {
+          assert.deepStrictEqual(result, [
+            { key: 'beep', count: 2 },
+            { key: 'boop', count: 1 }
+          ])
+        })
+    })
+    it('returns an empty array when given an empty array', function () {
+      return stats.campaigns([])
         .then(function (result) {
           assert.deepStrictEqual(result, [])
         })
@@ -240,8 +265,8 @@ describe('src/stats.js', function () {
       ])
         .then(function (result) {
           assert.deepStrictEqual(result, [
-            { url: 'https://www.example.net/foo', pageviews: 2 },
-            { url: 'https://beep.boop/site', pageviews: 1 }
+            { key: 'https://www.example.net/foo', count: 2 },
+            { key: 'https://beep.boop/site', count: 1 }
           ])
         })
     })
@@ -264,8 +289,8 @@ describe('src/stats.js', function () {
       ])
         .then(function (result) {
           assert.deepStrictEqual(result, [
-            { url: 'https://beep.boop/site', pageviews: 1 },
-            { url: 'https://www.example.net/foo', pageviews: 1 }
+            { key: 'https://beep.boop/site', count: 1 },
+            { key: 'https://www.example.net/foo', count: 1 }
           ])
         })
     })
@@ -291,8 +316,8 @@ describe('src/stats.js', function () {
       ])
         .then(function (result) {
           assert.deepStrictEqual(result, [
-            { url: 'https://www.example.net/foo', pageviews: 2 },
-            { url: 'https://beep.boop/site', pageviews: 1 }
+            { key: 'https://www.example.net/foo', count: 2 },
+            { key: 'https://beep.boop/site', count: 1 }
           ])
         })
     })
@@ -318,8 +343,8 @@ describe('src/stats.js', function () {
       ])
         .then(function (result) {
           assert.deepStrictEqual(result, [
-            { url: 'https://www.example.net/bar', pageviews: 1 },
-            { url: 'https://www.example.net/baz', pageviews: 1 }
+            { key: 'https://www.example.net/bar', count: 1 },
+            { key: 'https://www.example.net/baz', count: 1 }
           ])
         })
     })


### PR DESCRIPTION
This PR piggy backs on the established `utm_source` and `utm_campaign` parameters used by other vendors (i.e. Google Analytics). Referrers that have one of these parameters will be counted and displayed in another referrers table.

---

When dealing with the frontend in Milestone 3, the 3 tables should be joined and the user allowed to pick which mode they want to display.