### PR TITLE
When serving from localhost, do not use Secure cookies

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -108,7 +108,6 @@ function view (state, emit) {
         ${raw(__('You are viewing your <strong>usage</strong> data.'))}
       </p>
       ${!state.model.hasOptedIn ? html`<p><strong>${__('You have not opted in to data collection. You can use the buttons below to do so.')}</strong></p>` : null}
-      ${state.model.allowsCookies ? null : html`<p><strong>${__('Your browser does not allow 3rd party cookies. We respect this setting and collect only very basic data in this case, yet it also means we cannot display any data to you here.')}</strong></p>`}
     `
     if (!state.model.allowsCookies) {
       var noCookiesCopy = __('Your browser does not allow 3rd party cookies. We respect this setting and collect only very basic data in this case, yet it also means we cannot display any data to you here.')

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -44,13 +44,17 @@ const (
 )
 
 func (rt *router) userCookie(userID string, secure bool) *http.Cookie {
+	sameSite := http.SameSiteNoneMode
+	if !secure {
+		sameSite = http.SameSiteLaxMode
+	}
 	return &http.Cookie{
 		Name:     cookieKey,
 		Value:    userID,
 		Expires:  time.Now().Add(rt.config.App.EventRetentionPeriod),
 		HttpOnly: true,
 		Secure:   secure,
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSite,
 		Path:     "/",
 	}
 }

--- a/vault/src/allows-cookies.js
+++ b/vault/src/allows-cookies.js
@@ -1,13 +1,15 @@
 module.exports = allowsCookies
 
 function allowsCookies () {
+  var isLocalhost = window.location.hostname === 'localhost'
+  var sameSite = isLocalhost ? 'Lax' : 'None'
   var token = randomString()
   document.cookie = serialize({
-    ok: token, SameSite: 'None', Secure: true
+    ok: token, SameSite: sameSite, Secure: !isLocalhost
   })
   var support = document.cookie.indexOf(token) >= 0
   document.cookie = serialize({
-    ok: '', expires: new Date(0).toUTCString(), SameSite: 'None', Secure: true
+    ok: '', expires: new Date(0).toUTCString(), SameSite: sameSite, Secure: !isLocalhost
   })
   return support
 }
@@ -18,8 +20,12 @@ function serialize (obj) {
       if (obj[key] === true) {
         return key
       }
+      if (obj[key] === false) {
+        return null
+      }
       return key + '=' + obj[key]
     })
+    .filter(Boolean)
     .join(';')
 }
 

--- a/vault/src/user-consent.js
+++ b/vault/src/user-consent.js
@@ -218,13 +218,14 @@ function getConsentStatus () {
 exports.set = setConsentStatus
 
 function setConsentStatus (status) {
+  var isLocalhost = window.location.hostname === 'localhost'
   var expires = new Date(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000)
   var cookie = {
     consent: status,
     expires: expires.toUTCString(),
     path: '/',
-    SameSite: 'None',
-    Secure: true
+    SameSite: isLocalhost ? 'Lax' : 'None',
+    Secure: !isLocalhost
   }
   document.cookie = serialize(cookie)
 }
@@ -235,7 +236,11 @@ function serialize (obj) {
       if (obj[key] === true) {
         return key
       }
+      if (obj[key] === false) {
+        return null
+      }
       return [key, '=', obj[key]].join('')
     })
+    .filter(Boolean)
     .join(';')
 }


### PR DESCRIPTION
When serving from localhost, cookies need to be SameSite, yet _not_ Secure (as it's served via http), else browsers reject setting them in development.