### PR TITLE
Add interactive table component

### DIFF
--- a/auditorium/components/bar-chart.test.js
+++ b/auditorium/components/bar-chart.test.js
@@ -1,17 +1,11 @@
 var assert = require('assert')
-var choo = require('choo')
 
 var BarChart = require('./bar-chart')
 
 describe('components/bar-chart.js', function () {
   describe('BarChart', function () {
-    var app
-    beforeEach(function () {
-      app = choo()
-    })
-
-    it('renders a chartist bar chart', function () {
-      var chart = new BarChart('test-component', app.state)
+    it('renders a bar chart', function () {
+      var chart = new BarChart('test-component', { components: {} })
       var el = chart.render()
       assert(el.classList.contains('chart'))
     })

--- a/auditorium/components/table.js
+++ b/auditorium/components/table.js
@@ -1,0 +1,83 @@
+var html = require('choo/html')
+var Component = require('choo/component')
+
+module.exports = Table
+
+function Table (id, state) {
+  Component.call(this)
+  this.selected = state.components[id] = 0
+}
+
+Table.prototype = Object.create(Component.prototype)
+
+Table.prototype.update = function (update) {
+  return true
+}
+
+Table.prototype.toggle = function (index) {
+  this.selected = index
+  this.rerender()
+}
+
+Table.prototype.createElement = function (tableSets) {
+  var self = this
+  if (!Array.isArray(tableSets)) {
+    tableSets = [tableSets]
+  }
+  var selected = tableSets[this.selected]
+  var rows = Array.isArray(selected.rows) && selected.rows.length
+    ? selected.rows.map(function (row) {
+      return html`
+        <tr>
+          <td class="pv2 bt b--black-10">
+            ${row.key}
+          </td>
+          <td class="pv2 bt b--black-10">
+            ${row.count}
+          </td>
+        </tr>
+      `
+    })
+    : html`<tr><td colspan="2">${__('No data available for this view')}</td></tr>`
+
+  var headlines = tableSets.map(function (set, index) {
+    var css = ['f5', 'normal', 'mt0', 'mb3', 'dib', 'mr3']
+    var onclick = null
+    if (tableSets.length > 1) {
+      css.push('pointer')
+      onclick = self.toggle.bind(self, index)
+    }
+    if (index === self.selected) {
+      css.push('b')
+    }
+    var attrs = { class: css.join(' '), onclick: onclick }
+    return html`
+      <a role="button" ${attrs}>
+        ${set.headline}
+      </a>
+    `
+  })
+
+  return html`
+    <div>
+      <div>
+        ${headlines}
+      </div>
+      <table class="w-100 collapse mb3 dt--fixed">
+        <thead>
+          <tr>
+            <th class="pv2 b">
+              ${selected.col1Label}
+            </th>
+            <th class="pv2 b">
+              ${selected.col2Label}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows}
+        </tbody>
+      </table>
+    </div>
+  `
+}

--- a/auditorium/components/table.test.js
+++ b/auditorium/components/table.test.js
@@ -1,0 +1,35 @@
+var assert = require('assert')
+
+var Table = require('./table')
+
+describe('components/table.js', function () {
+  describe('Table', function () {
+    it('renders a table out of the given datasets', function () {
+      var table = new Table('test-component', { components: {} })
+      var el = table.render([
+        {
+          headline: 'Animals',
+          col1Label: 'Type',
+          col2Label: 'Count',
+          rows: [
+            { key: 'Llama', value: 45 },
+            { key: 'Frog', value: 12 },
+            { key: 'Snake', value: 8 }
+          ]
+        },
+        {
+          headline: 'Plants',
+          col1Label: 'Type',
+          col2Label: 'Count',
+          rows: [
+            { key: 'Fern', value: 32 },
+            { key: 'Tree', value: 12 }
+          ]
+        }
+      ])
+      assert.strictEqual(el.querySelectorAll('table').length, 1)
+      assert.strictEqual(el.querySelectorAll('tbody tr').length, 3)
+      assert.strictEqual(el.querySelector('a[role="button"]').innerText.trim(), 'Animals')
+    })
+  })
+})

--- a/auditorium/views/main.test.js
+++ b/auditorium/views/main.test.js
@@ -12,7 +12,7 @@ describe('views/main.js', function () {
   })
 
   describe('mainView', function () {
-    it('renders 9 sections for operators', function () {
+    it('renders 7 sections for operators', function () {
       app.state.model = {
         pageviews: [
           { date: '12.12.2019', pageviews: 12 }
@@ -46,13 +46,13 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 9)
+      assert.strictEqual(headlines.length, 7)
 
       var chart = result.querySelector('.chart')
       assert(chart)
     })
 
-    it('renders 7 sections and an additional data management panel for users', function () {
+    it('renders 5 sections and an additional data management panel for users', function () {
       app.state.model = {
         pageviews: [
           { date: '12.12.2019', pageviews: 12 }
@@ -80,7 +80,7 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 7)
+      assert.strictEqual(headlines.length, 5)
 
       var chart = result.querySelector('.chart')
       assert(chart)


### PR DESCRIPTION
This serves as a blueprint for how to use interactive components in the auditorium.

Tables can now hold multiple datasets and use a tabbed navigation for picking what to display:

![Peek 2019-12-19 23-07](https://user-images.githubusercontent.com/1662740/71213642-598b9900-22b4-11ea-966e-20ce079e2919.gif)
