### PR TITLE
If available, track canonical link instead of href

### DIFF
--- a/script/src/events.js
+++ b/script/src/events.js
@@ -1,9 +1,10 @@
 exports.pageview = pageview
 
 function pageview (initial) {
+  var canonicalLink = document.head.querySelector('link[rel="canonical"]')
   return {
     type: 'PAGEVIEW',
-    href: window.location.href,
+    href: (canonicalLink && canonicalLink.getAttribute('href')) || window.location.href,
     title: document.title,
     referrer: document.referrer,
     pageload: (function () {


### PR DESCRIPTION
Picking up on this brilliant tweet: https://twitter.com/pedroborg_es/status/1219315806288384000 collect the canonical URL if available.