### PR TITLE
Polyfill window.fetch

### DIFF
--- a/script/src/check-support.js
+++ b/script/src/check-support.js
@@ -9,9 +9,6 @@ function checkSupport (callback) {
   if (!err && !supportsIndexedDb()) {
     err = new Error(__('Browser does not support IndexedDB which is required'))
   }
-  if (!err && !supportsFetch()) {
-    err = new Error(__('Browser does not support window.fetch which is required'))
-  }
   if (!err && !supportsURL()) {
     err = new Error(__('Browser does not support window.URL which is required'))
   }
@@ -22,10 +19,6 @@ function checkSupport (callback) {
 
 function supportsIndexedDb () {
   return typeof window.indexedDB === 'object'
-}
-
-function supportsFetch () {
-  return typeof window.fetch === 'function'
 }
 
 function supportsURL () {

--- a/vault/index.js
+++ b/vault/index.js
@@ -3,6 +3,10 @@ var handler = require('./src/handler')
 var allowsCookies = require('./src/allows-cookies')
 var getSessionId = require('./src/session-id')
 
+if (!window.fetch) {
+  require('unfetch/polyfill')
+}
+
 var register = router()
 
 register('EVENT', eventDuplexerMiddleware, anonymousMiddleware, function (event, respond, next) {

--- a/vault/package-lock.json
+++ b/vault/package-lock.json
@@ -14020,6 +14020,11 @@
       "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
       "dev": true
     },
+    "unfetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
+    },
     "unibabel": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/unibabel/-/unibabel-2.1.8.tgz",

--- a/vault/package.json
+++ b/vault/package.json
@@ -20,6 +20,7 @@
     "offen": "file:./../packages",
     "split-require": "^3.1.2",
     "underscore": "^1.9.1",
+    "unfetch": "^4.1.0",
     "unibabel": "^2.1.8",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
This enables Offen to support a broader range of browsers if needed by polyfilling `window.fetch` if needed.

---

Ideally, we'd also polyfill `window.URL` next, making IndexedDB the only hard requirement for using Offen.