### PR TITLE
Cross compile for Windows and Darwin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build binary
-          command: make build
+          command: |
+            make build
+            cp ./bin/offen-linux-amd64 ./offen
       - run:
           name: Setup application
           command: sudo ./offen bootstrap -email circle@offen.dev -name circle -password secret

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,21 +188,11 @@ jobs:
 
   build:
     docker:
-      - image: docker:18-git
+      - image: circleci/golang:1.13
     working_directory: ~/offen
     steps:
       - checkout
       - setup_remote_docker
-      - restore_cache:
-          keys:
-            - v1-{{ .Branch }}
-          paths:
-            - /caches/offen.tar
-      - run:
-          name: Load Docker image layer cache
-          command: |
-            set +o pipefail
-            docker load -i /caches/offen.tar | true
       - run:
           name: Build application Docker image and binary
           command: |
@@ -212,32 +202,10 @@ jobs:
             else
               export DOCKER_IMAGE_TAG="latest"
             fi
-            docker build --build-arg rev=$OFFEN_GIT_REVISION -t offen/offen:$DOCKER_IMAGE_TAG -f build/Dockerfile .
-            # next, extract the single binary from the container so it can
-            # be stored as a build artifact (this needs to be formalized into
-            # versioned releases at some point)
-            docker create -it --name builder offen/offen:$DOCKER_IMAGE_TAG ash
-            docker cp builder:/offen .
-            docker rm -f builder
+            BUILD_DARWIN=1 BUILD_WINDOWS=1 make build
+            make build-docker
             mkdir -p /tmp/artifacts
-            tar -czvf /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz offen
-      - run:
-          name: Save Docker image layer cache
-          command: |
-            mkdir -p /caches
-            docker save -o /caches/offen.tar offen/offen
-      - save_cache:
-          key: v1-{{ .Branch }}-{{ epoch }}
-          paths:
-            - /caches/server.tar
-      - deploy:
-          name: Push application Docker image
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              export DOCKER_IMAGE_TAG="stable"
-            else
-              export DOCKER_IMAGE_TAG="latest"
-            fi
+            cd ./bin && tar -czvf /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz $(ls -A)
             echo "$DOCKER_ACCESSTOKEN" | docker login --username $DOCKER_USER --password-stdin
             docker push offen/offen:$DOCKER_IMAGE_TAG
       - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,16 @@ extract-strings:
 
 DOCKER_IMAGE_TAG ?= local
 ROBOTS_FILE ?= robots.txt.staging
+BUILD_LINUX ?= '1'
+BUILD_WINDOWS ?= ''
+BUILD_DARWIN ?= ''
 
 build:
-	@docker build --build-arg rev=$(shell git rev-parse --short HEAD) -t offen/offen:${DOCKER_IMAGE_TAG} -f build/Dockerfile .
-	@docker create -it --name binary offen/offen:local ash
-	@docker cp binary:/offen .
+	@docker build --build-arg BUILD_LINUX=${BUILD_LINUX} --build-arg BUILD_WINDOWS=${BUILD_WINDOWS} --build-arg BUILD_DARWIN=${BUILD_DARWIN} --build-arg GIT_REVISION=$(shell git rev-parse --short HEAD) -t offen/build:${DOCKER_IMAGE_TAG} -f build/Dockerfile.build .
+	@docker create -it --name binary offen/build:local bash
+	@docker cp binary:/code/server/bin/ .
 	@docker rm binary
+	@docker build -t offen/offen:${DOCKER_IMAGE_TAG} -f build/Dockerfile .
 
 secret:
 	@docker-compose run server make secret

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Offen is designed with the following objectives in mind:
 
 ---
 
