### PR TITLE
Fix bootstrap command failing on bad previous state

### DIFF
--- a/server/persistence/bootstrap.go
+++ b/server/persistence/bootstrap.go
@@ -47,6 +47,11 @@ func (p *persistenceLayer) Bootstrap(config BootstrapConfig, emailSalt []byte) e
 		return fmt.Errorf("persistence: error dropping tables before inserting seed data: %w", err)
 	}
 
+	if err := txn.ApplyMigrations(); err != nil {
+		txn.Rollback()
+		return fmt.Errorf("persistence: error applying initial migrations: %w", err)
+	}
+
 	accounts, accountUsers, relationships, err := bootstrapAccounts(&config, emailSalt)
 	if err != nil {
 		txn.Rollback()

--- a/server/persistence/relational/relational.go
+++ b/server/persistence/relational/relational.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 	"github.com/offen/offen/server/persistence"
+
 	// GORM imports the dialects for side effects only
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
@@ -55,8 +56,8 @@ func (r *relationalDAL) ApplyMigrations() error {
 		},
 	})
 
-	m.InitSchema(func(tx *gorm.DB) error {
-		return tx.AutoMigrate(
+	m.InitSchema(func(db *gorm.DB) error {
+		return db.AutoMigrate(
 			&Event{},
 			&Account{},
 			&User{},
@@ -73,20 +74,15 @@ func (r *relationalDAL) Ping() error {
 }
 
 func (r *relationalDAL) DropAll() error {
-	if err := r.db.Delete(&Event{}).Error; err != nil {
-		return fmt.Errorf("relational: error dropping events table: %w,", err)
-	}
-	if err := r.db.Delete(&Account{}).Error; err != nil {
-		return fmt.Errorf("relational: error dropping accounts table: %w,", err)
-	}
-	if err := r.db.Delete(&User{}).Error; err != nil {
-		return fmt.Errorf("relational: error dropping user table: %w,", err)
-	}
-	if err := r.db.Delete(&AccountUser{}).Error; err != nil {
-		return fmt.Errorf("relational: error dropping account user table: %w,", err)
-	}
-	if err := r.db.Delete(&AccountUserRelationship{}).Error; err != nil {
-		return fmt.Errorf("relational: error dropping account user relationship table: %w,", err)
+	if err := r.db.DropTableIfExists(
+		&Event{},
+		&Account{},
+		&User{},
+		&AccountUser{},
+		&AccountUserRelationship{},
+		"migrations",
+	).Error; err != nil {
+		return fmt.Errorf("relational: error dropping tables: %w,", err)
 	}
 	return nil
 }

--- a/server/persistence/relational/relational_test.go
+++ b/server/persistence/relational/relational_test.go
@@ -50,6 +50,10 @@ func TestRelationalDAL_DropAll(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
+	if err := dal.ApplyMigrations(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
 	err := db.Where("event_id = ?", "event-id").First(&Event{}).Error
 	if !gorm.IsRecordNotFoundError(err) {
 		t.Errorf("Unexpected error value %v", err)

--- a/server/persistence/relational/transaction.go
+++ b/server/persistence/relational/transaction.go
@@ -32,7 +32,3 @@ func (t *transaction) Transaction() (persistence.Transaction, error) {
 func (t *transaction) Ping() error {
 	return errors.New("relational: cannot call ping on a transaction")
 }
-
-func (t *transaction) ApplyMigrations() error {
-	return errors.New("relational: cannot apply migrations on a transaction")
-}

--- a/server/persistence/relational/transaction_test.go
+++ b/server/persistence/relational/transaction_test.go
@@ -27,8 +27,8 @@ func TestRelationalDAL_Transaction(t *testing.T) {
 		t.Error("Expected error when using transaction to ping")
 	}
 
-	if err := txn.ApplyMigrations(); err == nil {
-		t.Errorf("Expected error when applying migrations to a transaction")
+	if err := txn.ApplyMigrations(); err != nil {
+		t.Errorf("Unexpected error when applying migrations to a transaction")
 	}
 
 	if err := txn.CreateEvent(&persistence.Event{


### PR DESCRIPTION
Previously, bootstrapping would fail on tables being renamed or such. This makes sure it always works against a clean slate.