### PR TITLE
Enable client side key storage for Safari

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       GOPATH: /data/go
       OFFEN_APP_DEVELOPMENT: '1'
       OFFEN_SERVER_REVERSEPROXY: '1'
-      OFFEN_APP_EVENTRETENTIONPERIOD: 4464h
       OFFEN_SERVER_PORT: 8080
     command: refresh run
 

--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -245,7 +245,7 @@ func main() {
 		}
 
 		if cfg.App.SingleNode {
-			hourlyJob := time.Tick(time.Minute)
+			hourlyJob := time.Tick(time.Hour)
 			runOnInit := make(chan bool)
 			go func() {
 				for {
@@ -262,7 +262,6 @@ func main() {
 				}
 			}()
 			runOnInit <- true
-			close(runOnInit)
 		}
 
 		quit := make(chan os.Signal)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
@@ -17,6 +18,12 @@ import (
 )
 
 const envFileName = "offen.env"
+
+var (
+	// EventRetention defines the duration for which events are expected to
+	//  be kept before expired.
+	EventRetention = time.Hour * 24 * 6 * 31
+)
 
 // ErrPopulatedMissing can be returned by New to signal that missing values
 // have been populated and persisted.

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -2,8 +2,6 @@
 
 package config
 
-import "time"
-
 // Config contains all runtime configuration needed for running offen as
 // and also defines the desired defaults. Package envconfig is used to
 // source values from the application environment at runtime.
@@ -26,12 +24,11 @@ type Config struct {
 		ConnectionString EnvString `default:"/var/opt/offen/offen.db"`
 	}
 	App struct {
-		Development          bool          `default:"false"`
-		EventRetentionPeriod time.Duration `default:"4464h"`
-		LogLevel             LogLevel      `default:"info"`
-		SingleNode           bool          `default:"true"`
-		Locale               Locale        `default:"en"`
-		RootAccount          string
+		Development bool     `default:"false"`
+		LogLevel    LogLevel `default:"info"`
+		SingleNode  bool     `default:"true"`
+		Locale      Locale   `default:"en"`
+		RootAccount string
 	}
 	Secrets struct {
 		CookieExchange Bytes

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -27,7 +27,6 @@ type Config struct {
 	}
 	App struct {
 		Development          bool          `default:"false"`
-		EventRetentionPeriod time.Duration `default:"4464h"`
 		LogLevel             LogLevel      `default:"info"`
 		SingleNode           bool          `default:"true"`
 		Locale               Locale        `default:"en"`

--- a/server/go.mod
+++ b/server/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/gorilla/securecookie v1.1.1
-	github.com/jasonlvhit/gocron v0.0.0-20191021204008-47e27a9e0dc7
 	github.com/jinzhu/gorm v1.9.2
 	github.com/jinzhu/now v1.0.0 // indirect
 	github.com/joho/godotenv v1.3.0
@@ -23,6 +22,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rakyll/statik v0.1.6
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/sys v0.0.0-20200107162124-548cf772de50

--- a/server/go.sum
+++ b/server/go.sum
@@ -39,7 +39,6 @@ github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df h1:Bao6dhmbTA1KFV
 github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df/go.mod h1:GJr+FCSXshIwgHBtLglIg9M2l2kQSi6QjVAngtzI08Y=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
-github.com/go-redis/redis v6.15.5+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -72,8 +71,6 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jasonlvhit/gocron v0.0.0-20191021204008-47e27a9e0dc7 h1:RzbZz1y/PkFOqvj3Gjvmdmf9Zx47zuYQyo+EZYWfWtk=
-github.com/jasonlvhit/gocron v0.0.0-20191021204008-47e27a9e0dc7/go.mod h1:1nXLkt6gXojCECs34KL3+LlZ3gTpZlkPUA8ejW3WeP0=
 github.com/jinzhu/gorm v1.9.2 h1:lCvgEaqe/HVE+tjAR2mt4HbbHAZsQOv3XAZiEZV37iw=
 github.com/jinzhu/gorm v1.9.2/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a h1:eeaG9XMUvRBYXJi4pg1ZKM7nxc5AfXfojeLLW7O5J3k=
@@ -119,10 +116,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
@@ -202,7 +197,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/p
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200107162124-548cf772de50 h1:YvQ10rzcqWXLlJZ3XCUoO25savxmscf4+SC+ZqiCHhA=
 golang.org/x/sys v0.0.0-20200107162124-548cf772de50/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 h1:gZpLHxUX5BdYLA08Lj4YCJNN/jk7KtquiArPoeX0WvA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -56,7 +56,7 @@ func (rt *router) userCookie(userID string, secure bool) *http.Cookie {
 		HttpOnly: true,
 		Secure:   secure,
 		SameSite: sameSite,
-		Path:     "/",
+		Path:     "/api",
 	}
 	if userID != "" {
 		c.Expires = time.Now().Add(config.EventRetention)
@@ -70,6 +70,7 @@ func (rt *router) authCookie(userID string, secure bool) (*http.Cookie, error) {
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 		Secure:   secure,
+		Path:     "/api",
 	}
 	if userID == "" {
 		c.Expires = time.Unix(0, 0)

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -59,7 +59,7 @@ func (rt *router) userCookie(userID string, secure bool) *http.Cookie {
 		Path:     "/",
 	}
 	if userID != "" {
-		c.Expires = time.Now().Add(rt.config.App.EventRetentionPeriod)
+		c.Expires = time.Now().Add(config.EventRetention)
 	}
 	return c
 }

--- a/vault/src/allows-cookies.js
+++ b/vault/src/allows-cookies.js
@@ -1,32 +1,19 @@
+var cookies = require('./cookie-tools')
+
 module.exports = allowsCookies
 
 function allowsCookies () {
   var isLocalhost = window.location.hostname === 'localhost'
   var sameSite = isLocalhost ? 'Lax' : 'None'
   var token = randomString()
-  document.cookie = serialize({
+  document.cookie = cookies.serialize({
     ok: token, SameSite: sameSite, Secure: !isLocalhost
   })
   var support = document.cookie.indexOf(token) >= 0
-  document.cookie = serialize({
+  document.cookie = cookies.serialize({
     ok: '', expires: new Date(0).toUTCString(), SameSite: sameSite, Secure: !isLocalhost
   })
   return support
-}
-
-function serialize (obj) {
-  return Object.keys(obj)
-    .map(function (key) {
-      if (obj[key] === true) {
-        return key
-      }
-      if (obj[key] === false) {
-        return null
-      }
-      return key + '=' + obj[key]
-    })
-    .filter(Boolean)
-    .join(';')
 }
 
 function randomString () {

--- a/vault/src/cookie-tools.js
+++ b/vault/src/cookie-tools.js
@@ -1,0 +1,27 @@
+exports.serialize = serialize
+
+function serialize (obj) {
+  return Object.keys(obj)
+    .map(function (key) {
+      if (obj[key] === true) {
+        return key
+      }
+      if (obj[key] === false) {
+        return null
+      }
+      return key + '=' + obj[key]
+    })
+    .filter(Boolean)
+    .join('; ')
+}
+
+exports.parse = parse
+
+function parse (cookieString) {
+  return cookieString.split(';')
+    .reduce(function (acc, pair) {
+      var chunks = pair.trim().split('=')
+      acc[chunks[0]] = chunks[1]
+      return acc
+    }, {})
+}

--- a/vault/src/cookie-tools.test.js
+++ b/vault/src/cookie-tools.test.js
@@ -1,0 +1,25 @@
+var assert = require('assert')
+
+var cookies = require('./cookie-tools')
+
+describe('src/cookie-tools.js', function () {
+  describe('cookies.serialize(obj)', function () {
+    it('serializes an object', function () {
+      var result = cookies.serialize({ ok: 'yes', other: 1 })
+      assert.strictEqual(result, 'ok=yes; other=1')
+    })
+
+    it('handles boolean flags correctly', function () {
+      var result1 = cookies.serialize({ ok: 'yes', Secure: true })
+      assert.strictEqual(result1, 'ok=yes; Secure')
+      var result2 = cookies.serialize({ ok: 'yes', Secure: false })
+      assert.strictEqual(result2, 'ok=yes')
+    })
+  })
+  describe('cookies.parse(cookieString)', function () {
+    it('parses key value pairs into an object', function () {
+      var result = cookies.parse('ok=yes; other=1')
+      assert.deepStrictEqual(result, { ok: 'yes', other: '1' })
+    })
+  })
+})

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -1,4 +1,5 @@
 var _ = require('underscore')
+var dexie = require('dexie')
 var startOfHour = require('date-fns/start_of_hour')
 var startOfDay = require('date-fns/start_of_day')
 var startOfWeek = require('date-fns/start_of_week')
@@ -12,6 +13,7 @@ var subHours = require('date-fns/sub_hours')
 var subDays = require('date-fns/sub_days')
 var subWeeks = require('date-fns/sub_weeks')
 var subMonths = require('date-fns/sub_months')
+var addDays = require('date-fns/add_days')
 
 var getDatabase = require('./database')
 var decryptEvents = require('./decrypt-events')
@@ -244,6 +246,28 @@ function getUserSecretWith (getDatabase) {
         if (result) {
           return result.value
         }
+        // This is a nifty hack to work around the following situation:
+        // When run in a non-Auditorium context, Safari throws an OpenFailedError
+        // when trying to access IndexedDB which is we we need to fall back to
+        // cookie based persistence for user secrets.
+        // When run in the context of the Auditorium, Safari allows IndexedDB
+        // to be accessed, but the lookup will not yield any result. This means
+        // we throw this error to make another lookup attempt before returning
+        // null.
+        throw new dexie.OpenFailedError('Trying to fall back to cookie based persistence.')
+      })
+      .catch(dexie.OpenFailedError, function () {
+        var cookieData = document.cookie.split(';')
+          .reduce(function (acc, pair) {
+            var chunks = pair.split('=')
+            acc[chunks[0]] = chunks[1]
+            return acc
+          }, {})
+
+        var lookupKey = TYPE_USER_SECRET + '-' + accountId
+        if (cookieData[lookupKey]) {
+          return JSON.parse(cookieData[lookupKey])
+        }
         return null
       })
   }
@@ -259,6 +283,20 @@ function putUserSecretWith (getDatabase) {
         type: TYPE_USER_SECRET,
         value: userSecret
       })
+      .catch(dexie.OpenFailedError, function () {
+        var isLocalhost = window.location.hostname === 'localhost'
+        var sameSite = isLocalhost ? 'Lax' : 'None'
+
+        var entry = {}
+        entry[TYPE_USER_SECRET + '-' + accountId] = JSON.stringify(userSecret)
+        Object.assign(entry, {
+          Path: '/vault',
+          SameSite: sameSite,
+          Secure: !isLocalhost,
+          expires: addDays(new Date(), 365).toUTCString()
+        })
+        document.cookie = serializeCookie(entry)
+      })
   }
 }
 
@@ -270,6 +308,14 @@ function deleteUserSecretWith (getDatabase) {
     return db.keys
       .where({ type: TYPE_USER_SECRET })
       .delete()
+      .catch(dexie.OpenFailedError, function () {
+        var entry = {}
+        entry[TYPE_USER_SECRET + '-' + accountId] = ''
+        Object.assign(entry, {
+          expires: new Date(0).toUTCString()
+        })
+        document.cookie = serializeCookie(entry)
+      })
   }
 }
 
@@ -357,4 +403,19 @@ function getEncryptedSecretsWith (getDatabase) {
       .equals(TYPE_ENCRYPTED_SECRET)
       .toArray()
   }
+}
+
+function serializeCookie (obj) {
+  return Object.keys(obj)
+    .map(function (key) {
+      if (obj[key] === true) {
+        return key
+      }
+      if (obj[key] === false) {
+        return null
+      }
+      return key + '=' + obj[key]
+    })
+    .filter(Boolean)
+    .join(';')
 }

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -13,7 +13,7 @@ var subHours = require('date-fns/sub_hours')
 var subDays = require('date-fns/sub_days')
 var subWeeks = require('date-fns/sub_weeks')
 var subMonths = require('date-fns/sub_months')
-var addDays = require('date-fns/add_days')
+var addHours = require('date-fns/add_hours')
 
 var getDatabase = require('./database')
 var decryptEvents = require('./decrypt-events')
@@ -288,7 +288,7 @@ function putUserSecretWith (getDatabase) {
           Path: '/vault',
           SameSite: sameSite,
           Secure: !isLocalhost,
-          expires: addDays(new Date(), 365).toUTCString()
+          expires: addHours(new Date(), 4464).toUTCString()
         })
         document.cookie = cookies.serialize(entry)
       })

