### PR TITLE
Server tweaks

### DIFF
--- a/auditorium/stores/consent.js
+++ b/auditorium/stores/consent.js
@@ -15,6 +15,11 @@ function store (state, emitter) {
         return postMessage(consentRequest)
       })
       .then(function () {
+        if (allow) {
+          state.flash = __('Your have now opted in. Use the Auditorium to review and manage your data at any time.')
+        } else {
+          state.flash = __('Your have now opted out and all usage data has been deleted.')
+        }
         emitter.emit('offen:query', Object.assign({}, state.params, state.query), state.authenticatedUser)
       })
       .catch(function (err) {

--- a/auditorium/stores/data.js
+++ b/auditorium/stores/data.js
@@ -25,7 +25,7 @@ function store (state, emitter) {
         var optinMessage = results[1]
         state.model = queryMessage.payload.result
         Object.assign(state.model, optinMessage.payload)
-        state.flash = onSuccessMessage
+        state.flash = state.flash || onSuccessMessage
       })
       .catch(function (err) {
         if (process.env.NODE_ENV !== 'production') {

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -157,7 +157,7 @@ func New(opts ...Config) http.Handler {
 
 	app.GET("/", etag, csp, rt.getRoot)
 
-	app.GET("/healthz", noStore, rt.getHealth)
+	app.Any("/healthz", noStore, rt.getHealth)
 	app.GET("/versionz", noStore, rt.getVersion)
 	{
 		api := app.Group("/api")


### PR DESCRIPTION
This adds 3 minor improvements:
- The `/healthz` endpoint now also answers HEAD requests
- The Auditorium shows a flash message on opt-out or opt-in
- Caching of static assets is improved to prevent 404s of old revisioned assets on update