### PR TITLE
Add debug command for printing configuration

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -413,6 +413,9 @@ func main() {
 		}
 	case "version":
 		logger.WithField("revision", config.Revision).Info("Current build created using")
+	case "debug":
+		cfg := mustConfig(false)
+		logger.WithField("config", fmt.Sprintf("%+v", cfg)).Info("Current configuration values")
 	default:
 		logger.Fatalf("Unknown subcommand %s\n", os.Args[1])
 	}


### PR DESCRIPTION
This is helpful for deployments that do unexpected things and one needs to find out which configuration is actually applied.

---

In the long run, the configuration should probably be simplified and using an explicit location for `offen.env` instead of a cascade.