### PR TITLE
Do not run autorefresh when window has lost focus

### DIFF
--- a/auditorium/stores/data.js
+++ b/auditorium/stores/data.js
@@ -74,7 +74,14 @@ function store (state, emitter) {
       if (state.updatePending) {
         return
       }
-      emitter.emit('offen:query', Object.assign({}, state.params, state.query), state.authenticatedUser, true)
+      if (document.hasFocus()) {
+        emitter.emit('offen:query', Object.assign({}, state.params, state.query), state.authenticatedUser, true)
+      } else {
+        window.onfocus = function () {
+          emitter.emit('offen:query', Object.assign({}, state.params, state.query), state.authenticatedUser, true)
+          window.onfocus = Function.prototype
+        }
+      }
     }, interval)
   })
 


### PR DESCRIPTION
Disabling auto refresh while the page is not in focus can save significant amounts of traffic coming from phones left idling or never closed tabs.