### PR TITLE
Do not print misleading message when using AutoTLS

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -217,7 +217,11 @@ func main() {
 				}
 			}
 		}()
-		logger.Infof("Server now listening on port %d", cfg.Server.Port)
+		if cfg.Server.AutoTLS != "" {
+			logger.Info("Server now listening using AutoTLS settings")
+		} else {
+			logger.Infof("Server now listening on port %d", cfg.Server.Port)
+		}
 
 		if cfg.App.SingleNode {
 			scheduler := gocron.NewScheduler()


### PR DESCRIPTION
Right now, a message about the default port would be printed. Instead, refer to AutoTLS settings.