### PR TITLE
Always specify SameSite value for cookies

### DIFF
--- a/vault/src/allows-cookies.js
+++ b/vault/src/allows-cookies.js
@@ -1,9 +1,25 @@
 module.exports = allowsCookies
 
 function allowsCookies () {
-  var token = Math.random().toString(16).slice(2)
-  document.cookie = 'ok=' + token
+  var token = randomString()
+  document.cookie = serialize({
+    ok: token, SameSite: 'Lax'
+  })
   var support = document.cookie.indexOf(token) >= 0
-  document.cookie = 'ok=; expires=' + new Date(0).toUTCString()
+  document.cookie = serialize({
+    ok: '', expires: new Date(0).toUTCString(), SameSite: 'Lax'
+  })
   return support
+}
+
+function serialize (obj) {
+  return Object.keys(obj)
+    .map(function (key) {
+      return key + '=' + obj[key]
+    })
+    .join(';')
+}
+
+function randomString () {
+  return Math.random().toString(16).slice(2)
 }

--- a/vault/src/session-id.js
+++ b/vault/src/session-id.js
@@ -25,7 +25,7 @@ function getSessionId (accountId) {
 
     if (!sessionId) {
       sessionId = uuid()
-      document.cookie = [lookupKey, sessionId].join('=')
+      document.cookie = [lookupKey, sessionId].join('=') + '; SameSite=Lax'
     }
   } catch (err) {
     sessionId = uuid()

--- a/vault/src/session-id.test.js
+++ b/vault/src/session-id.test.js
@@ -1,0 +1,15 @@
+var assert = require('assert')
+
+var getSessionId = require('./session-id')
+
+describe('src/session-id.js', function () {
+  describe('getSessionId(accountId)', function () {
+    it('returns unstable values in the context of the test setup', function () {
+      var resultA = getSessionId('account-a')
+      var resultB = getSessionId('account-a')
+      var resultC = getSessionId('account-b')
+      assert.notStrictEqual(resultA, resultB)
+      assert.notStrictEqual(resultB, resultC)
+    })
+  })
+})


### PR DESCRIPTION
As of Chrome 80, a `SameSite` attribute on a cookie will be mandatory: https://www.chromestatus.com/feature/5088147346030592

This sets the default value of `SameSite=Lax` for all client side cookies.