### PR TITLE
Use docker access token instead of password to push builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
             else
               export DOCKER_IMAGE_TAG="latest"
             fi
-            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+            echo "$DOCKER_ACCESSTOKEN" | docker login --username $DOCKER_USER --password-stdin
             docker push offen/offen:$DOCKER_IMAGE_TAG
       - store_artifacts:
           path: /tmp/artifacts


### PR DESCRIPTION
When the build was setup, Docker Hub did neither support access tokens nor 2FA which meant we needed our account's password to push the built images from CI.

Now that both is supported, we can enable 2FA on our account and use revokable tokens in CI.