### PR TITLE
Ensure versioning info is correct throughout environments

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -402,10 +402,7 @@ func main() {
 			logger.WithField("secret", value).Infof("Created %d bytes secret", *length)
 		}
 	case "version":
-		// calling version does not require a valid config, so this does not
-		// check errors.
-		cfg, _ := config.New(false)
-		logger.WithField("revision", cfg.App.Revision).Info("Current build created using")
+		logger.WithField("revision", config.Revision).Info("Current build created using")
 	default:
 		logger.Fatalf("Unknown subcommand %s\n", os.Args[1])
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -41,7 +41,6 @@ type Config struct {
 	App struct {
 		Development          bool          `default:"false"`
 		EventRetentionPeriod time.Duration `default:"4464h"`
-		Revision             string        `default:"not set"`
 		LogLevel             LogLevel      `default:"info"`
 		SingleNode           bool          `default:"true"`
 		Locale               Locale        `default:"en"`
@@ -135,10 +134,6 @@ func New(populateMissing bool) (*Config, error) {
 	err := envconfig.Process("offen", &c)
 	if err != nil && !populateMissing {
 		return &c, fmt.Errorf("error processing environment: %v", err)
-	}
-
-	if Revision != "" {
-		c.App.Revision = Revision
 	}
 
 	if err != nil && populateMissing {

--- a/server/go.sum
+++ b/server/go.sum
@@ -117,6 +117,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/offen/offen v0.0.0-20191031105048-b8b1e9b77391 h1:DnYbQd85n0arrKigA91TEwSWWEYBfa67g2BS5K+Yiq8=
 github.com/offen/offen v0.0.0-20191104142728-b3c572c7322a h1:ZXG6TXOuTtu65EmViepsbG/Ja0kD97S3ZDIipURhQYE=
+github.com/offen/offen v0.0.0-20191231104847-1b7795e97e91 h1:dm8IPul9ciqmqgdZ6apNSu3zBCmOpdpHLInYkn6ERR8=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/server/router/version.go
+++ b/server/router/version.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/offen/offen/server/config"
 )
 
 type versionInfo struct {
@@ -14,6 +15,6 @@ func (rt *router) getVersion(c *gin.Context) {
 	// this endpoint is mostly to be consumed by humans, so
 	// we pretty print the output
 	c.IndentedJSON(http.StatusOK, versionInfo{
-		Revision: rt.config.App.Revision,
+		Revision: config.Revision,
 	})
 }


### PR DESCRIPTION
Currently the Docker image would  not expose its versioning info.