### PR TITLE
Polyfill window.URL

### DIFF
--- a/auditorium/index.js
+++ b/auditorium/index.js
@@ -17,6 +17,10 @@ var withError = require('./views/decorators/with-error')
 var withLayout = require('./views/decorators/with-layout')
 var withPreviousRoute = require('./views/decorators/with-previous-route')
 
+if (!window.URL || !window.URLSearchParams) {
+  require('url-polyfill')
+}
+
 var app = choo()
 
 if (process.env.NODE_ENV !== 'production') {

--- a/auditorium/package-lock.json
+++ b/auditorium/package-lock.json
@@ -14411,6 +14411,11 @@
       "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
     },
+    "url-polyfill": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
+      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
+    },
     "url-trim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-trim/-/url-trim-1.0.0.tgz",

--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -20,7 +20,8 @@
     "date-fns": "^1.30.1",
     "offen": "file:./../packages",
     "plotly.js-basic-dist": "^1.51.2",
-    "underscore": "^1.9.1"
+    "underscore": "^1.9.1",
+    "url-polyfill": "^1.1.7"
   },
   "devDependencies": {
     "browserify": "^16.2.3",
@@ -44,7 +45,12 @@
   },
   "browserify": {
     "transform": [
-      ["envify", { "LOCALE": "en" }],
+      [
+        "envify",
+        {
+          "LOCALE": "en"
+        }
+      ],
       "nanohtml",
       "offen/localize"
     ]

--- a/script/src/check-support.js
+++ b/script/src/check-support.js
@@ -1,16 +1,13 @@
 module.exports = checkSupport
 
 // checkSupport ensures all features the application assumes present are
-// supported by the browser that is running the script and that "Do Not Track"
-// is not enabled. It is important that this does use a callback interface
+// supported by the browser that is running the script.
+// It is important that this does use a callback interface
 // as it native Promises might not necessarily be supported.
 function checkSupport (callback) {
   var err = null
   if (!err && !supportsIndexedDb()) {
     err = new Error(__('Browser does not support IndexedDB which is required'))
-  }
-  if (!err && !supportsURL()) {
-    err = new Error(__('Browser does not support window.URL which is required'))
   }
   setTimeout(function () {
     callback(err)
@@ -18,9 +15,6 @@ function checkSupport (callback) {
 }
 
 function supportsIndexedDb () {
+  // this implictly guarantees native Promises are available
   return typeof window.indexedDB === 'object'
-}
-
-function supportsURL () {
-  return typeof window.URL === 'function'
 }

--- a/vault/index.js
+++ b/vault/index.js
@@ -7,6 +7,10 @@ if (!window.fetch) {
   require('unfetch/polyfill')
 }
 
+if (!window.URL || !window.URLSearchParams) {
+  require('url-polyfill')
+}
+
 var register = router()
 
 register('EVENT', eventDuplexerMiddleware, anonymousMiddleware, function (event, respond, next) {

--- a/vault/package-lock.json
+++ b/vault/package-lock.json
@@ -14137,6 +14137,11 @@
         }
       }
     },
+    "url-polyfill": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
+      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
+    },
     "url-trim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-trim/-/url-trim-1.0.0.tgz",

--- a/vault/package.json
+++ b/vault/package.json
@@ -22,6 +22,7 @@
     "underscore": "^1.9.1",
     "unfetch": "^4.1.0",
     "unibabel": "^2.1.8",
+    "url-polyfill": "^1.1.7",
     "uuid": "^3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Following up on #215 this adds a polyfill for `window.URL`, meaning IndexedDB is now the only hard client side requirement for using Offen :tada: 