### PR TITLE
Add weekly retention table

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -43,8 +43,58 @@ function keyMetric (name, value) {
     `
 }
 
+function retentionSquare (value) {
+  if (value === null) {
+    return null
+  }
+  return html`
+    <div title="${formatNumber(value, 100)}%">
+      <div
+        style="opacity: ${value !== 0 ? (value * 0.75 + 0.25) : 1}"
+        class="${value !== 0 ? 'bg-dark-green' : 'bg-light-gray'} h3 w-100"
+      >
+      </div>
+    </div>
+  `
+}
+
+function relativeTime (offset) {
+  if (offset === 0) {
+    return __('This week')
+  }
+  return __('%d days earlier', offset * 7)
+}
+
+function retentionTable (matrix) {
+  var rows = matrix.map(function (row, index) {
+    var elements = row.slice()
+    while (elements.length < matrix[0].length) {
+      elements.push(null)
+    }
+    return html`
+      <tr>
+        <td>${relativeTime(index)}</td>
+        ${elements.map(function (element) { return html`<td>${retentionSquare(element)}</td>` })}
+      </tr>
+    `
+  })
+  return html`
+    <table class="w-100 collapse mb3 dt--fixed">
+      <thead>
+        <tr>
+          <td></td>
+          ${matrix.map(function (row, index) { return html`<td>${relativeTime(index)}</td>` })}
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `
+}
+
 function formatNumber (value, factor) {
-  return (parseInt(value, 10) * (factor || 1)).toLocaleString(process.env.LOCALE, {
+  return (value * (factor || 1)).toLocaleString(process.env.LOCALE, {
     maximumFractionDigits: 1,
     minimumFractionDigits: 1
   })
@@ -273,6 +323,13 @@ function view (state, emit) {
     </div>
   `
 
+  var retention = html`
+    <div class="w-100 pa3 mb2 ba b--black-10 br2 bg-white">
+      <h4 class ="f5 normal mt0 mb3 mb4-ns">Weekly retention</h4>
+      ${retentionTable(state.model.retentionMatrix)}
+    </div>
+  `
+
   var goSettings = isOperator
     ? html`
         <div class="flex flex-column flex-row-ns mt4">
@@ -298,6 +355,7 @@ function view (state, emit) {
         ${live}
         ${rowUsersSessionsChart}
         ${urlTables}
+        ${retention}
         ${goSettings}
         ${state.stale ? html`<div class="fixed top-0 right-0 bottom-0 left-0 bg-white o-40"></div>` : null}
       </div>

--- a/auditorium/views/main.test.js
+++ b/auditorium/views/main.test.js
@@ -12,7 +12,7 @@ describe('views/main.js', function () {
   })
 
   describe('mainView', function () {
-    it('renders 8 sections for operators', function () {
+    it('renders 9 sections for operators', function () {
       app.state.model = {
         pageviews: [
           { date: '12.12.2019', pageviews: 12 }
@@ -32,7 +32,8 @@ describe('views/main.js', function () {
         loss: 0.1234,
         account: {
           accountId: 'test'
-        }
+        },
+        retentionMatrix: [[1, 0, 0], [1, 0], [0]]
       }
       app.state.authenticatedUser = {
         accounts: [
@@ -45,7 +46,7 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 8)
+      assert.strictEqual(headlines.length, 9)
 
       var chart = result.querySelector('.chart')
       assert(chart)
@@ -70,7 +71,8 @@ describe('views/main.js', function () {
           }
         ],
         allowsCookies: true,
-        hasOptedOut: false
+        hasOptedOut: false,
+        retentionMatrix: [[1, 0, 0], [1, 0], [0]]
       }
       app.state.authenticated = true
 
@@ -78,7 +80,7 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 6)
+      assert.strictEqual(headlines.length, 7)
 
       var chart = result.querySelector('.chart')
       assert(chart)

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -55,7 +55,7 @@ describe('src/queries.js', function () {
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
                 'mobileShare', 'livePages', 'liveUsers', 'campaigns',
-                'sources', 'resolution', 'range'
+                'sources', 'retentionMatrix', 'resolution', 'range'
               ]
             )
             assert.strictEqual(data.uniqueUsers, 0)
@@ -74,6 +74,7 @@ describe('src/queries.js', function () {
             assert(data.pageviews[0].date < data.pageviews[1].date)
 
             assert.strictEqual(data.bounceRate, 0)
+            assert.strictEqual(data.retentionMatrix.length, 4)
           })
       })
 
@@ -319,7 +320,7 @@ describe('src/queries.js', function () {
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
                 'mobileShare', 'livePages', 'liveUsers', 'campaigns',
-                'sources', 'resolution', 'range'
+                'sources', 'retentionMatrix', 'resolution', 'range'
               ]
             )
 
@@ -352,6 +353,7 @@ describe('src/queries.js', function () {
 
             assert.strictEqual(data.bounceRate, 0.75)
             assert.strictEqual(data.loss, 1 - (5 / 7))
+            assert.strictEqual(data.retentionMatrix.length, 4)
           })
       })
 
@@ -369,7 +371,7 @@ describe('src/queries.js', function () {
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
                 'mobileShare', 'livePages', 'liveUsers', 'campaigns',
-                'sources', 'resolution', 'range'
+                'sources', 'retentionMatrix', 'resolution', 'range'
               ]
             )
 
@@ -395,6 +397,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.bounceRate, 0.8)
 
             assert.strictEqual(data.loss, 1 - (6 / 9))
+            assert.strictEqual(data.retentionMatrix.length, 4)
           })
       })
 
@@ -412,7 +415,7 @@ describe('src/queries.js', function () {
                 'referrers', 'pages', 'pageviews', 'bounceRate', 'loss',
                 'avgPageload', 'avgPageDepth', 'landingPages', 'exitPages',
                 'mobileShare', 'livePages', 'liveUsers', 'campaigns',
-                'sources', 'resolution', 'range'
+                'sources', 'retentionMatrix', 'resolution', 'range'
               ]
             )
 
@@ -438,6 +441,7 @@ describe('src/queries.js', function () {
             assert.strictEqual(data.bounceRate, 0)
 
             assert.strictEqual(data.loss, 1 - (2 / 3))
+            assert.strictEqual(data.retentionMatrix.length, 4)
           })
       })
     })

--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -317,7 +317,7 @@ function retention (/* ...events */) {
       }
       acc.push(share)
       return acc
-    }, [1])
+    }, [referenceIds.length ? 1 : 0])
     result.push(innerResult)
   }
   return result

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -365,7 +365,7 @@ describe('src/stats.js', function () {
         []
       )
         .then(function (result) {
-          assert.deepStrictEqual(result, [[1, 0.5, 0.25, 0], [1, 2 / 3, 0], [1, 0], [1]])
+          assert.deepStrictEqual(result, [[1, 0.5, 0.25, 0], [1, 2 / 3, 0], [1, 0], [0]])
         })
     })
     it('returns 0 values when given empty chunks', function () {
@@ -375,7 +375,7 @@ describe('src/stats.js', function () {
         []
       )
         .then(function (result) {
-          assert.deepStrictEqual(result, [[1, 0, 0], [1, 0], [1]])
+          assert.deepStrictEqual(result, [[0, 0, 0], [0, 0], [0]])
         })
     })
     it('returns an empty array when given no events', function () {

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -355,4 +355,34 @@ describe('src/stats.js', function () {
         })
     })
   })
+
+  describe('stats.retention(...events)', function () {
+    it('returns a retention matrix for the given event chunks', function () {
+      return stats.retention(
+        [{}, { userId: 'user-a' }, { userId: 'user-b' }, { userId: 'user-y' }, { userId: 'user-z' }],
+        [{}, { userId: 'user-m' }, { userId: 'user-a' }, { userId: 'user-z' }],
+        [{}, { userId: 'user-k' }, { userId: 'user-m' }, { userId: 'user-z' }],
+        []
+      )
+        .then(function (result) {
+          assert.deepStrictEqual(result, [[1, 0.5, 0.25, 0], [1, 2 / 3, 0], [1, 0], [1]])
+        })
+    })
+    it('returns 0 values when given empty chunks', function () {
+      return stats.retention(
+        [],
+        [],
+        []
+      )
+        .then(function (result) {
+          assert.deepStrictEqual(result, [[1, 0, 0], [1, 0], [1]])
+        })
+    })
+    it('returns an empty array when given no events', function () {
+      return stats.retention()
+        .then(function (result) {
+          assert.deepStrictEqual(result, [])
+        })
+    })
+  })
 })


### PR DESCRIPTION
This adds a table displaying weekly retention stats to the auditorium:

![image](https://user-images.githubusercontent.com/1662740/70848342-5c2f5e00-1e70-11ea-81e7-d27b431d9ea2.png)

---

Styling in this PR is to be considered temporarily. It's also important to double check how this kind of table can be made more accessible when tackling the final styling.