### PR TITLE
Ensure components in auditorium are refreshed correctly

### DIFF
--- a/auditorium/stores/consent.js
+++ b/auditorium/stores/consent.js
@@ -15,7 +15,7 @@ function store (state, emitter) {
         return postMessage(consentRequest)
       })
       .then(function () {
-        emitter.emit('offen:query')
+        emitter.emit('offen:query', Object.assign({}, state.params, state.query), state.authenticatedUser)
       })
       .catch(function (err) {
         state.error = err

--- a/auditorium/views/decorators/with-layout.js
+++ b/auditorium/views/decorators/with-layout.js
@@ -10,10 +10,12 @@ function withLayout () {
       state.flash = null
       return html`
         <div data-role="app-host" class="mw8 center pa3 pb5 f5 roboto dark-gray">
-          <h1 class="f2 normal mt0 mb4">${raw(__('<strong>offen</strong> auditorium'))}</h1>
-          ${flash ? html`
-            <p data-role="flash-message" class="dib pa2 br2 bg-black-05 mt0 mb2">${flash}</p>
-          ` : null}
+          <div id="headline">
+            <h1 class="f2 normal mt0 mb4">${raw(__('<strong>offen</strong> auditorium'))}</h1>
+            ${flash ? html`
+              <p data-role="flash-message" class="dib pa2 br2 bg-black-05 mt0 mb2">${flash}</p>
+            ` : null}
+          </div>
           ${originalView(state, emit)}
         </div>
       `

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -344,12 +344,14 @@ function view (state, emit) {
   return html`
       <div>
         ${accountHeader}
-        ${rowRangeManage}
-        ${live}
-        ${rowUsersSessionsChart}
-        ${urlTables}
-        ${retention}
-        ${goSettings}
+        <div id="main">
+          ${rowRangeManage}
+          ${live}
+          ${rowUsersSessionsChart}
+          ${urlTables}
+          ${retention}
+          ${goSettings}
+        </div>
         ${state.stale ? html`<div class="fixed top-0 right-0 bottom-0 left-0 bg-white o-40"></div>` : null}
       </div>
     `


### PR DESCRIPTION
This works around an ugly issue with choo where components would lose their reference element when the auditorium inserts flash messages that have not been there before.

This should be revisited at some point and markup be restructured to keep the same hierarchy throughout all possible mutations. For now, it's just a bugfix.