### PR TITLE
Add missing unit tests for events related HTTP endpoints

### DIFF
--- a/server/go.sum
+++ b/server/go.sum
@@ -118,6 +118,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/offen/offen v0.0.0-20191031105048-b8b1e9b77391 h1:DnYbQd85n0arrKigA91TEwSWWEYBfa67g2BS5K+Yiq8=
 github.com/offen/offen v0.0.0-20191104142728-b3c572c7322a h1:ZXG6TXOuTtu65EmViepsbG/Ja0kD97S3ZDIipURhQYE=
 github.com/offen/offen v0.0.0-20191231104847-1b7795e97e91 h1:dm8IPul9ciqmqgdZ6apNSu3zBCmOpdpHLInYkn6ERR8=
+github.com/offen/offen v0.0.0-20200102091349-13b48c8e9b3b h1:A+6ZjmdsqnTROFiBoyeT5EjEtN1YHN+jIPWJ5/k41Ws=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/server/router/events.go
+++ b/server/router/events.go
@@ -21,7 +21,7 @@ type ackResponse struct {
 var errBadRequestContext = errors.New("could not use user id in request context")
 
 func (rt *router) postEvents(c *gin.Context) {
-	userID, _ := c.Value(contextKeyCookie).(string)
+	userID := c.GetString(contextKeyCookie)
 	evt := inboundEventPayload{}
 	if err := c.BindJSON(&evt); err != nil {
 		newJSONError(
@@ -74,14 +74,7 @@ type getResponse struct {
 }
 
 func (rt *router) getEvents(c *gin.Context) {
-	userID, ok := c.Value(contextKeyCookie).(string)
-	if !ok {
-		newJSONError(
-			errBadRequestContext,
-			http.StatusInternalServerError,
-		).Pipe(c)
-		return
-	}
+	userID := c.GetString(contextKeyCookie)
 	result, err := rt.db.Query(persistence.Query{
 		UserID: userID,
 		Since:  c.Query("since"),
@@ -106,7 +99,7 @@ type deletedQuery struct {
 }
 
 func (rt *router) getDeletedEvents(c *gin.Context) {
-	userID, _ := c.Value(contextKeyCookie).(string)
+	userID := c.GetString(contextKeyCookie)
 
 	query := deletedQuery{}
 	if err := c.BindJSON(&query); err != nil {
@@ -131,7 +124,7 @@ func (rt *router) getDeletedEvents(c *gin.Context) {
 }
 
 func (rt *router) purgeEvents(c *gin.Context) {
-	userID, _ := c.Value(contextKeyCookie).(string)
+	userID := c.GetString(contextKeyCookie)
 	if err := rt.db.Purge(userID); err != nil {
 		newJSONError(
 			fmt.Errorf("router: error purging user events: %v", err),

--- a/server/router/events_test.go
+++ b/server/router/events_test.go
@@ -1,0 +1,302 @@
+package router
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/offen/offen/server/config"
+	"github.com/offen/offen/server/persistence"
+)
+
+func strptr(s string) *string {
+	return &s
+}
+
+type mockPurgeEventsService struct {
+	persistence.Service
+	err error
+}
+
+func (m *mockPurgeEventsService) Purge(string) error {
+	return m.err
+}
+
+func TestRouter_purgeEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		db             persistence.Service
+		expectedStatus int
+	}{
+		{
+			"not ok",
+			&mockPurgeEventsService{
+				err: errors.New("did not work"),
+			},
+			http.StatusInternalServerError,
+		},
+		{
+			"ok",
+			&mockPurgeEventsService{},
+			http.StatusNoContent,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := gin.New()
+			rt := router{
+				db: test.db,
+			}
+			m.POST("/", func(c *gin.Context) {
+				c.Set(contextKeyCookie, "user-id")
+				c.Next()
+			}, rt.purgeEvents)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+
+			m.ServeHTTP(w, r)
+
+			if w.Code != test.expectedStatus {
+				t.Errorf("Expected status code %d, got %d", test.expectedStatus, w.Code)
+			}
+		})
+	}
+}
+
+type mockGetDeletedEventsService struct {
+	persistence.Service
+	result []string
+	err    error
+}
+
+func (m *mockGetDeletedEventsService) GetDeletedEvents([]string, string) ([]string, error) {
+	return m.result, m.err
+}
+
+func TestRouter_getDeletedEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		db             persistence.Service
+		body           string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			"bad request body",
+			&mockGetDeletedEventsService{},
+			"zomfg what is this even",
+			http.StatusBadRequest,
+			"",
+		},
+		{
+			"database error",
+			&mockGetDeletedEventsService{
+				err: errors.New("did not work"),
+			},
+			`{"eventIds":["event-a", "event-b"]}`,
+			http.StatusInternalServerError,
+			"",
+		},
+		{
+			"ok",
+			&mockGetDeletedEventsService{
+				result: []string{"event-a"},
+			},
+			`{"eventIds":["event-a", "event-b"]}`,
+			http.StatusOK,
+			`{"eventIds":["event-a"]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := gin.New()
+			rt := router{
+				db: test.db,
+			}
+			m.POST("/", func(c *gin.Context) {
+				c.Set(contextKeyCookie, "user-id")
+				c.Next()
+			}, rt.getDeletedEvents)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(test.body))
+
+			m.ServeHTTP(w, r)
+
+			if w.Code != test.expectedStatus {
+				t.Errorf("Expected status code %d, got %d", test.expectedStatus, w.Code)
+			}
+
+			if test.expectedBody != "" {
+				if !strings.Contains(w.Body.String(), test.expectedBody) {
+					t.Errorf("Expected response body %s to contain %s", w.Body.String(), test.expectedBody)
+				}
+			}
+		})
+	}
+}
+
+type mockGetEventsService struct {
+	persistence.Service
+	result map[string][]persistence.EventResult
+	err    error
+}
+
+func (m *mockGetEventsService) Query(persistence.Query) (map[string][]persistence.EventResult, error) {
+	return m.result, m.err
+}
+
+func TestRouter_getEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		db             persistence.Service
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			"database error",
+			&mockGetEventsService{
+				err: errors.New("did not work"),
+			},
+			http.StatusInternalServerError,
+			"",
+		},
+		{
+			"StatusOK",
+			&mockGetEventsService{
+				result: map[string][]persistence.EventResult{
+					"account-a": []persistence.EventResult{
+						{AccountID: "account-a", UserID: strptr("user-a"), EventID: "event-a", Payload: "payload"},
+					},
+				},
+			},
+			http.StatusOK,
+			`{"events":{"account-a":[{"accountId":"account-a","userId":"user-a","eventId":"event-a","payload":"payload"}]}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := gin.New()
+			rt := router{
+				db: test.db,
+			}
+			m.GET("/", func(c *gin.Context) {
+				c.Set(contextKeyCookie, "user-id")
+				c.Next()
+			}, rt.getEvents)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			m.ServeHTTP(w, r)
+
+			if w.Code != test.expectedStatus {
+				t.Errorf("Expected status code %d, got %d", test.expectedStatus, w.Code)
+			}
+
+			if test.expectedBody != "" {
+				if !strings.Contains(w.Body.String(), test.expectedBody) {
+					t.Errorf("Expected response body %s to contain %s", w.Body.String(), test.expectedBody)
+				}
+			}
+		})
+	}
+}
+
+type mockPostEventsService struct {
+	persistence.Service
+	err error
+}
+
+func (m *mockPostEventsService) Insert(string, string, string) error {
+	return m.err
+}
+
+func TestRouter_postEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		db             persistence.Service
+		body           string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			"bad payload",
+			&mockPostEventsService{},
+			"o hai!",
+			http.StatusBadRequest,
+			"",
+		},
+		{
+			"database error",
+			&mockPostEventsService{
+				err: errors.New("did not work"),
+			},
+			`{"accountId":"account-a","payload":"some-payload"}`,
+			http.StatusInternalServerError,
+			"",
+		},
+		{
+			"unknown account",
+			&mockPostEventsService{
+				err: persistence.ErrUnknownAccount("unknown account"),
+			},
+			`{"accountId":"account-a","payload":"some-payload"}`,
+			http.StatusNotFound,
+			"",
+		},
+		{
+			"unknown user",
+			&mockPostEventsService{
+				err: persistence.ErrUnknownUser("unknown user"),
+			},
+			`{"accountId":"account-a","payload":"some-payload"}`,
+			http.StatusBadRequest,
+			"",
+		},
+		{
+			"ok",
+			&mockPostEventsService{},
+			`{"accountId":"account-a","payload":"some-payload"}`,
+			http.StatusCreated,
+			`{"ack":true}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := gin.New()
+			rt := router{
+				db:     test.db,
+				config: &config.Config{},
+			}
+			m.POST("/", func(c *gin.Context) {
+				c.Set(contextKeyCookie, "user-id")
+				c.Set(contextKeySecureContext, false)
+				c.Next()
+			}, rt.postEvents)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(test.body))
+
+			m.ServeHTTP(w, r)
+
+			if w.Code != test.expectedStatus {
+				t.Errorf("Expected status code %d, got %d", test.expectedStatus, w.Code)
+			}
+
+			if test.expectedBody != "" {
+				if !strings.Contains(w.Body.String(), test.expectedBody) {
+					t.Errorf("Expected response body %s to contain %s", w.Body.String(), test.expectedBody)
+				}
+			}
+		})
+	}
+}

--- a/server/router/root_test.go
+++ b/server/router/root_test.go
@@ -1,0 +1,30 @@
+package router
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/offen/offen/server/config"
+)
+
+func TestRouter_getRoot(t *testing.T) {
+	rt := router{
+		config: &config.Config{},
+	}
+	m := gin.New()
+	m.GET("/", rt.getRoot)
+	tpl := template.Must(template.New("index.go.html").Parse("ok!"))
+	m.SetHTMLTemplate(tpl)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	m.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Unexpected status code %v", w.Code)
+	}
+}

--- a/server/router/version.go
+++ b/server/router/version.go
@@ -12,7 +12,7 @@ type versionInfo struct {
 }
 
 func (rt *router) getVersion(c *gin.Context) {
-	// this endpoint is mostly to be consumed by humans, so
+	// this endpoint is most likely to be consumed by humans, so
 	// we pretty print the output
 	c.IndentedJSON(http.StatusOK, versionInfo{
 		Revision: config.Revision,

--- a/server/router/version_test.go
+++ b/server/router/version_test.go
@@ -1,0 +1,24 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRouter_getVersion(t *testing.T) {
+	rt := router{}
+	m := gin.New()
+	m.GET("/", rt.getVersion)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	m.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Unexpected status code %v", w.Code)
+	}
+}


### PR DESCRIPTION
Long overdue, this adds unit tests for event ingestion and querying on router level.