### PR TITLE
Allow more flexible styling of consent UI

### DIFF
--- a/packages/vault/index.js
+++ b/packages/vault/index.js
@@ -14,10 +14,11 @@ function createVault (host) {
   vault.src = host
 
   vault.style.display = 'none'
-  vault.setAttribute('width', '0')
-  vault.setAttribute('height', '0')
   vault.setAttribute('frameBorder', '0')
   vault.setAttribute('scrolling', 'no')
+
+  var elementId = createElementId()
+  vault.setAttribute('id', elementId)
 
   createVault[host] = new Promise(function (resolve, reject) {
     vault.addEventListener('load', function (e) {
@@ -40,13 +41,18 @@ function createVault (host) {
           }
 
           var receiveStyles = new window.MessageChannel()
+          var stylesheet = document.createElement('style')
+          stylesheet.setAttribute('id', 'offen-vault-styles')
           receiveStyles.port1.onmessage = function (event) {
-            Object.assign(vault.style, event.data.styles)
+            if (!document.head.contains(stylesheet)) {
+              document.head.appendChild(stylesheet)
+            }
+            stylesheet.innerHTML = event.data.styles
             Object.keys(event.data.attributes || {}).forEach(function (attribute) {
               vault.setAttribute(attribute, event.data.attributes[attribute])
             })
           }
-
+          message.host = message.host || '#' + elementId
           vault.contentWindow.postMessage(message, origin, [messageChannel.port2, receiveStyles.port2])
         })
       }
@@ -69,4 +75,8 @@ function createVault (host) {
       })
   }
   return createVault[host]
+}
+
+function createElementId () {
+  return 'offen-vault-' + Math.random().toString(36).slice(2)
 }

--- a/packages/vault/index.test.js
+++ b/packages/vault/index.test.js
@@ -28,9 +28,6 @@ describe('vault/index.js', function () {
           var vaultElement = iframeElements[0]
           assert.strictEqual(vaultElement.src, 'http://localhost:9876/')
 
-          assert.strictEqual(vaultElement.getAttribute('height'), '0')
-          assert.strictEqual(vaultElement.getAttribute('width'), '0')
-
           assert.strictEqual(typeof postMessage, 'function')
           return postMessage({ please: 'respond' }, false)
         })

