### PR TITLE
Use single message channel for communicating with vault

### DIFF
--- a/vault/src/middleware.js
+++ b/vault/src/middleware.js
@@ -10,13 +10,19 @@ function optIn (event, respond, next) {
       if (status) {
         return status
       }
-      respond.styleHost({
-        styles: consentStatus.hostStyles(respond.styleHost.selector).visible.innerHTML
+      respond({
+        type: 'STYLES',
+        payload: {
+          styles: consentStatus.hostStyles(respond.selector).visible.innerHTML
+        }
       })
       return consentStatus.askForConsent()
         .then(function (result) {
-          respond.styleHost({
-            styles: consentStatus.hostStyles(respond.styleHost.selector).hidden.innerHTML
+          respond({
+            type: 'STYLES',
+            payload: {
+              styles: consentStatus.hostStyles(respond.selector).hidden.innerHTML
+            }
           })
           return result
         })

--- a/vault/src/router.js
+++ b/vault/src/router.js
@@ -9,12 +9,7 @@ function router () {
         event.ports[0].postMessage(message)
       }
     }
-    respond.styleHost = function (data) {
-      if (event.ports && event.ports.length > 1) {
-        event.ports[1].postMessage(data)
-      }
-    }
-    respond.styleHost.selector = event.data.host
+    respond.selector = event.data.host
 
     var stack = (registeredRoutes[event.data.type] || []).slice()
 


### PR DESCRIPTION
It looks like Firefox is not able to handle to different `MessageChannel` instances being passed down in a message like:

```js
var channel1 = new MessageChannel()
var channel2 = new MessageChannel()

target.contentWindow.postMessage(message, origin, [channel1.port2, channel2.port2])
```

This apparently leads to internal race conditions resulting in messages being never delivered from time to time.

Instead of using a distinct port for styling info, this PR changes the message exchange mechanism to use a single channel only and switch on the message type instead.