### PR TITLE
In dockerfile expose all default ports, set working directory

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,8 @@ LABEL maintainer="offen <hioffen@posteo.de>"
 RUN apk add -U --no-cache ca-certificates
 COPY ./bin/offen-linux-amd64 /usr/bin/offen
 
-ENV OFFEN_SERVER_PORT 3000
-EXPOSE 3000
+ENV OFFEN_SERVER_PORT 80
+EXPOSE 80 443
 
+WORKDIR /root
 ENTRYPOINT ["offen"]


### PR DESCRIPTION
This will make it more obvious where to put relative configuration files.