### PR TITLE
Scaffold integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ build_preconditions: &build_preconditions
     - script
     - auditorium
     - packages
+    - integration
   filters:
     branches:
       only:
@@ -150,6 +151,41 @@ jobs:
           name: Run tests
           command: npm test
 
+  integration:
+    docker:
+      - image: circleci/node:12-browsers
+    working_directory: ~/offen
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build binary
+          command: make build
+      - run:
+          name: Setup application
+          command: sudo ./offen bootstrap -email circle@offen.dev -name circle -password secret
+      - run:
+          name: Serve application
+          command: OFFEN_SERVER_PORT=8080 sudo ./offen
+          background: true
+      - run:
+          name: Wait for server to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z localhost 8080 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for server && exit 1
+      - run:
+          name: Check URLs
+          command: |
+            curl -sS -X GET localhost:8080 > /dev/null
+            curl -sS -X GET localhost:8080/script.js > /dev/null
+            curl -sS -X GET localhost:8080/vault/ > /dev/null
+            curl -sS -X GET localhost:8080/auditorium/ > /dev/null
+
   build:
     docker:
       - image: docker:18-git
@@ -216,5 +252,6 @@ workflows:
       - script
       - auditorium
       - packages
+      - integration
       - build:
           <<: *build_preconditions


### PR DESCRIPTION
This introduces basic integration tests against the packaged binary.

Right now, only the existence of fundamental HTTP URIs is being tested. In the mid term, this should be replaced by:
1. an automated Lighthouse audit (possibly feeding back into the PR checks)
1. full integration tests using cypress