### PR TITLE
Add test site for generating usage data during development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,7 @@ services:
       OFFEN_SECRETS_EMAILSALT: JuhbRA4lCdo8rt5qVdLpk3==
       OFFEN_SERVER_PORT: 8080
       OFFEN_SERVER_REVERSEPROXY: '1'
-      OFFEN_APP_ROOTACCOUNT: 9b63c4d8-65c0-438c-9d30-cc4b01173393
     command: refresh run
-    ports:
-      - 8081:8080
 
   vault:
     build:
@@ -71,6 +68,13 @@ services:
       - .:/offen
       - auditoriumdeps:/offen/auditorium/node_modules
     command: npm start
+
+  test_site:
+    image: nginx:1.17-alpine
+    ports:
+      - 8081:80
+    volumes:
+      - ./test-site:/usr/share/nginx/html
 
 volumes:
   serverdata:

--- a/test-site/README.md
+++ b/test-site/README.md
@@ -1,0 +1,3 @@
+# test-site
+
+This is a simple test site you can use for generating usage data during development. It is being served on `http://localhost:8081` when using the default setup.

--- a/test-site/index.html
+++ b/test-site/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Index</title>
+  <script async src="http://localhost:8080/script.js" data-account-id="9b63c4d8-65c0-438c-9d30-cc4b01173393"></script>
+</head>
+<body>
+  <h1>This is the Index page</h1>
+  <h2>Other pages:</h2>
+  <ul>
+    <li><a href="/page-one/">Page one</a></li>
+    <li><a href="/page-two/">Page two</a></li>
+  </ul>
+</body>
+</html>

--- a/test-site/page-one/index.html
+++ b/test-site/page-one/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Page one</title>
+  <script async src="http://localhost:8080/script.js" data-account-id="9b63c4d8-65c0-438c-9d30-cc4b01173393"></script>
+</head>
+<body>
+  <h1>This is Page one</h1>
+  <h2>Other pages:</h2>
+  <ul>
+    <li><a href="/">Index page</a></li>
+    <li><a href="/page-two/">Page two</a></li>
+  </ul>
+</body>
+</html>

--- a/test-site/page-two/index.html
+++ b/test-site/page-two/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Page two</title>
+  <script async src="http://localhost:8080/script.js" data-account-id="9b63c4d8-65c0-438c-9d30-cc4b01173393"></script>
+</head>
+<body>
+  <h1>This is Page two</h1>
+  <h2>Other pages:</h2>
+  <ul>
+    <li><a href="/">Index page</a></li>
+    <li><a href="/page-one/">Page one</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
Handling the creation of usage data during development in the running Offen instance being developed is hairy and far from real world use cases.

This PR adds a simple static site that embeds the Offen script running at `http://localhost:8081`