### PR TITLE
Move text inputs into stateful components

### DIFF
--- a/auditorium/components/input.js
+++ b/auditorium/components/input.js
@@ -1,0 +1,23 @@
+var html = require('choo/html')
+var Component = require('choo/component')
+
+module.exports = Input
+
+function Input (id, state, emit, props) {
+  Component.call(this)
+  this.props = props || {}
+}
+
+Input.prototype = Object.create(Component.prototype)
+
+Input.prototype.update = function (update) {
+  return false
+}
+
+Input.prototype.createElement = function (tableSets) {
+  var props = Object.assign({
+    class: 'w-100 pa2 mb3 input-reset ba b--black-10 bg-white',
+    type: 'text'
+  }, this.props)
+  return html`<input ${props}>`
+}

--- a/auditorium/stores/auth.js
+++ b/auditorium/stores/auth.js
@@ -24,7 +24,9 @@ function store (state, emitter) {
           return
         } else if (response.type === 'LOGIN_FAILURE') {
           state.flash = __('Could not log in. Try again.')
-          emitter.emit(state.events.PUSHSTATE, '/auditorium/login/')
+          if (!credentials) {
+            emitter.emit(state.events.PUSHSTATE, '/auditorium/login/')
+          }
           return
         }
         throw new Error('Received unknown response type: ' + response.type)

--- a/auditorium/views/account.js
+++ b/auditorium/views/account.js
@@ -1,6 +1,8 @@
 var html = require('choo/html')
 var raw = require('choo/html/raw')
 
