### PR TITLE
Add option to use naked port from env, use var directory for storing db

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,9 @@ jobs:
   integration:
     docker:
       - image: circleci/node:12-browsers
+        environment:
+          OFFEN_SERVER_PORT: 3000
+          OFFEN_DATABASE_CONNECTIONSTRING: $HOME/offen.db
     working_directory: ~/offen
     steps:
       - checkout
@@ -153,10 +156,10 @@ jobs:
           name: Setup application
           command: |
             touch offen.env
-            sudo ./offen setup -email circle@offen.dev -name circle -password secret -populate
+            ./offen setup -email circle@offen.dev -name circle -password secret -populate
       - run:
           name: Serve application
-          command: OFFEN_SERVER_PORT=8080 sudo ./offen
+          command:  ./offen
           background: true
       - run:
           name: Wait for server to be ready

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -132,11 +132,11 @@ func New(populateMissing bool, override string) (*Config, error) {
 		return &c, fmt.Errorf("config: error processing configuration: %w", err)
 	}
 
-	// The Heroku runtimes does not allow specifying the port in any other
-	// variable than PORT which is why we need to make an exception in this case
-	// and override the default.
-	if val, ok := os.LookupEnv("PORT"); ok {
-		port, _ := strconv.Atoi(val)
+	if c.Server.UseNakedPort {
+		port, portErr := strconv.Atoi(os.Getenv("PORT"))
+		if portErr != nil {
+			return &c, fmt.Errorf("config: error reading naked port: %w", portErr)
+		}
 		c.Server.Port = port
 	}
 

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -9,7 +9,12 @@ import "time"
 // source values from the application environment at runtime.
 type Config struct {
 	Server struct {
-		Port             int  `default:"3000"`
+		Port int `default:"3000"`
+		// Some runtimes (e.g. Heroku) require the usage of PORT for specifying
+		// the TCP port to bind to, no matter what. As a workaround, these environments
+		// can set OFFEN_SERVER_USENAKEDPORT to make the application use the
+		// port given by PORT.
+		UseNakedPort     bool `default:"false"`
 		ReverseProxy     bool `default:"false"`
 		SSLCertificate   EnvString
 		SSLKey           EnvString
@@ -18,9 +23,7 @@ type Config struct {
 	}
 	Database struct {
 		Dialect          Dialect   `default:"sqlite3"`
-		// The default value is expecting usage in the official Docker image.
-		// Other consumers will likely need to adjust this value.
-		ConnectionString EnvString `default:"/root/offen.db"`
+		ConnectionString EnvString `default:"/var/opt/offen/offen.db"`
 	}
 	App struct {
 		Development          bool          `default:"false"`

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -10,6 +10,11 @@ import "time"
 type Config struct {
 	Server struct {
 		Port             int  `default:"8080"`
+		// Some runtimes (e.g. Heroku) require the usage of PORT for specifying
+		// the TCP port to bind to, no matter what. As a workaround, these environments
+		// can set OFFEN_SERVER_USENAKEDPORT to make the application use the
+		// port given by PORT.
+		UseNakedPort     bool `default:"false"`
 		ReverseProxy     bool `default:"false"`
 		SSLCertificate   EnvString
 		SSLKey           EnvString


### PR DESCRIPTION
In Heroku or Heroku-like environments usage is PORT is a hard requirement. As we still want to use namespaced keys for configuration, this makes falling back to PORT a configuration option itself.

---

Drive-By Fix: use a more Unixy default location for the database file.