--- a/script/src/router.test.js
+++ b/script/src/router.test.js
@@ -14,6 +14,8 @@ describe('src/router.js', function () {
           payload: context
         }, true)
           .then(function (response) {
+            assert(response.host)
+            delete response.host
             assert.deepStrictEqual(
               response,
               { type: 'TEST', payload: { some: 'value', other: true } }

--- a/vault/src/middleware.js
+++ b/vault/src/middleware.js
@@ -11,29 +11,12 @@ function optIn (event, respond, next) {
         return status
       }
       respond.styleHost({
-        styles: {
-          position: 'fixed',
-          right: '0',
-          bottom: '0',
-          left: '0',
-          width: '100%',
-          display: 'block',
-          backgroundColor: 'transparent'
-        },
-        attributes: {
-          height: '120px',
-          width: '100%'
-        }
+        styles: consentStatus.hostStyles(respond.styleHost.selector).visible.innerHTML
       })
       return consentStatus.askForConsent()
         .then(function (result) {
           respond.styleHost({
-            styles: {
-              display: 'none'
-            },
-            attributes: {
-              height: '0'
-            }
+            styles: consentStatus.hostStyles(respond.styleHost.selector).hidden.innerHTML
           })
           return result
         })

--- a/vault/src/router.js
+++ b/vault/src/router.js
@@ -14,6 +14,7 @@ function router () {
         event.ports[1].postMessage(data)
       }
     }
+    respond.styleHost.selector = event.data.host
 
     var stack = (registeredRoutes[event.data.type] || []).slice()
 

--- a/vault/src/user-consent.js
+++ b/vault/src/user-consent.js
@@ -7,6 +7,74 @@ var COOKIE_NAME = 'consent'
 exports.ALLOW = ALLOW
 exports.DENY = DENY
 
+exports.askForConsent = askForConsent
+
+function askForConsent () {
+  return new Promise(function (resolve) {
+    var banner = html`
+      <div class="roboto dark-gray bg-white absolute w-100 h-100 ph5 pv2 flex flex-column items-center justify-center">
+        <div>
+          <p class="mt0">
+            ${__('Are you ok with us collecting usage data?')}
+          </p>
+          <button class="pointer f5 tc dim bn ph3 pv2 dib br1 white bg-dark-green mr2" onclick=${handleConsentAction(ALLOW)}>
+            ${__('Accept')}
+          </button>
+          <button class="pointer f5 tc dim bn ph3 pv2 dib br1 white bg-dark-green mr2" onclick=${handleConsentAction(DENY)}>
+            ${__('Decline')}
+          </button>
+          <a target="_blank" rel="noopener" href="https://www.offen.dev" class="f5 tc dim bn ph3 pv2 dib br1 white bg-dark-green">
+            ${__('Learn more')}
+          </button>
+        </div>
+      </div>
+    `
+    var styleSheet = html`
+      <link rel="stylesheet" href="/tachyons.min.css">
+      <link rel="stylesheet" href="/fonts.css">
+    `
+    document.head.appendChild(styleSheet)
+    document.body.appendChild(banner)
+
+    function handleConsentAction (result) {
+      return function () {
+        resolve(result)
+        document.body.removeChild(banner)
+      }
+    }
+  })
+}
+
+exports.hostStyles = hostStyles
+
+function hostStyles (selector) {
+  return {
+    visible: html`
+<style>
+  ${selector} {
+    display: block !important;
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 120px;
+    width: 100%;
+  }
+  @media all and (max-width: 480px) {
+    ${selector} {
+      height: 25vh;
+    }
+  }
+</style>`,
+    hidden: html`
+<style>
+  ${selector} {
+    display: none;
+  }
+</style>`
+  }
+}
+
 exports.get = getConsentStatus
 
 function getConsentStatus () {
@@ -45,42 +113,4 @@ function serialize (obj) {
       return [key, '=', obj[key]].join('')
     })
     .join(';')
-}
-
-exports.askForConsent = askForConsent
-
-function askForConsent () {
-  return new Promise(function (resolve) {
-    var banner = html`
-      <div class="roboto dark-gray bg-white absolute w-100 h-100 ph5 pv2 flex flex-column items-center justify-center">
-        <div>
-          <p class="mt0">
-            ${__('Are you ok with us collecting usage data?')}
-          </p>
-          <button class="pointer f5 tc dim bn ph3 pv2 dib br1 white bg-dark-green mr2" onclick=${handleConsentAction(ALLOW)}>
-            ${__('Accept')}
-          </button>
-          <button class="pointer f5 tc dim bn ph3 pv2 dib br1 white bg-dark-green mr2" onclick=${handleConsentAction(DENY)}>
-            ${__('Decline')}
-          </button>
-          <a target="_blank" rel="noopener" href="https://www.offen.dev" class="f5 tc dim bn ph3 pv2 dib br1 white bg-dark-green">
-            ${__('Learn more')}
-          </button>
-        </div>
-      </div>
-    `
-    var styleSheet = html`
-      <link rel="stylesheet" href="/tachyons.min.css">
-      <link rel="stylesheet" href="/fonts.css">
-    `
-    document.head.appendChild(styleSheet)
-    document.body.appendChild(banner)
-
-    function handleConsentAction (result) {
-      return function () {
-        resolve(result)
-        document.body.removeChild(banner)
-      }
-    }
-  })
 }


### PR DESCRIPTION
This allows passing of actual stylesheets (instead of an object of inline styles) to the host so that for example media queries and other stylesheet-only features can be leveraged.