### PR TITLE
Prevent directory listings from being served

### DIFF
--- a/server/public/filesystem.go
+++ b/server/public/filesystem.go
@@ -2,10 +2,12 @@ package public
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 
 	_ "github.com/offen/offen/server/public/statik"
@@ -49,7 +51,7 @@ func (l *localizedFS) Open(file string) (http.File, error) {
 	for _, location := range cascade {
 		f, err = l.root.Open(location)
 		if err == nil {
-			return f, nil
+			return neuteredReaddirFile{f}, nil
 		}
 	}
 	return nil, err
@@ -105,4 +107,12 @@ func HTMLTemplate(gettext func(string, ...interface{}) template.HTML, rev func(s
 		}
 	}
 	return t, nil
+}
+
+type neuteredReaddirFile struct {
+	http.File
+}
+
+func (f neuteredReaddirFile) Readdir(count int) ([]os.FileInfo, error) {
+	return nil, errors.New("forcefully skipping directory listings")
 }

--- a/server/router/static.go
+++ b/server/router/static.go
@@ -32,7 +32,10 @@ func staticMiddleware(fileServer, fallback http.Handler) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		status, contentType := tryStatic(c.Request.Method, c.Request.URL.String())
-		if status == 404 {
+		// Right now, we manually trigger an error when trying to read a directory
+		// so we can skip the directory listings provided by the Go FileServer.
+		// TODO: revisit this solution.
+		if status == http.StatusNotFound || status == http.StatusInternalServerError {
 			fallback.ServeHTTP(c.Writer, c.Request)
 			return
 		}


### PR DESCRIPTION
We do not want the FileServer to show directory listings, so we make it error forcefully on trying to read a directory.