### PR TITLE
Add async attribute to embed instructions

### DIFF
--- a/auditorium/views/main.js
+++ b/auditorium/views/main.js
@@ -331,7 +331,7 @@ function view (state, emit) {
         <div class="w-100 w-80-ns pa3 mb2 br0 br2-ns bg-black-05">
           <h4 class="f5 mb3 mt0">${__('No data showing up?')}</h4>
           <p>${raw(__('To use Offen with the account <strong>%s</strong> on your website, embed the following script on each page you want to appear in your statistics:', state.model.account.name))}</p>
-          <pre class="pre">${raw(`&lt;script src="${window.location.origin}/script.js" data-account-id="${state.model.account.accountId}"&gt;&lt;/script&gt;`)}</pre>
+          <pre class="pre">${raw(`&lt;script async src="${window.location.origin}/script.js" data-account-id="${state.model.account.accountId}"&gt;&lt;/script&gt;`)}</pre>
         </div>
       </div>
     `


### PR DESCRIPTION
The `script` can (and should) be embedded using the `async` attribute in order to not affect or block loading of the host site.