### PR TITLE
Tag master releases as stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,13 @@ jobs:
 
             mkdir -p /tmp/artifacts
             cd ./bin && md5sum * > checksums.txt && cp ~/offen/LICENSE . && cp ~/offen/README.md . && tar -czvf /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz $(ls -A)
+
             echo "$DOCKER_ACCESSTOKEN" | docker login --username $DOCKER_USER --password-stdin
+
+            if [ ! -z "$CIRCLE_TAG" ]; then
+              docker tag offen/offen:$DOCKER_IMAGE_TAG offen/offen:stable
+              docker push offen/offen:stable
+            fi
             docker push offen/offen:$DOCKER_IMAGE_TAG
       - store_artifacts:
           path: /tmp/artifacts


### PR DESCRIPTION
The latest official release should also be tagged as `stable` on Docker Hub.