### PR TITLE
Use 128 bit aes keys

### DIFF
--- a/vault/src/web-crypto.js
+++ b/vault/src/web-crypto.js
@@ -136,7 +136,7 @@ function createSymmetricKey () {
     .generateKey(
       {
         name: 'AES-GCM',
-        length: 256
+        length: 128
       },
       true,
       ['encrypt', 'decrypt']


### PR DESCRIPTION
Considering events are expected to be pruned after 6 months, 128 bit AES keys - which give us 40% more performance - are considered secure as of today and for the years to come.

Keys that have already been created using 256 bits will keep working.