### PR TITLE
Ensure text in th elements is left aligned

### DIFF
--- a/auditorium/components/table.js
+++ b/auditorium/components/table.js
@@ -66,10 +66,10 @@ Table.prototype.createElement = function (tableSets) {
       <table class="w-100 collapse mb3 dt--fixed">
         <thead>
           <tr>
-            <th class="pv2 b">
+            <th class="tl pv2 b">
               ${selected.col1Label}
             </th>
-            <th class="pv2 b">
+            <th class="tl pv2 b">
               ${selected.col2Label}
             </th>
           </tr>


### PR DESCRIPTION
This fixes a visual regression where text in `th` elements would be centered instead of left-aligned:

![image](https://user-images.githubusercontent.com/1662740/71248923-5926e880-231c-11ea-8535-87242f1c7e65.png)
