### PR TITLE
Do not collect timing before load event

### DIFF
--- a/script/index.js
+++ b/script/index.js
@@ -26,7 +26,17 @@ app.on('PAGEVIEW', supportMiddleware, function (context, send, next) {
   send(message)
 })
 
-app.dispatch('PAGEVIEW', 'initial')
+switch (document.readyState) {
+  case 'complete':
+  case 'loaded':
+  case 'interactive':
+    app.dispatch('PAGEVIEW', 'initial')
+    break
+  default:
+    document.addEventListener('DOMContentLoaded', function () {
+      app.dispatch('PAGEVIEW', 'initial')
+    })
+}
 
 historyEvents.addEventListener(window, 'changestate', function () {
   app.dispatch('PAGEVIEW')


### PR DESCRIPTION
Right now, embedding the script in the head would create negative timings as we do not wait for the page to load.