### PR TITLE
Allow 400 failure when purging non-existent user

### DIFF
--- a/vault/src/handler.js
+++ b/vault/src/handler.js
@@ -116,7 +116,17 @@ exports.handlePurgeWith = handlePurgeWith
 function handlePurgeWith (api, queries, getUserEvents, getOperatorEvents) {
   var handleQuery = handleQueryWith(getUserEvents, getOperatorEvents)
   return function handlePurge (message) {
-    return Promise.all([api.purge(), queries.purge()])
+    return Promise.all([
+      api
+        .purge()
+        .catch(function (err) {
+          if (err.status === 400) {
+            return null
+          }
+          throw err
+        }),
+      queries.purge()
+    ])
       .then(function () {
         return handleQuery(message)
       })


### PR DESCRIPTION
A user without an assigned identifier might still try to delete their user data. This is a case we can tolerate instead of failing hard.