### PR TITLE
Add exception for heroku port binding

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"reflect"
 	"runtime"
+	"strconv"
 
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
@@ -129,6 +130,14 @@ func New(populateMissing bool, override string) (*Config, error) {
 	err := envconfig.Process("offen", &c)
 	if err != nil && !populateMissing {
 		return &c, fmt.Errorf("config: error processing configuration: %w", err)
+	}
+
+	// The Heroku runtimes does not allow specifying the port in any other
+	// variable than PORT which is why we need to make an exception in this case
+	// and override the default.
+	if _, ok := os.LookupEnv("HEROKU_APP_ID"); ok {
+		port, _ := strconv.Atoi(os.Getenv("PORT"))
+		c.Server.Port = port
 	}
 
 	if err != nil && populateMissing {


### PR DESCRIPTION
When deploying to Heroku, the port the application binds to HAS to be specified in `PORT` no matter what. This means the config creation needs an exception for using `PORT` instead when run on the platform.