### PR TITLE
Add embed instructions in account view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Offen is designed with the following objectives in mind:
 
 - **Privacy friendly**: Data collection is opt in, users that do not actively opt in will never leave a trace. After opt in Offen collects the minimum amount of data needed to generate meaningful statistics for operators. No IPs, User-Agent strings or similar are being collected.
-- **Security**: Data in Offen is encrypted End-To-End. Clients encrypt usage data before it leaves the browser and there is no way for the server storing this data to decrypt it. This means there is no way for attackers to compromise an instance, or for accidental data leaks to expose user data.
+- **Security**: Data in Offen is encrypted End-To-End. Clients encrypt usage data before it leaves the browser and there is no way for the server storing this data to decrypt it. Attackers have no means to compromise an instance, accidental data leaks to expose user data.
 - **Self hosted and lightweight**: You can run Offen on-premises, or in any other deployment scenario that fits your need. All you need to do is download a single binary file and run it on a server. It will automatically install SSL certficates for you if you want to. If you do not want to deploy a database, you can use SQLite to store data directly on the server.
 - **Transparent and fair**: Offen treats the user as a party of equal importance in the collection of usage data. Users have access to the same set of tools for analyzing their own data and they can delete their data at any time.
 

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -322,7 +322,6 @@ function view (state, emit) {
       ${retentionTable(state.model.retentionMatrix)}
     </div>
   `
-
   var goSettings = isOperator
     ? html`
       <div class="flex flex-column flex-row-ns mt4">
@@ -330,11 +329,16 @@ function view (state, emit) {
           <h4 class ="f5 normal mt0 mb3">
             ${__('Admin console')}
           </h4>
-          <a href="/auditorium/account/" class="w-100-ns f5 tc link dim bn ph3 pv2 mr1 mb2 dib br1 white bg-mid-gray">
-            ${__('Settings')}
-          </a>
+          <div class="flex items-center">
+            <a href="/auditorium/account/" class="w-100-ns f5 tc link dim bn ph3 pv2 mr1 mb2 dib br1 white bg-mid-gray">
+              ${__('Settings')}
+            </a>
+          </div>
         </div>
-        <div class="dn db-ns w-100 w-80-ns pa3 mb2 br2 bg-black-05">
+        <div class="w-100 w-80-ns pa3 mb2 br2 bg-black-05">
+          <h4 class="f5 mb3 mt0">${__('No data showing up?')}</h4>
+          <p>${raw(__('To use Offen with the account <strong>%s</strong> on your website, embed the following script on each page you want to appear in your statistics:', state.model.account.name))}</p>
+          <pre class="pre">${raw(`&lt;script src="${window.location.origin}/script.js" data-account-id="${state.model.account.accountId}"&gt;&lt;/script&gt;`)}</pre>
         </div>
       </div>
     `

--- a/auditorium/views/main.test.js
+++ b/auditorium/views/main.test.js
@@ -12,7 +12,7 @@ describe('views/main.js', function () {
   })
 
   describe('mainView', function () {
-    it('renders 7 sections for operators', function () {
+    it('renders 8 sections for operators', function () {
       app.state.model = {
         pageviews: [
           { date: '12.12.2019', pageviews: 12 }
@@ -46,7 +46,7 @@ describe('views/main.js', function () {
 
       var headlines = result.querySelectorAll('h4')
       assert(headlines)
-      assert.strictEqual(headlines.length, 7)
+      assert.strictEqual(headlines.length, 8)
 
       var chart = result.querySelector('.chart')
       assert(chart)


### PR DESCRIPTION
For a start this displays the script operators need to embed on the account view of the Auditorium:

![image](https://user-images.githubusercontent.com/1662740/71284681-94003f00-2363-11ea-9102-aa3a54b46969.png)
