### PR TITLE
Expose ACME challenge on port 80 when using autotls

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -208,7 +208,13 @@ func main() {
 					logger.WithError(err).Fatal("Error binding server to network")
 				}
 			} else if cfg.Server.AutoTLS != "" {
-				if err := http.Serve(autocert.NewListener(cfg.Server.AutoTLS), srv.Handler); err != nil && err != http.ErrServerClosed {
+				m := autocert.Manager{
+					Prompt:     autocert.AcceptTOS,
+					HostPolicy: autocert.HostWhitelist(cfg.Server.AutoTLS),
+					Cache:      autocert.DirCache(cfg.Server.CertificateCache),
+				}
+				go http.ListenAndServe(":http", m.HTTPHandler(nil))
+				if err := http.Serve(m.Listener(), srv.Handler); err != nil && err != http.ErrServerClosed {
 					logger.WithError(err).Fatal("Error binding server to network")
 				}
 			} else {
@@ -218,7 +224,7 @@ func main() {
 			}
 		}()
 		if cfg.Server.AutoTLS != "" {
-			logger.Info("Server now listening using AutoTLS settings")
+			logger.Info("Server now listening on port 80 and 443 using AutoTLS")
 		} else {
 			logger.Infof("Server now listening on port %d", cfg.Server.Port)
 		}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -28,11 +28,12 @@ var Revision string
 // source values from the application environment at runtime.
 type Config struct {
 	Server struct {
-		Port           int  `default:"8080"`
-		ReverseProxy   bool `default:"false"`
-		SSLCertificate string
-		SSLKey         string
-		AutoTLS        string
+		Port             int  `default:"8080"`
+		ReverseProxy     bool `default:"false"`
+		SSLCertificate   string
+		SSLKey           string
+		AutoTLS          string
+		CertificateCache string `default:"/var/www/.cache"`
 	}
 	Database struct {
 		Dialect          Dialect `default:"sqlite3"`


### PR DESCRIPTION
This is still needed to acquire the certificates on startup.