### PR TITLE
Use last page instead of first in active pages

### DIFF
--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -134,12 +134,13 @@ function _pages (events, perUser) {
   if (perUser) {
     // in this branch, only the most recent event for each user
     // will be considered
+    var sortBy = _.property(['payload', 'timestamp'])
     result = result
       .groupBy('userId')
       .pairs()
       .map(function (pair) {
-        return _.head(
-          _.sortBy(pair[1], _.property(['payload', 'timestamp']))
+        return _.last(
+          _.sortBy(pair[1], sortBy)
         )
       })
       .flatten(true)

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -282,9 +282,9 @@ describe('src/stats.js', function () {
     it('returns a sorted list of active pages grouped by a clean URL', function () {
       return stats.activePages([
         {},
-        { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo') } },
-        { accountId: 'account-a', userId: 'user-a', payload: { href: new window.URL('https://www.example.net/foo?param=bar') } },
-        { accountId: 'account-b', userId: 'user-z', payload: { href: new window.URL('https://beep.boop/site#!/foo') } },
+        { accountId: 'account-a', userId: 'user-a', payload: { timestamp: '100', href: new window.URL('https://www.example.net/bar') } },
+        { accountId: 'account-a', userId: 'user-a', payload: { timestamp: '120', href: new window.URL('https://www.example.net/foo?param=bar') } },
+        { accountId: 'account-b', userId: 'user-z', payload: { timestamp: '200', href: new window.URL('https://beep.boop/site#!/foo') } },
         { accountId: 'account-a', userId: null, payload: { } }
       ])
         .then(function (result) {


### PR DESCRIPTION
Fixes a bug where "Active Pages" would show the first page of active sessions instead of the expected last page.