### PR TITLE
Format numbers and dates in app instead of user locale

### DIFF
--- a/auditorium/components/bar-chart.js
+++ b/auditorium/components/bar-chart.js
@@ -58,11 +58,11 @@ BarChart.prototype.getChartData = function () {
       return 'W' + getISOWeek(date)
     }
     if (self.local.resolution === 'months') {
-      return date.toLocaleDateString(undefined, { month: 'short' })
+      return date.toLocaleDateString(process.env.LOCALE, { month: 'short' })
     }
-    var result = date.toLocaleDateString(undefined, { day: 'numeric' })
+    var result = date.toLocaleDateString(process.env.LOCALE, { day: 'numeric' })
     if (index === 0 || isFirstDayOfMonth(date)) {
-      result = date.toLocaleDateString(undefined, { month: 'short' }) + ' ' + result
+      result = date.toLocaleDateString(process.env.LOCALE, { month: 'short' }) + ' ' + result
     }
     return result
   })

--- a/auditorium/gulpfile.js
+++ b/auditorium/gulpfile.js
@@ -60,6 +60,9 @@ function makeScriptTask (dest, locale) {
         if (transform === 'offen/localize') {
           return ['offen/localize', { locale: locale }]
         }
+        if (Array.isArray(transform) && transform[0] === 'envify') {
+          return ['envify', { LOCALE: locale }]
+        }
         return transform
       })
     })

--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -44,7 +44,7 @@
   },
   "browserify": {
     "transform": [
-      "envify",
+      ["envify", { "LOCALE": "en" }],
       "nanohtml",
       "offen/localize"
     ]

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -43,8 +43,8 @@ function keyMetric (name, value) {
     `
 }
 
-function formatPercentage (value) {
-  return (value * 100).toLocaleString(undefined, {
+function formatNumber (value, factor) {
+  return (parseInt(value, 10) * (factor || 1)).toLocaleString(process.env.LOCALE, {
     maximumFractionDigits: 1,
     minimumFractionDigits: 1
   })
@@ -245,11 +245,11 @@ function view (state, emit) {
         ${keyMetric(__('Unique %s', entityName), uniqueEntities)}
         ${keyMetric(__('Unique Sessions'), uniqueSessions)}
         <hr class="mt0 mb3 w-100 bb bw1 b--black-10">
-        ${state.model.avgPageDepth ? keyMetric(__('Avg. Page Depth'), state.model.avgPageDepth.toFixed(1)) : null}
-        ${keyMetric(__('Bounce Rate'), `${formatPercentage(state.model.bounceRate)} %`)}
-        ${isOperator && state.model.loss ? keyMetric(__('Plus'), `${formatPercentage(state.model.loss)} %`) : null}
+        ${state.model.avgPageDepth ? keyMetric(__('Avg. Page Depth'), formatNumber(state.model.avgPageDepth)) : null}
+        ${keyMetric(__('Bounce Rate'), `${formatNumber(state.model.bounceRate, 100)} %`)}
+        ${isOperator && state.model.loss ? keyMetric(__('Plus'), `${formatNumber(state.model.loss, 100)} %`) : null}
         <hr class="mt0 mb3 w-100 bb bw1 b--black-10">
-        ${keyMetric(__('Mobile Users'), `${formatPercentage(state.model.mobileShare)} %`)}
+        ${keyMetric(__('Mobile Users'), `${formatNumber(state.model.mobileShare, 100)} %`)}
         ${state.model.avgPageload ? keyMetric(__('Avg. Page Load time'), `${Math.round(state.model.avgPageload)} ms`) : null}
       </div>
     </div>


### PR DESCRIPTION
Right now, dates and numbers in the Auditorium are formatted in the browser locale when the UI is localized in the app's locale setting (see german `Dez` vs english copy, also numbers will use English 8.8 or German 9,9):

![image](https://user-images.githubusercontent.com/1662740/70819430-88969c00-1dd6-11ea-9eca-875e75dec194.png)

This PR normalizes the used locale to always respect the app's locale:

![image](https://user-images.githubusercontent.com/1662740/70819499-b4b21d00-1dd6-11ea-9dcc-145b9ac2845d.png)
