### PR TITLE
Create checksums file before creating archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
             make build-docker
 
             mkdir -p /tmp/artifacts
-            cd ./bin && tar -czvf /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz $(ls -A)
+            cd ./bin && md5sum * > checksums.txt && tar -czvf /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz $(ls -A)
             echo "$DOCKER_ACCESSTOKEN" | docker login --username $DOCKER_USER --password-stdin
             docker push offen/offen:$DOCKER_IMAGE_TAG
       - store_artifacts:

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -67,5 +67,3 @@ ENV GOPATH /go
 WORKDIR /build
 
 RUN xgo --targets=$TARGETS --ldflags="-linkmode external -extldflags '$LDFLAGS' -s -w -X github.com/offen/offen/server/config.Revision=$GIT_REVISION" github.com/offen/offen/server/cmd/offen
-
-RUN md5sum * > checksums.txt


### PR DESCRIPTION
#234 introduced the creation of a checksum file, yet the implementation would override the values for Linux and Windows in case the build would be called with different parameters (like it's currently done for Darwin). This PR ensures the checksums will always be created for all builds.