### PR TITLE
Use more robust pageload measurement

### DIFF
--- a/script/src/events.js
+++ b/script/src/events.js
@@ -10,7 +10,7 @@ function pageview (initial) {
     pageload: (function () {
       if (initial && window.performance && window.performance.timing) {
         return Math.round(
-          window.performance.timing.domInteractive - (window.performance.timeOrigin || window.performance.timing.navigationStart)
+          window.performance.timing.domContentLoadedEventEnd - window.performance.timing.navigationStart
         )
       }
       return null

--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -177,6 +177,7 @@ function avgPageload (events) {
   var total = _.chain(events)
     .map(_.property(['payload', 'pageload']))
     .compact()
+    .filter(function (value) { return value > 0 })
     .tap(function (entries) {
       count = entries.length
     })


### PR DESCRIPTION
We still seem to generate some negative values when working against cached versions.