### PR TITLE
Use deploy target value to specify env overrides

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -137,12 +136,13 @@ func New(populateMissing bool, override string) (*Config, error) {
 		return &c, fmt.Errorf("config: error processing configuration: %w", err)
 	}
 
-	if c.Server.UseNakedPort {
-		port, portErr := strconv.Atoi(os.Getenv("PORT"))
-		if portErr != nil {
-			return &c, fmt.Errorf("config: error reading naked port: %w", portErr)
+	// some deploy targets have custom overrides for creating the
+	// runtime configuration
+	switch c.App.DeployTarget {
+	case DeployTargetHeroku:
+		if err := applyHerokuSpecificOverrides(&c); err != nil {
+			return &c, fmt.Errorf("config: error applying deploy target specific rules: %w", err)
 		}
-		c.Server.Port = port
 	}
 
 	if c.Secrets.CookieExchange.IsZero() {

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -7,12 +7,7 @@ package config
 // source values from the application environment at runtime.
 type Config struct {
 	Server struct {
-		Port int `default:"3000"`
-		// Some runtimes (e.g. Heroku) require the usage of PORT for specifying
-		// the TCP port to bind to, no matter what. As a workaround, these environments
-		// can set OFFEN_SERVER_USENAKEDPORT to make the application use the
-		// port given by PORT.
-		UseNakedPort     bool `default:"false"`
+		Port             int  `default:"3000"`
 		ReverseProxy     bool `default:"false"`
 		SSLCertificate   EnvString
 		SSLKey           EnvString
@@ -24,11 +19,12 @@ type Config struct {
 		ConnectionString EnvString `default:"/var/opt/offen/offen.db"`
 	}
 	App struct {
-		Development bool     `default:"false"`
-		LogLevel    LogLevel `default:"info"`
-		SingleNode  bool     `default:"true"`
-		Locale      Locale   `default:"en"`
-		RootAccount string
+		Development  bool     `default:"false"`
+		LogLevel     LogLevel `default:"info"`
+		SingleNode   bool     `default:"true"`
+		Locale       Locale   `default:"en"`
+		RootAccount  string
+		DeployTarget DeployTarget
 	}
 	Secrets struct {
 		CookieExchange Bytes

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -8,11 +8,6 @@ package config
 type Config struct {
 	Server struct {
 		Port int `default:"8080"`
-		// Some runtimes (e.g. Heroku) require the usage of PORT for specifying
-		// the TCP port to bind to, no matter what. As a workaround, these environments
-		// can set OFFEN_SERVER_USENAKEDPORT to make the application use the
-		// port given by PORT.
-		UseNakedPort     bool `default:"false"`
 		ReverseProxy     bool `default:"false"`
 		SSLCertificate   EnvString
 		SSLKey           EnvString
@@ -29,6 +24,7 @@ type Config struct {
 		SingleNode  bool     `default:"true"`
 		Locale      Locale   `default:"en"`
 		RootAccount string
+		DeployTarget DeployTarget
 	}
 	Secrets struct {
 		CookieExchange Bytes

--- a/server/config/deploytarget.go
+++ b/server/config/deploytarget.go
@@ -1,0 +1,27 @@
+package config
+
+import "fmt"
+
+// DeployTarget identifies a known deploy target.
+type DeployTarget string
+
+// this defines all the known deploy targets that have
+// defined exceptions for generating a runtime config.
+const (
+	DeployTargetHeroku DeployTarget = "heroku"
+)
+
+// Decode validates and assigns v.
+func (d *DeployTarget) Decode(v string) error {
+	switch v {
+	case string(DeployTargetHeroku):
+		*d = DeployTargetHeroku
+	default:
+		return fmt.Errorf("config: unknown or unsupported deploy target %s", v)
+	}
+	return nil
+}
+
+func (d *DeployTarget) String() string {
+	return string(*d)
+}

--- a/server/config/overrides.go
+++ b/server/config/overrides.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+type herokuRuntime struct {
+	DatabaseURL string `split_words:"true"`
+	Port        int
+}
+
+func applyHerokuSpecificOverrides(c *Config) error {
+	var overrides herokuRuntime
+	if err := envconfig.Process("", &overrides); err != nil {
+		return fmt.Errorf("config: error applying heroku specific runtime overrides: %w", err)
+	}
+	if overrides.DatabaseURL != "" {
+		c.Database.ConnectionString = EnvString(overrides.DatabaseURL)
+	}
+	if overrides.Port != 0 {
+		c.Server.Port = overrides.Port
+	}
+	return nil
+}


### PR DESCRIPTION
This introduces a `OFFEN_APP_DEPLOYTARGET` configuration that can be used to target runtimes (e.g. Heroku) that require special adjustments about how configuration is being picked up.