### PR TITLE
Add section about key features to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
-# offen
 [![CircleCI](https://circleci.com/gh/offen/offen/tree/master.svg?style=svg)](https://circleci.com/gh/offen/offen/tree/master)
 [![Patreon](https://img.shields.io/static/v1.svg?label=patreon&message=donate&color=e85b46)](https://www.patreon.com/offen)
 
-> Web analytics that handle your data with respect
+# offen
+
+## Web analytics that handle your data with respect
+
+Offen is designed with the following objectives in mind:
+
+- **Privacy friendly**: Data collection is opt in, users that do not actively opt in will never leave a trace. After opt in Offen collects the minimum amount of data needed to generate meaningful statistics for operators. No IPs, User-Agent strings or similar are being collected.
+- **Security**: Data in Offen is encrypted End-To-End. Clients encrypt usage data before it leaves the browser and there is no way for the server storing this data to decrypt it. This means there is no way for attackers to compromise an instance, or for accidental data leaks to expose user data.
+- **Self hosted and lightweight**: You can run Offen on-premises, or in any other deployment scenario that fits your need. All you need to do is download a single binary file and run it on a server. It will automatically install SSL certficates for you if you want to. If you do not want to deploy a database, you can use SQLite to store data directly on the server.
+- **Transparent and fair**: Offen treats the user as a party of equal importance in the collection of usage data. Users have access to the same set of tools for analyzing their own data and they can delete their data at any time.
 
 ---
 
 **IMPORTANT NOTE BEFORE YOU START**: Offen is in the early stages of its development. We're happy if you would like to experiment with using it, but at this point in time we cannot guarantee any upgrade stability. Each release might contain breaking changes that might result in data being lost on the next upgrade.
 
 
-This repository contains all source code needed to build and run Offen, both on the server as well as on the client. Also see each of the READMEs in the subdirectories for information on how to work on that particular area of the application. Documentation on developing, running and using Offen is currently being collected in our [wiki][].
+This repository contains all source code needed to build and run Offen, both on the server as well as on the client. Also see each of the READMEs in the subdirectories for information on how to work on that particular area of the application.
+
+__Documentation on developing, running and using Offen__ is currently being collected in our [wiki][].
 
 [wiki]: https://github.com/offen/offen/wiki
 


### PR DESCRIPTION
Now, that Offen is theoretically ready to deploy to use, some information on our key features is a welcome addition to the README.