### PR TITLE
Allow for multiple host domains to be served

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -222,10 +222,10 @@ func main() {
 				if err != nil && err != http.ErrServerClosed {
 					logger.WithError(err).Fatal("Error binding server to network")
 				}
-			} else if cfg.Server.AutoTLS != "" {
+			} else if len(cfg.Server.AutoTLS) != 0 {
 				m := autocert.Manager{
 					Prompt:     autocert.AcceptTOS,
-					HostPolicy: autocert.HostWhitelist(cfg.Server.AutoTLS),
+					HostPolicy: autocert.HostWhitelist(cfg.Server.AutoTLS...),
 					Cache:      autocert.DirCache(cfg.Server.CertificateCache),
 				}
 				go http.ListenAndServe(":http", m.HTTPHandler(nil))
@@ -238,7 +238,7 @@ func main() {
 				}
 			}
 		}()
-		if cfg.Server.AutoTLS != "" {
+		if len(cfg.Server.AutoTLS) != 0 {
 			logger.Info("Server now listening on port 80 and 443 using AutoTLS")
 		} else {
 			logger.Infof("Server now listening on port %d", cfg.Server.Port)

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -18,7 +18,7 @@ type Config struct {
 		ReverseProxy     bool `default:"false"`
 		SSLCertificate   EnvString
 		SSLKey           EnvString
-		AutoTLS          string
+		AutoTLS          []string
 		CertificateCache EnvString `default:"/var/www/.cache"`
 	}
 	Database struct {

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -9,7 +9,7 @@ import "time"
 // source values from the application environment at runtime.
 type Config struct {
 	Server struct {
-		Port             int  `default:"8080"`
+		Port int `default:"8080"`
 		// Some runtimes (e.g. Heroku) require the usage of PORT for specifying
 		// the TCP port to bind to, no matter what. As a workaround, these environments
 		// can set OFFEN_SERVER_USENAKEDPORT to make the application use the
@@ -18,7 +18,7 @@ type Config struct {
 		ReverseProxy     bool `default:"false"`
 		SSLCertificate   EnvString
 		SSLKey           EnvString
-		AutoTLS          string
+		AutoTLS          []string
 		CertificateCache EnvString `default:"%AppData%\offen\.cache"`
 	}
 	Database struct {


### PR DESCRIPTION
In case an operator wants to serve accounts for multiple domains on the same instance we need to issue certificates for each one of them.