### PR TITLE
Default to alpine friendly database location

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -45,10 +45,6 @@ func main() {
 			}
 		}
 		logger.SetLevel(cfg.App.LogLevel.LogLevel())
-		if cfg.IsDefaultDatabase() {
-			logger.Warn("The configuration is currently using a temporary local database, data will not persist")
-			logger.Warn("Refer to the documentation to find out how to connect to a persistent database")
-		}
 		if !cfg.SMTPConfigured() {
 			logger.Warn("SMTP for transactional email is not configured right now, mail delivery will be unreliable")
 			logger.Warn("Refer to the documentation to find out how to configure SMTP")

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -18,7 +18,9 @@ type Config struct {
 	}
 	Database struct {
 		Dialect          Dialect   `default:"sqlite3"`
-		ConnectionString EnvString `default:"/tmp/offen.db"`
+		// The default value is expecting usage in the official Docker image.
+		// Other consumers will likely need to adjust this value.
+		ConnectionString EnvString `default:"/root/offen.db"`
 	}
 	App struct {
 		Development          bool          `default:"false"`


### PR DESCRIPTION
This allows operators that use the official Docker setup to instantly use `offen setup` without any prior configuration needed.