+If you're curious, you can give it a test drive right now:
+
+```sh
+docker run --rm -it -p 9876:9876 offen/offen:latest demo -port 9876
+```
+
+This gives you a ephemeral one-off installation running on `http://localhost:9876`.
+
+---
+
 **IMPORTANT NOTE BEFORE YOU START**: Offen is in the early stages of its development. We're happy if you would like to experiment with using it, but at this point in time we cannot guarantee any upgrade stability. Each release might contain breaking changes that might result in data being lost on the next upgrade.
 
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,78 +1,10 @@
-FROM node:12 as auditorium
-
-COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
-COPY ./packages /code/packages
-WORKDIR /code/deps
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-RUN npm ci
-COPY ./auditorium /code/auditorium
-COPY ./banner.txt /code/banner.txt
-WORKDIR /code/auditorium
-RUN cp -a /code/deps/node_modules /code/auditorium/
-ENV NODE_ENV production
-RUN npm run build
-
-FROM node:12 as script
-
-COPY ./script/package.json ./script/package-lock.json /code/deps/
-COPY ./packages /code/packages
-WORKDIR /code/deps
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-RUN npm ci
-COPY ./script /code/script
-COPY ./banner.txt /code/banner.txt
-WORKDIR /code/script
-RUN cp -a /code/deps/node_modules /code/script/
-ENV NODE_ENV production
-RUN npm run build
-
-FROM node:12 as vault
-
-COPY ./vault/package.json ./vault/package-lock.json /code/deps/
-COPY ./packages /code/packages
-WORKDIR /code/deps
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-RUN npm ci
-COPY ./vault /code/vault
-COPY ./banner.txt /code/banner.txt
-WORKDIR /code/vault
-RUN cp -a /code/deps/node_modules /code/vault/
-ENV NODE_ENV production
-RUN npm run build
-
-FROM golang:1.13 as server
-
-RUN apt-get update \
-	&& apt-get -y install musl-tools \
-	&& rm -rf /var/lib/apt/lists/*
-
-COPY ./server/go.mod ./server/go.sum /code/server/
-WORKDIR /code/server
-RUN go mod download
-
-COPY ./server /code/server
-
-ARG rev
-ENV GIT_REVISION=$rev
-
-COPY --from=script /code/script/dist /code/server/public
-COPY --from=vault /code/vault/dist /code/server/public
-COPY --from=auditorium /code/auditorium/dist /code/server/public
-
-RUN go get github.com/rakyll/statik
-RUN statik -dest public -src public
-RUN statik -dest locales -src locales
-
-ENV GOOS linux
-RUN CC=musl-gcc go build -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/offen/offen/server/config.Revision=$GIT_REVISION" -o bin/offen cmd/offen/main.go
-
 FROM alpine:3.10
 LABEL maintainer="offen <hioffen@posteo.de>"
 
 RUN apk add -U --no-cache ca-certificates
-COPY --from=server /code/server/bin/offen /
+COPY ./bin/offen-linux-amd64 /usr/bin/offen
 
 ENV OFFEN_SERVER_PORT 3000
 EXPOSE 3000
 
-ENTRYPOINT ["/offen"]
+ENTRYPOINT ["offen"]

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,0 +1,78 @@
+FROM node:12 as auditorium
+
+COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
+COPY ./packages /code/packages
+WORKDIR /code/deps
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+RUN npm ci
+COPY ./auditorium /code/auditorium
+COPY ./banner.txt /code/banner.txt
+WORKDIR /code/auditorium
+RUN cp -a /code/deps/node_modules /code/auditorium/
+ENV NODE_ENV production
+RUN npm run build
+
+FROM node:12 as script
+
+COPY ./script/package.json ./script/package-lock.json /code/deps/
+COPY ./packages /code/packages
+WORKDIR /code/deps
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+RUN npm ci
+COPY ./script /code/script
+COPY ./banner.txt /code/banner.txt
+WORKDIR /code/script
+RUN cp -a /code/deps/node_modules /code/script/
+ENV NODE_ENV production
+RUN npm run build
+
+FROM node:12 as vault
+
+COPY ./vault/package.json ./vault/package-lock.json /code/deps/
+COPY ./packages /code/packages
+WORKDIR /code/deps
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+RUN npm ci
+COPY ./vault /code/vault
+COPY ./banner.txt /code/banner.txt
+WORKDIR /code/vault
+RUN cp -a /code/deps/node_modules /code/vault/
+ENV NODE_ENV production
+RUN npm run build
+
+FROM bepsays/ci-goreleaser:latest as server
+
+RUN apt-get update \
+    && apt-get -y install musl-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./server/go.mod ./server/go.sum /code/server/
+WORKDIR /code/server
+RUN go mod download
+
+COPY ./server /code/server
+
+ARG GIT_REVISION
+ARG BUILD_LINUX
+ARG BUILD_WINDOWS
+ARG BUILD_DARWIN
+
+COPY --from=script /code/script/dist /code/server/public
+COPY --from=vault /code/vault/dist /code/server/public
+COPY --from=auditorium /code/auditorium/dist /code/server/public
+
+RUN go get github.com/rakyll/statik
+RUN statik -dest public -src public
+RUN statik -dest locales -src locales
+
+ENV GOARCH amd64
+ENV CGO_ENABLED 1
+
+ENV GOOS linux
+RUN if [ "x$BUILD_LINUX" != "x" ]; then CC=musl-gcc go build -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/offen/offen/server/config.Revision=$GIT_REVISION" -o bin/offen-linux-amd64 cmd/offen/main.go; fi
+
+ENV GOOS windows
+RUN if [ "x$BUILD_WINDOWS" != "x" ]; then CC=x86_64-w64-mingw32-gcc go build -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/offen/offen/server/config.Revision=$GIT_REVISION" -o bin/offen-windows-amd64 cmd/offen/main.go; fi
+
+ENV GOOS darwin
+RUN if [ "x$BUILD_DARWIN" != "x" ]; then CC=o64-clang go build -ldflags "-s -w -X github.com/offen/offen/server/config.Revision=$GIT_REVISION" -o bin/offen-darwin-amd64 cmd/offen/main.go; fi


### PR DESCRIPTION
This adds the option of building for MacOS and Windows too, and includes the built files in the artifact bundle produced in CI.

Ideally, the dependency on the `bepsays/ci-goreleaser:latest` Docker image (which is used for building Hugo) should be removed soon and replaced with something that is officially supported.