+var Input = require('./../components/input')
+
 module.exports = view
 
 function view (state, emit) {
@@ -43,11 +45,11 @@ function view (state, emit) {
       <form class="mw6 center" onsubmit="${handleChangeEmail}">
         <label class="b lh-copy">
           ${__('New email address')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" type="text" name="email-address">
+          ${state.cache(Input, 'account/change-email-email', { name: 'email-address' }).render()}
         </label>
         <label class="b lh-copy">
           ${__('Password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" type="password" name="password">
+          ${state.cache(Input, 'account/change-email-password', { name: 'password', type: 'password' }).render()}
         </label>
         <input class="pointer w-100 w-auto-ns f5 link dim bn ph3 pv2 mb3 dib br1 white bg-mid-gray" type="submit" value="${__('Change Email address')}">
       </form>
@@ -72,15 +74,15 @@ function view (state, emit) {
       <form class="mw6 center" onsubmit="${handleChangePassword}">
         <label class="b lh-copy">
           ${__('Current password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" type="password" name="current">
+          ${state.cache(Input, 'account/change-password-current', { type: 'password', name: 'password' }).render()}
         </label>
         <label class="b lh-copy">
           ${__('New password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" type="password" name="changed">
+          ${state.cache(Input, 'account/change-password-changed', { type: 'password', name: 'changed' }).render()}
         </label>
         <label class="b lh-copy">
           ${__('Repeat new password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" type="password" name="repeat">
+          ${state.cache(Input, 'account/change-password-repeat', { type: 'password', name: 'repeat' }).render()}
         </label>
         <input class="pointer w-100 w-auto-ns f5 link dim bn ph3 pv2 mb3 dib br1 white bg-mid-gray" type="submit" value="${__('Change password')}">
       </form>

--- a/auditorium/views/forgot-password.js
+++ b/auditorium/views/forgot-password.js
@@ -1,5 +1,7 @@
 var html = require('choo/html')
 
+var Input = require('./../components/input')
+
 module.exports = view
 
 function view (state, emit) {
@@ -17,7 +19,7 @@ function view (state, emit) {
       <form class="mw6 center" onsubmit=${handleSubmit}>
         <label class="b lh-copy">
           ${__('Email address')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" required type="email" name="email-address">
+          ${state.cache(Input, 'forgot-password/email', { name: 'email-address', required: true })}
         </label>
         <input class="pointer w-100 w-auto-ns f5 link dim bn ph3 pv2 mb3 dib br1 white bg-mid-gray" type="submit" value="${__('Send Email')}">
     </form>

--- a/auditorium/views/login.js
+++ b/auditorium/views/login.js
@@ -1,5 +1,7 @@
 var html = require('choo/html')
 
+var Input = require('./../components/input')
+
 module.exports = view
 
 function view (state, emit) {
@@ -17,11 +19,11 @@ function view (state, emit) {
       <form class="mw6 center" onsubmit=${handleSubmit}>
         <label class="b lh-copy">
           ${__('Email address')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" required type="email" name="username">
+          ${state.cache(Input, 'login/username', { required: true, type: 'email', name: 'username' }).render()}
         </label>
         <label class="b lh-copy">
           ${__('Password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" required type="password" name="password">
+          ${state.cache(Input, 'login/password', { name: 'password', required: true, type: 'password' }).render()}
         </label>
         <input class="pointer w-100 w4-ns f5 link dim bn ph3 pv2 mb3 dib br1 white bg-mid-gray" type="submit" value="${__('Log in')}">
         <div class="mb3">

--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -238,7 +238,7 @@ function view (state, emit) {
             ${keyMetric('Unique users', state.model.liveUsers)}
           </div>
           <div class="w-100 w-70-ns">
-            ${state.cache(Table, 'live-table').render([tableData])}
+            ${state.cache(Table, 'main/live-table').render([tableData])}
           </div>
         </div>
       </div>
@@ -256,7 +256,7 @@ function view (state, emit) {
       <h4 class="f5 normal mt0 mb3">
         ${__('Page views and %s', isOperator ? __('visitors') : __('accounts'))}
       </h4>
-      ${state.cache(BarChart, 'bar-chart').render(chartData)}
+      ${state.cache(BarChart, 'main/bar-chart').render(chartData)}
     </div>
   `
 
@@ -306,13 +306,13 @@ function view (state, emit) {
   ]
   var urlTables = html`
     <div class="w-100 pa3 mb2 ba b--black-10 br2 bg-white">
-      ${state.cache(Table, 'pages-table').render(pagesTableData)}
+      ${state.cache(Table, 'main/pages-table').render(pagesTableData)}
     </div>
     <div class="w-100 pa3 mb2 ba b--black-10 br2 bg-white">
-      ${state.cache(Table, 'referrers-table').render(referrersTableData)}
+      ${state.cache(Table, 'main/referrers-table').render(referrersTableData)}
     </div>
     <div class="w-100 pa3 mb2 ba b--black-10 br2 bg-white">
-      ${state.cache(Table, 'landing-exit-table').render(landingExitTableData)}
+      ${state.cache(Table, 'main/landing-exit-table').render(landingExitTableData)}
     </div>
   `
 

--- a/auditorium/views/reset-password.js
+++ b/auditorium/views/reset-password.js
@@ -1,5 +1,7 @@
 var html = require('choo/html')
 
+var Input = require('./../components/input')
+
 module.exports = view
 
 function view (state, emit) {
@@ -21,15 +23,15 @@ function view (state, emit) {
       <form class="mw6 center" onsubmit=${handleSubmit}>
         <label class="b lh-copy">
           ${__('Email address')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" required type="email" name="email-address">
+          ${state.cache(Input, 'reset-password/email', { name: 'email-address', required: true })}
         </label>
         <label class="b lh-copy">
           ${__('New password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" required type="password" name="password">
+          ${state.cache(Input, 'reset-password/password', { name: 'password', type: 'password', required: true })}
         </label>
         <label class="b lh-copy">
           ${__('Repeat new password')}
-          <input class="w-100 pa2 mb3 input-reset ba b--black-10 bg-white" required type="password" name="repeat-password">
+          ${state.cache(Input, 'reset-password/repeat', { name: 'repeat-password', type: 'password', required: true })}
         </label>
         <input class="pointer w-100 w-auto-ns f5 link dim bn ph3 pv2 mb3 dib br1 white bg-mid-gray" type="submit" value="${__('Reset password')}">
         <input type="hidden" name="token" value=${state.params.token}>


### PR DESCRIPTION
Right now choo empties text inputs on re-render, which is bad when accidentally providing bad credentials on login or similar.

This PR makes the input elements stateful so that they will keep their values on re-render:

![Peek 2019-12-22 19-04](https://user-images.githubusercontent.com/1662740/71325514-30564d00-24ee-11ea-9d65-8005baa1c0d3.gif)