--- a/vault/src/session-id.js
+++ b/vault/src/session-id.js
@@ -1,5 +1,7 @@
 var uuid = require('uuid/v4')
 
+var cookies = require('./cookie-tools')
+
 module.exports = getSessionId
 
 function getSessionId (accountId) {
@@ -9,20 +11,8 @@ function getSessionId (accountId) {
   var sessionId
   try {
     var lookupKey = 'session-' + accountId
-    var matches = document.cookie.split(';')
-      .map(function (chunk) {
-        return chunk.trim().split('=')
-      })
-      .filter(function (pair) {
-        return pair[0] === lookupKey
-      })
-      .map(function (pair) {
-        return pair[1]
-      })
-    sessionId = matches.length
-      ? matches[0]
-      : null
-
+    var cookieData = cookies.parse(document.cookie)
+    sessionId = cookieData[lookupKey] || null
     if (!sessionId) {
       sessionId = uuid()
       document.cookie = [lookupKey, sessionId].join('=') + '; SameSite=Lax'

--- a/vault/src/user-consent.js
+++ b/vault/src/user-consent.js
@@ -1,6 +1,8 @@
 var html = require('nanohtml')
 var raw = require('nanohtml/raw')
 
+var cookies = require('./cookie-tools')
+
 var ALLOW = 'allow'
 var DENY = 'deny'
 var COOKIE_NAME = 'consent'
@@ -263,20 +265,5 @@ function setConsentStatus (status) {
     SameSite: isLocalhost ? 'Lax' : 'None',
     Secure: !isLocalhost
   }
-  document.cookie = serialize(cookie)
-}
-
-function serialize (obj) {
-  return Object.keys(obj)
-    .map(function (key) {
-      if (obj[key] === true) {
-        return key
-      }
-      if (obj[key] === false) {
-        return null
-      }
-      return [key, '=', obj[key]].join('')
-    })
-    .filter(Boolean)
-    .join(';')
+  document.cookie = cookies.serialize(cookie)
 }

--- a/vault/src/user-consent.js
+++ b/vault/src/user-consent.js
@@ -261,6 +261,8 @@ function setConsentStatus (status) {
   var cookie = {
     consent: status,
     expires: expires.toUTCString(),
+    // it is important not to lock this cookie down to `/vault` as the
+    // server checks for it before accepting events
     path: '/',
     SameSite: isLocalhost ? 'Lax' : 'None',
     Secure: !isLocalhost

--- a/vault/src/user-secret.js
+++ b/vault/src/user-secret.js
@@ -24,11 +24,13 @@ function ensureUserSecretWith (api, queries) {
           return jwk
         }
         return exchangeUserSecret(api, accountId)
-          .then(function (jwk) {
-            return queries.putUserSecret(accountId, jwk)
-              .then(function () {
-                return jwk
-              })
+      })
+      .then(function (jwk) {
+        // persisting the secret every time we look it up
+        // ensures it does not expire while in use
+        return queries.putUserSecret(accountId, jwk)
+          .then(function () {
+            return jwk
           })
       })
   }

--- a/vault/src/user-secret.js
+++ b/vault/src/user-secret.js
@@ -24,11 +24,11 @@ function ensureUserSecretWith (api, queries) {
           return jwk
         }
         return exchangeUserSecret(api, accountId)
-      })
-      .then(function (jwk) {
-        return queries.putUserSecret(accountId, jwk)
-          .then(function () {
-            return jwk
+          .then(function (jwk) {
+            return queries.putUserSecret(accountId, jwk)
+              .then(function () {
+                return jwk
+              })
           })
       })
   }


### PR DESCRIPTION
This allows users on Safari browsers to store their keys client side by implementing a fallback storage using Cookies. It is important to lock this cookie down to the `/vault` path so that it does not leak into the actual server application.