### PR TITLE
Rename bootstrap command to setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
             cp ./bin/offen-linux-amd64 ./offen
       - run:
           name: Setup application
-          command: sudo ./offen bootstrap -email circle@offen.dev -name circle -password secret
+          command: sudo ./offen setup -email circle@offen.dev -name circle -password secret
       - run:
           name: Serve application
           command: OFFEN_SERVER_PORT=8080 sudo ./offen

--- a/server/Makefile
+++ b/server/Makefile
@@ -7,8 +7,8 @@ up:
 install:
 	@go mod download
 
-bootstrap:
-	@go run cmd/offen/main.go bootstrap -source bootstrap.yml
+setup:
+	@go run cmd/offen/main.go setup -source bootstrap.yml
 	@echo ""
 	@echo "You can now log into the development backend using the following credentials:"
 	@echo ""
@@ -22,7 +22,7 @@ migrate:
 secret:
 	@go run cmd/offen/main.go secret
 
-test-ci: bootstrap
+test-ci: setup
 	@go test ./... -cover -tags="integration"
 
 extract-strings:

--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	secretCmd := flag.NewFlagSet("secret", flag.ExitOnError)
-	bootstrapCmd := flag.NewFlagSet("bootstrap", flag.ExitOnError)
+	setupCmd := flag.NewFlagSet("bootstrap", flag.ExitOnError)
 	demoCmd := flag.NewFlagSet("demo", flag.ExitOnError)
 
 	if len(os.Args) < 2 {
@@ -246,17 +246,17 @@ func main() {
 		}
 
 		logger.Info("Gracefully shut down server")
-	case "bootstrap":
+	case "setup":
 		var (
-			accountID         = bootstrapCmd.String("forceid", "", "force usage of given account id")
-			accountName       = bootstrapCmd.String("name", "", "the account name")
-			email             = bootstrapCmd.String("email", "", "the email address used for login")
-			password          = bootstrapCmd.String("password", "", "the password used for login")
-			passwordFromStdin = bootstrapCmd.Bool("stdin-password", false, "read password from stdin")
-			source            = bootstrapCmd.String("source", "", "the configuration file")
-			populateMissing   = bootstrapCmd.Bool("populate", true, "in case required secrets are missing from the configuration, create and persist them in ~/.config/offen.env")
+			accountID         = setupCmd.String("forceid", "", "force usage of given account id")
+			accountName       = setupCmd.String("name", "", "the account name")
+			email             = setupCmd.String("email", "", "the email address used for login")
+			password          = setupCmd.String("password", "", "the password used for login")
+			passwordFromStdin = setupCmd.Bool("stdin-password", false, "read password from stdin")
+			source            = setupCmd.String("source", "", "the configuration file")
+			populateMissing   = setupCmd.Bool("populate", true, "in case required secrets are missing from the configuration, create and persist them in ~/.config/offen.env")
 		)
-		bootstrapCmd.Parse(os.Args[2:])
+		setupCmd.Parse(os.Args[2:])
 
 		pw := *password
 		if *passwordFromStdin {


### PR DESCRIPTION
Renames the `bootstrap` command to `setup` which is a lot more obvious.