### PR TITLE
Implement proper sendmail fallback

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -145,6 +145,7 @@ func main() {
 				router.WithTemplate(tpl),
 				router.WithConfig(cfg),
 				router.WithFS(fs),
+				router.WithMailer(cfg.NewMailer()),
 			),
 		}
 		go func() {
@@ -214,6 +215,7 @@ func main() {
 				router.WithTemplate(tpl),
 				router.WithConfig(cfg),
 				router.WithFS(fs),
+				router.WithMailer(cfg.NewMailer()),
 			),
 		}
 		go func() {

--- a/server/mailer/localmailer/local.go
+++ b/server/mailer/localmailer/local.go
@@ -18,7 +18,7 @@ func (*localMailer) Send(from, to, subject, body string) error {
 	fmt.Println("=========")
 	fmt.Printf("From: %s\n", from)
 	fmt.Printf("To: %s\n", to)
-	fmt.Printf("Subject: %s\n", to)
+	fmt.Printf("Subject: %s\n", subject)
 	fmt.Printf("Body: %s\n", body)
 	fmt.Println("=========")
 	return nil

--- a/server/mailer/sendmailmailer/mailer.go
+++ b/server/mailer/sendmailmailer/mailer.go
@@ -1,0 +1,79 @@
+package sendmailmailer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/go-gomail/gomail"
+	"github.com/offen/offen/server/mailer"
+)
+
+// New creates a new Mailer that sends email using a local sendmail installation
+func New() mailer.Mailer {
+	return &sendmailMailer{}
+}
+
+type sendmailMailer struct{}
+
+func (s *sendmailMailer) Send(from, to, subject, body string) error {
+	m := gomail.NewMessage()
+	m.SetHeader("From", from)
+	m.SetHeader("To", to)
+	m.SetHeader("Subject", subject)
+	m.SetBody("text/plain", body)
+
+	if err := submitMail(m); err != nil {
+		return fmt.Errorf("sendmailmailer: error sending: %w", err)
+	}
+	return nil
+}
+
+func submitMail(m *gomail.Message) error {
+	// see: https://stackoverflow.com/a/35521846/797194
+	bin, err := lookupSendmail()
+	if err != nil {
+		return fmt.Errorf("sendmailmailer: error looking up sendmail: %w", err)
+	}
+
+	cmd := exec.Command(bin, "-t")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	pw, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("sendmailmailer: error connecting to pipe: %w", err)
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("sendmailmailer: error starting command: %w", err)
+	}
+
+	var errs [3]error
+	_, errs[0] = m.WriteTo(pw)
+	errs[1] = pw.Close()
+	errs[2] = cmd.Wait()
+	for _, err = range errs {
+		if err != nil {
+			return fmt.Errorf("sendmailmailer: error sending email: %w", err)
+		}
+	}
+	return nil
+}
+
+func lookupSendmail() (string, error) {
+	if runtime.GOOS == "windows" {
+		return "", errors.New("sendmailmailer: using sendmail on windows is currently not supported")
+	}
+	cmd := exec.Command("which", "sendmail")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("sendmailmailer: error looking up sendmail binary: %w", err)
+	}
+	return string(bytes.TrimSpace(out)), nil
+
+}

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -124,6 +124,13 @@ func WithFS(fs http.FileSystem) Config {
 	}
 }
 
+// WithMailer attaches a mailer for sending transactional email
+func WithMailer(m mailer.Mailer) Config {
+	return func(r *router) {
+		r.mailer = m
+	}
+}
+
 // New creates a new application router that reads and writes data
 // to the given database implementation. In the context of the application
 // this expects to be the only top level router in charge of handling all
@@ -135,7 +142,6 @@ func New(opts ...Config) http.Handler {
 	}
 
 	rt.cookieSigner = securecookie.New(rt.config.Secrets.CookieExchange.Bytes(), nil)
-	rt.mailer = rt.config.NewMailer()
 
 	optin := optinMiddleware(optinKey, optinValue)
 	userCookie := userCookieMiddleware(cookieKey, contextKeyCookie)


### PR DESCRIPTION
Adds a proper sendmail fallback for when SMTP is not configured. This **does not work on Windows**.