### PR TITLE
Retire accounts

### DIFF
--- a/auditorium/src/action-creators/management.js
+++ b/auditorium/src/action-creators/management.js
@@ -104,3 +104,38 @@ exports.createAccount = (payload, onSuccessMessage, onFailureMessage) => (dispat
     })
     .catch((err) => dispatch(errors.unrecoverable(err)))
 }
+
+exports.retireAccount = (payload, onSuccessMessage, onFailureMessage) => (dispatch, getState, postMessage) => {
+  dispatch({
+    type: 'RETIRE_ACCOUNT_REQUEST',
+    payload: null
+  })
+
+  return postMessage({
+    type: 'RETIRE_ACCOUNT',
+    payload: payload
+  })
+    .then(function (response) {
+      switch (response.type) {
+        case 'RETIRE_ACCOUNT_SUCCESS':
+          dispatch({
+            type: 'RETIRE_ACCOUNT_SUCCESS',
+            payload: {
+              flash: onSuccessMessage
+            }
+          })
+          return
+        case 'RETIRE_ACCOUNT_FAILURE':
+          dispatch({
+            type: 'RETIRE_ACCOUNT_FAILURE',
+            payload: {
+              flash: onFailureMessage
+            }
+          })
+          return
+        default:
+          throw new Error('Unhandled response of type "' + response.type + '"')
+      }
+    })
+    .catch((err) => dispatch(errors.unrecoverable(err)))
+}

--- a/auditorium/src/action-creators/management.test.js
+++ b/auditorium/src/action-creators/management.test.js
@@ -350,4 +350,119 @@ describe('src/action-creators/management.js', function () {
         })
     })
   })
+
+  describe('retireAccount(payload, onSuccessMessage, onFailureMessage)', function () {
+    it('handles successful responses', function () {
+      const mockPostMessage = sinon.stub()
+      mockPostMessage.resolves({ type: 'RETIRE_ACCOUNT_SUCCESS', payload: null })
+      const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
+      const store = mockStore({})
+      return store.dispatch(management.retireAccount('account-id', 'on-success', 'on-failure'))
+        .then(function () {
+          const actions = store.getActions()
+          assert.strictEqual(actions.length, 2)
+
+          assert(mockPostMessage.calledOnce)
+          assert(mockPostMessage.calledWith({
+            type: 'RETIRE_ACCOUNT',
+            payload: 'account-id'
+          }))
+
+          assert.deepStrictEqual(actions[0], {
+            type: 'RETIRE_ACCOUNT_REQUEST',
+            payload: null
+          })
+
+          assert.deepStrictEqual(actions[1], {
+            type: 'RETIRE_ACCOUNT_SUCCESS',
+            payload: {
+              flash: 'on-success'
+            }
+          })
+        })
+    })
+
+    it('handles unsuccessful responses', function () {
+      const mockPostMessage = sinon.stub()
+      mockPostMessage.resolves({ type: 'RETIRE_ACCOUNT_FAILURE', payload: null })
+      const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
+      const store = mockStore({})
+      return store.dispatch(management.retireAccount('account-id', 'on-success', 'on-failure'))
+        .then(function () {
+          const actions = store.getActions()
+          assert.strictEqual(actions.length, 2)
+
+          assert(mockPostMessage.calledOnce)
+          assert(mockPostMessage.calledWith({
+            type: 'RETIRE_ACCOUNT',
+            payload: 'account-id'
+          }))
+
+          assert.deepStrictEqual(actions[0], {
+            type: 'RETIRE_ACCOUNT_REQUEST',
+            payload: null
+          })
+
+          assert.deepStrictEqual(actions[1], {
+            type: 'RETIRE_ACCOUNT_FAILURE',
+            payload: {
+              flash: 'on-failure'
+            }
+          })
+        })
+    })
+
+    it('handles unknown actions', function () {
+      const mockPostMessage = sinon.stub()
+      mockPostMessage.resolves({ type: 'ZALGO_ACTION', payload: 'boo!' })
+      const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
+      const store = mockStore({})
+
+      return store.dispatch(management.retireAccount('account-id', 'on-success', 'on-failure'))
+        .then(function () {
+          const actions = store.getActions()
+          assert.strictEqual(actions.length, 2)
+
+          assert(mockPostMessage.calledOnce)
+          assert(mockPostMessage.calledWith({
+            type: 'RETIRE_ACCOUNT',
+            payload: 'account-id'
+          }))
+
+          assert.deepStrictEqual(actions[0], {
+            type: 'RETIRE_ACCOUNT_REQUEST',
+            payload: null
+          })
+
+          assert.strictEqual(actions[1].type, 'UNRECOVERABLE_ERROR')
+        })
+    })
+
+    it('handles global errors', function () {
+      const mockPostMessage = sinon.stub()
+      mockPostMessage.rejects(new Error('Did not work!'))
+      const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
+      const store = mockStore({})
+
+      return store.dispatch(management.retireAccount('account-id', 'on-success', 'on-failure'))
+        .then(function () {
+          const actions = store.getActions()
+          assert.strictEqual(actions.length, 2)
+
+          assert(mockPostMessage.calledOnce)
+          assert(mockPostMessage.calledWith({
+            type: 'RETIRE_ACCOUNT',
+            payload: 'account-id'
+          }))
+
+          assert.deepStrictEqual(actions[0], {
+            type: 'RETIRE_ACCOUNT_REQUEST',
+            payload: null
+          })
+
+          assert.strictEqual(actions[1].type, 'UNRECOVERABLE_ERROR')
+          assert.strictEqual(actions[1].payload.message, 'Did not work!')
+        })
+    })
+  })
 })

--- a/auditorium/src/middleware/redirect.js
+++ b/auditorium/src/middleware/redirect.js
@@ -4,6 +4,10 @@ module.exports = (store) => (next) => (action) => {
   switch (action.type) {
     case 'LOGIN_SUCCESS':
       next(action)
+      if (!action.payload.accounts) {
+        route('/console/')
+        return
+      }
       route(`/auditorium/${action.payload.accounts[0].accountId}`)
       return
     case 'AUTHENTICATION_FAILURE':

--- a/auditorium/src/middleware/redirect.js
+++ b/auditorium/src/middleware/redirect.js
@@ -11,6 +11,7 @@ module.exports = (store) => (next) => (action) => {
     case 'RESET_PASSWORD_SUCCESS':
     case 'CHANGE_CREDENTIALS_SUCCESS':
     case 'CREATE_ACCOUNT_SUCCESS':
+    case 'RETIRE_ACCOUNT_SUCCESS':
     case 'JOIN_SUCCESS':
       next(action)
       route('/login/')

--- a/auditorium/src/middleware/redirect.js
+++ b/auditorium/src/middleware/redirect.js
@@ -4,7 +4,7 @@ module.exports = (store) => (next) => (action) => {
   switch (action.type) {
     case 'LOGIN_SUCCESS':
       next(action)
-      if (!action.payload.accounts) {
+      if (!Array.isArray(action.payload.accounts) || !action.payload.accounts.length) {
         route('/console/')
         return
       }

--- a/auditorium/src/reducers/flash.js
+++ b/auditorium/src/reducers/flash.js
@@ -15,6 +15,7 @@ module.exports = (state = null, action) => {
     case 'RESET_PASSWORD_SUCCESS':
     case 'RESET_PASSWORD_FAILURE':
     case 'QUERY_FAILURE':
+    case 'RETIRE_ACCOUNT_SUCCESS':
     case 'RETIRE_ACCOUNT_FAILURE':
       if (action.payload && action.payload.flash) {
         return action.payload.flash

--- a/auditorium/src/reducers/flash.js
+++ b/auditorium/src/reducers/flash.js
@@ -15,7 +15,11 @@ module.exports = (state = null, action) => {
     case 'RESET_PASSWORD_SUCCESS':
     case 'RESET_PASSWORD_FAILURE':
     case 'QUERY_FAILURE':
-      return action.payload && action.payload.flash
+    case 'RETIRE_ACCOUNT_FAILURE':
+      if (action.payload && action.payload.flash) {
+        return action.payload.flash
+      }
+      return state
     case 'AUTHENTICATION_SUCCESS':
     case 'QUERY_SUCCESS':
       return null

--- a/auditorium/src/reducers/flash.test.js
+++ b/auditorium/src/reducers/flash.test.js
@@ -156,5 +156,25 @@ describe('src/reducers/flash.js', function () {
       })
       assert.strictEqual(next, 'msg')
     })
+
+    it('handles RETIRE_ACCOUNT_SUCCESS', function () {
+      const next = flash(null, {
+        type: 'RETIRE_ACCOUNT_SUCCESS',
+        payload: {
+          flash: 'msg'
+        }
+      })
+      assert.strictEqual(next, 'msg')
+    })
+
+    it('handles RETIRE_ACCOUNT_FAILURE', function () {
+      const next = flash(null, {
+        type: 'RETIRE_ACCOUNT_FAILURE',
+        payload: {
+          flash: 'msg'
+        }
+      })
+      assert.strictEqual(next, 'msg')
+    })
   })
 })

--- a/auditorium/src/views/auditorium.js
+++ b/auditorium/src/views/auditorium.js
@@ -19,6 +19,7 @@ const Share = require('./components/auditorium/share')
 const GoSettings = require('./components/auditorium/go-settings')
 const LoadingOverlay = require('./components/auditorium/loading-overlay')
 const AccountPicker = require('./components/auditorium/account-picker')
+const RetireAccount = require('./components/auditorium/retire-account')
 const Live = require('./components/auditorium/live')
 const model = require('./../action-creators/model')
 const consent = require('./../action-creators/consent-status')
@@ -27,7 +28,7 @@ const management = require('./../action-creators/management')
 
 const AuditoriumView = (props) => {
   const { matches, authenticatedUser, model, isOperator, consentStatus, stale } = props
-  const { handlePurge, handleQuery, expressConsent, getConsentStatus, handleInvite, handleValidationError } = props
+  const { handlePurge, handleQuery, expressConsent, getConsentStatus, handleInvite, handleValidationError, handleRetire } = props
   const { accountId, range, resolution } = matches
 
   useEffect(function fetchData () {
@@ -166,6 +167,14 @@ const AuditoriumView = (props) => {
               </div>
             </div>
             <div class='flex flex-column flex-row-l'>
+              <div class='w-100 flex br0 br2-ns mb2'>
+                <RetireAccount
+                  account={model.account}
+                  onRetire={handleRetire}
+                />
+              </div>
+            </div>
+            <div class='flex flex-column flex-row-l'>
               <div class='w-100 flex br0 br2-ns'>
                 <GoSettings />
               </div>
@@ -190,7 +199,8 @@ const mapDispatchToProps = {
   getConsentStatus: consent.get,
   expressConsent: consent.express,
   handleValidationError: errors.formValidation,
-  handleInvite: management.inviteUser
+  handleInvite: management.inviteUser,
+  handleRetire: management.retireAccount
 }
 
 const ConnectedAuditoriumView = connect(mapStateToProps, mapDispatchToProps)(AuditoriumView)

--- a/auditorium/src/views/components/_shared/account-picker.js
+++ b/auditorium/src/views/components/_shared/account-picker.js
@@ -4,25 +4,39 @@ const { h } = require('preact')
 const AccountPicker = (props) => {
   const { accounts, selectedId, headline } = props
 
-  const availableAccounts = accounts
-    .slice()
-    .sort(function (a, b) {
-      return a.accountName.localeCompare(b.accountName)
-    })
-    .map(function (account, idx) {
-      let buttonClass = 'link dim dib pv2 mt1 mb2 mr3 mid-gray'
-      if (account.accountId === selectedId) {
-        buttonClass = 'b link dim dib bt bw2 b--mid-gray pv2 mb2 mr3 mid-gray'
-      }
+  let body = null
+  if (!Array.isArray(accounts) || !accounts.length) {
+    body = (
+      <p class='ma0 mt2'>
+        {__('You currently do not have any active accounts. You can create one below.')}
+      </p>
+    )
+  } else {
+    const availableAccounts = accounts
+      .slice()
+      .sort(function (a, b) {
+        return a.accountName.localeCompare(b.accountName)
+      })
+      .map(function (account, idx) {
+        let buttonClass = 'link dim dib pv2 mt1 mb2 mr3 mid-gray'
+        if (account.accountId === selectedId) {
+          buttonClass = 'b link dim dib bt bw2 b--mid-gray pv2 mb2 mr3 mid-gray'
+        }
 
-      return (
-        <li class='bt b--moon-gray' key={idx}>
-          <a href={`/auditorium/${account.accountId}/`} class={buttonClass}>
-            {account.accountName}
-          </a>
-        </li>
-      )
-    })
+        return (
+          <li class='bt b--moon-gray' key={idx}>
+            <a href={`/auditorium/${account.accountId}/`} class={buttonClass}>
+              {account.accountName}
+            </a>
+          </li>
+        )
+      })
+    body = (
+      <ul class='flex flex-wrap list pl0 mt0 mb3 grow-list b--moon-gray'>
+        {availableAccounts}
+      </ul>
+    )
+  }
 
   return (
     <div class='flex-auto bg-black-05 pa3'>
@@ -32,9 +46,7 @@ const AccountPicker = (props) => {
           __html: headline
         }}
       />
-      <ul class='flex flex-wrap list pl0 mt0 mb3 grow-list b--moon-gray'>
-        {availableAccounts}
-      </ul>
+      {body}
     </div>
   )
 }

--- a/auditorium/src/views/components/auditorium/retire-account.js
+++ b/auditorium/src/views/components/auditorium/retire-account.js
@@ -1,0 +1,53 @@
+/** @jsx h */
+const { h } = require('preact')
+
+const Collapsible = require('./../_shared/collapsible')
+const classnames = require('classnames')
+
+const GoSettings = (props) => {
+  const { account } = props
+  const handleClick = () => {
+    props.onRetire(
+      { accountId: account.accountId },
+      __('The account has been retired successfully. Log in again to continue.'),
+      __('There was an error retiring the account, please try again.')
+    )
+  }
+  return (
+    <div class='pa3 bg-black-05 flex-auto'>
+      <Collapsible
+        header={(props) => {
+          const { isCollapsed, handleToggle } = props
+          return (
+            <div class='flex justify-between pointer' onclick={handleToggle}>
+              <h4 class='f4 normal ma0'>
+                {__('Retire account')}
+              </h4>
+              <a role='button' class={classnames('dib', 'label-toggle', isCollapsed ? 'label-toggle--rotate' : null)} />
+            </div>
+          )
+        }}
+        body={(props) => {
+          return (
+            <div class='mw6 center mb4 mt3'>
+              <p class='ma0 mb1'>
+                {__('If you retire the account "%s", it will not appear in your statistics anymore. Users will be able to access and manage their data for the account for another 6 months until data expires.', account.name)}
+              </p>
+              <p class='ma0 mb3'>
+                {__('This action cannot be undone.')}
+              </p>
+              <button
+                class='w-100 w-auto-ns f5 tc link dim bn dib br1 ph3 pv2 mr0 mr2-ns mb3 mb0-ns white bg-mid-gray'
+                onclick={handleClick}
+              >
+                {__('Retire account')}
+              </button>
+            </div>
+          )
+        }}
+      />
+    </div>
+  )
+}
+
+module.exports = GoSettings

--- a/auditorium/src/views/components/auditorium/retire-account.js
+++ b/auditorium/src/views/components/auditorium/retire-account.js
@@ -4,7 +4,7 @@ const { h } = require('preact')
 const Collapsible = require('./../_shared/collapsible')
 const classnames = require('classnames')
 
-const GoSettings = (props) => {
+const RetireAccount = (props) => {
   const { account } = props
   const handleClick = () => {
     props.onRetire(
@@ -50,4 +50,4 @@ const GoSettings = (props) => {
   )
 }
 
-module.exports = GoSettings
+module.exports = RetireAccount

--- a/auditorium/src/views/components/auditorium/retire-account.js
+++ b/auditorium/src/views/components/auditorium/retire-account.js
@@ -37,7 +37,7 @@ const GoSettings = (props) => {
                 {__('This action cannot be undone.')}
               </p>
               <button
-                class='w-100 w-auto-ns f5 tc link dim bn dib br1 ph3 pv2 mr0 mr2-ns mb3 mb0-ns white bg-mid-gray'
+                class='pointer w-100 w-auto-ns f5 tc link dim bn dib br1 ph3 pv2 mr0 mr2-ns mb3 mb0-ns white bg-mid-gray'
                 onclick={handleClick}
               >
                 {__('Retire account')}

--- a/auditorium/src/views/console.js
+++ b/auditorium/src/views/console.js
@@ -27,12 +27,16 @@ const ConsoleView = (props) => {
           accounts={props.authenticatedUser.accounts}
         />
       </div>
-      <div class='w-100 br0 br2-ns mb2'>
-        <ShareAccounts
-          onShare={props.handleInvite}
-          onValidationError={props.handleValidationError}
-        />
-      </div>
+      {Array.isArray(props.authenticatedUser.accounts) && props.authenticatedUser.accounts.length
+        ? (
+          <div class='w-100 br0 br2-ns mb2'>
+            <ShareAccounts
+              onShare={props.handleInvite}
+              onValidationError={props.handleValidationError}
+            />
+          </div>
+        )
+        : null}
       <div class='w-100 br0 br2-ns mb2'>
         <CreateAccount
           onCreateAccount={props.handleCreateAccount}

--- a/server/persistence/accounts.go
+++ b/server/persistence/accounts.go
@@ -204,3 +204,11 @@ func (p *persistenceLayer) CreateAccount(name, emailAddress, password string) er
 
 	return nil
 }
+
+func (p *persistenceLayer) RetireAccount(accountID string) error {
+	err := p.dal.RetireAccount(RetireAccountQueryByID(accountID))
+	if err != nil {
+		return fmt.Errorf("persistence: error retiring account %s: %w", accountID, err)
+	}
+	return nil
+}

--- a/server/persistence/accounts_test.go
+++ b/server/persistence/accounts_test.go
@@ -227,8 +227,24 @@ type mockRetireAccountDatabase struct {
 	result error
 }
 
-func (m *mockRetireAccountDatabase) RetireAccount(interface{}) error {
+func (m *mockRetireAccountDatabase) UpdateAccount(interface{}) error {
 	return m.result
+}
+
+func (m *mockRetireAccountDatabase) DeleteAccountUserRelationships(interface{}) error {
+	return m.result
+}
+
+func (m *mockRetireAccountDatabase) Commit() error {
+	return nil
+}
+
+func (m *mockRetireAccountDatabase) Rollback() error {
+	return nil
+}
+
+func (m *mockRetireAccountDatabase) Transaction() (Transaction, error) {
+	return m, nil
 }
 
 func TestPersistenceLayer_RetireAccount(t *testing.T) {

--- a/server/persistence/accounts_test.go
+++ b/server/persistence/accounts_test.go
@@ -224,15 +224,17 @@ func TestPersistenceLayer_AssociateUserSecret(t *testing.T) {
 
 type mockRetireAccountDatabase struct {
 	DataAccessLayer
-	result error
+	updateErr error
+	deleteErr error
+	txnErr    error
 }
 
 func (m *mockRetireAccountDatabase) UpdateAccount(interface{}) error {
-	return m.result
+	return m.updateErr
 }
 
 func (m *mockRetireAccountDatabase) DeleteAccountUserRelationships(interface{}) error {
-	return m.result
+	return m.deleteErr
 }
 
 func (m *mockRetireAccountDatabase) Commit() error {
@@ -244,7 +246,7 @@ func (m *mockRetireAccountDatabase) Rollback() error {
 }
 
 func (m *mockRetireAccountDatabase) Transaction() (Transaction, error) {
-	return m, nil
+	return m, m.txnErr
 }
 
 func TestPersistenceLayer_RetireAccount(t *testing.T) {
@@ -254,9 +256,23 @@ func TestPersistenceLayer_RetireAccount(t *testing.T) {
 		expectError bool
 	}{
 		{
-			"error",
+			"update error",
 			&mockRetireAccountDatabase{
-				result: errors.New("did not work"),
+				updateErr: errors.New("did not work"),
+			},
+			true,
+		},
+		{
+			"delete error",
+			&mockRetireAccountDatabase{
+				deleteErr: errors.New("did not work"),
+			},
+			true,
+		},
+		{
+			"transaction error",
+			&mockRetireAccountDatabase{
+				txnErr: errors.New("did not work"),
 			},
 			true,
 		},

--- a/server/persistence/accounts_test.go
+++ b/server/persistence/accounts_test.go
@@ -224,17 +224,22 @@ func TestPersistenceLayer_AssociateUserSecret(t *testing.T) {
 
 type mockRetireAccountDatabase struct {
 	DataAccessLayer
-	updateErr error
-	deleteErr error
-	txnErr    error
+	updateErr         error
+	deleteErr         error
+	txnErr            error
+	findAccountResult Account
+	findAccountErr    error
 }
 
-func (m *mockRetireAccountDatabase) UpdateAccount(interface{}) error {
+func (m *mockRetireAccountDatabase) UpdateAccount(*Account) error {
 	return m.updateErr
 }
 
 func (m *mockRetireAccountDatabase) DeleteAccountUserRelationships(interface{}) error {
 	return m.deleteErr
+}
+func (m *mockRetireAccountDatabase) FindAccount(interface{}) (Account, error) {
+	return m.findAccountResult, m.findAccountErr
 }
 
 func (m *mockRetireAccountDatabase) Commit() error {

--- a/server/persistence/accounts_test.go
+++ b/server/persistence/accounts_test.go
@@ -221,3 +221,42 @@ func TestPersistenceLayer_AssociateUserSecret(t *testing.T) {
 		})
 	}
 }
+
+type mockRetireAccountDatabase struct {
+	DataAccessLayer
+	result error
+}
+
+func (m *mockRetireAccountDatabase) RetireAccount(interface{}) error {
+	return m.result
+}
+
+func TestPersistenceLayer_RetireAccount(t *testing.T) {
+	tests := []struct {
+		name        string
+		db          *mockRetireAccountDatabase
+		expectError bool
+	}{
+		{
+			"error",
+			&mockRetireAccountDatabase{
+				result: errors.New("did not work"),
+			},
+			true,
+		},
+		{
+			"ok",
+			&mockRetireAccountDatabase{},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := persistenceLayer{test.db}
+			err := p.RetireAccount("account-a")
+			if test.expectError != (err != nil) {
+				t.Errorf("Unexpected error value: %v", err)
+			}
+		})
+	}
+}

--- a/server/persistence/dal.go
+++ b/server/persistence/dal.go
@@ -11,7 +11,7 @@ type DataAccessLayer interface {
 	FindSecret(interface{}) (Secret, error)
 	DeleteSecret(interface{}) error
 	CreateAccount(*Account) error
-	UpdateAccount(interface{}) error
+	UpdateAccount(*Account) error
 	FindAccount(interface{}) (Account, error)
 	FindAccounts(interface{}) ([]Account, error)
 	CreateAccountUser(*AccountUser) error

--- a/server/persistence/dal.go
+++ b/server/persistence/dal.go
@@ -11,7 +11,7 @@ type DataAccessLayer interface {
 	FindSecret(interface{}) (Secret, error)
 	DeleteSecret(interface{}) error
 	CreateAccount(*Account) error
-	RetireAccount(interface{}) error
+	UpdateAccount(interface{}) error
 	FindAccount(interface{}) (Account, error)
 	FindAccounts(interface{}) ([]Account, error)
 	CreateAccountUser(*AccountUser) error
@@ -21,6 +21,7 @@ type DataAccessLayer interface {
 	CreateAccountUserRelationship(*AccountUserRelationship) error
 	UpdateAccountUserRelationship(*AccountUserRelationship) error
 	FindAccountUserRelationships(interface{}) ([]AccountUserRelationship, error)
+	DeleteAccountUserRelationships(interface{}) error
 	Transaction() (Transaction, error)
 	ApplyMigrations() error
 	DropAll() error
@@ -89,6 +90,10 @@ type FindAccountUserQueryByAccountUserIDIncludeRelationships string
 // FindAccountUserRelationshipsQueryByAccountUserID requests all relationships for the user
 // with the given account user ID.
 type FindAccountUserRelationshipsQueryByAccountUserID string
+
+// DeleteAccountUserRelationshipsQueryByAccountID requests deletion of all relationships
+// with the given account id.
+type DeleteAccountUserRelationshipsQueryByAccountID string
 
 // FindAccountUsersQueryAllAccountUsers requests all account users.
 type FindAccountUsersQueryAllAccountUsers struct {

--- a/server/persistence/dal.go
+++ b/server/persistence/dal.go
@@ -11,6 +11,7 @@ type DataAccessLayer interface {
 	FindSecret(interface{}) (Secret, error)
 	DeleteSecret(interface{}) error
 	CreateAccount(*Account) error
+	RetireAccount(interface{}) error
 	FindAccount(interface{}) (Account, error)
 	FindAccounts(interface{}) ([]Account, error)
 	CreateAccountUser(*AccountUser) error
@@ -93,6 +94,9 @@ type FindAccountUserRelationshipsQueryByAccountUserID string
 type FindAccountUsersQueryAllAccountUsers struct {
 	IncludeRelationships bool
 }
+
+// RetireAccountQueryByID requests the account of the given id to be retired.
+type RetireAccountQueryByID string
 
 // Transaction is a data access layer that does not persist data until commit
 // is called. In case rollback is called before, the underlying database will

--- a/server/persistence/login.go
+++ b/server/persistence/login.go
@@ -41,6 +41,10 @@ func (p *persistenceLayer) Login(email, password string) (LoginResult, error) {
 			return LoginResult{}, fmt.Errorf(`persistence: error looking up account with id "%s": %w`, relationship.AccountID, err)
 		}
 
+		if account.Retired {
+			continue
+		}
+
 		result := LoginAccountResult{
 			AccountName:      account.Name,
 			AccountID:        relationship.AccountID,

--- a/server/persistence/login.go
+++ b/server/persistence/login.go
@@ -41,10 +41,6 @@ func (p *persistenceLayer) Login(email, password string) (LoginResult, error) {
 			return LoginResult{}, fmt.Errorf(`persistence: error looking up account with id "%s": %w`, relationship.AccountID, err)
 		}
 
-		if account.Retired {
-			continue
-		}
-
 		result := LoginAccountResult{
 			AccountName:      account.Name,
 			AccountID:        relationship.AccountID,

--- a/server/persistence/persistence.go
+++ b/server/persistence/persistence.go
@@ -12,6 +12,7 @@ type Service interface {
 	Query(Query) (map[string][]EventResult, error)
 	GetAccount(accountID string, events bool, eventsSince string) (AccountResult, error)
 	CreateAccount(name, creatorEmailAddress, creatorPassword string) error
+	RetireAccount(accountID string) error
 	GetDeletedEvents(ids []string, userID string) ([]string, error)
 	AssociateUserSecret(accountID, userID, encryptedUserSecret string) error
 	Purge(userID string) error

--- a/server/persistence/relational/accounts.go
+++ b/server/persistence/relational/accounts.go
@@ -20,6 +20,9 @@ func (r *relationalDAL) RetireAccount(q interface{}) error {
 	case persistence.RetireAccountQueryByID:
 		var account Account
 		if err := r.db.Find(&account, "account_id = ? AND retired = false", query).Error; err != nil {
+			if gorm.IsRecordNotFoundError(err) {
+				return persistence.ErrUnknownAccount("relational: no matching account found")
+			}
 			return fmt.Errorf("relational: error looking up account %s: %w", query, err)
 		}
 		account.Retired = true

--- a/server/persistence/relational/accounts.go
+++ b/server/persistence/relational/accounts.go
@@ -15,24 +15,12 @@ func (r *relationalDAL) CreateAccount(a *persistence.Account) error {
 	return nil
 }
 
-func (r *relationalDAL) UpdateAccount(q interface{}) error {
-	switch query := q.(type) {
-	case persistence.RetireAccountQueryByID:
-		var account Account
-		if err := r.db.Find(&account, "account_id = ? AND retired = false", query).Error; err != nil {
-			if gorm.IsRecordNotFoundError(err) {
-				return persistence.ErrUnknownAccount("relational: no matching account found")
-			}
-			return fmt.Errorf("relational: error looking up account %s: %w", query, err)
-		}
-		account.Retired = true
-		if err := r.db.Save(&account).Error; err != nil {
-			return fmt.Errorf("relational: error retiring account: %w", err)
-		}
-		return nil
-	default:
-		return persistence.ErrBadQuery
+func (r *relationalDAL) UpdateAccount(a *persistence.Account) error {
+	local := importAccount(a)
+	if err := r.db.Save(&local).Error; err != nil {
+		return fmt.Errorf("relational: error saving account: %w", err)
 	}
+	return nil
 }
 
 func (r *relationalDAL) FindAccount(q interface{}) (persistence.Account, error) {

--- a/server/persistence/relational/accounts.go
+++ b/server/persistence/relational/accounts.go
@@ -15,7 +15,7 @@ func (r *relationalDAL) CreateAccount(a *persistence.Account) error {
 	return nil
 }
 
-func (r *relationalDAL) RetireAccount(q interface{}) error {
+func (r *relationalDAL) UpdateAccount(q interface{}) error {
 	switch query := q.(type) {
 	case persistence.RetireAccountQueryByID:
 		var account Account

--- a/server/persistence/relational/accounts_test.go
+++ b/server/persistence/relational/accounts_test.go
@@ -50,7 +50,7 @@ func TestRelationalDAL_CreateAccount(t *testing.T) {
 	}
 }
 
-func TestRelationalDAL_RetireAccount(t *testing.T) {
+func TestRelationalDAL_UpdateAccount(t *testing.T) {
 	tests := []struct {
 		name        string
 		setup       dbAccess
@@ -140,7 +140,7 @@ func TestRelationalDAL_RetireAccount(t *testing.T) {
 				t.Fatalf("Error setting up test: %v", err)
 			}
 
-			err := dal.RetireAccount(test.arg)
+			err := dal.UpdateAccount(test.arg)
 
 			if test.expectError != (err != nil) {
 				t.Errorf("Unexpected error value: %v", err)

--- a/server/persistence/relational/accounts_test.go
+++ b/server/persistence/relational/accounts_test.go
@@ -54,40 +54,10 @@ func TestRelationalDAL_UpdateAccount(t *testing.T) {
 	tests := []struct {
 		name        string
 		setup       dbAccess
-		arg         interface{}
+		arg         *persistence.Account
 		expectError bool
 		assertion   dbAccess
 	}{
-		{
-			"bad arg",
-			noop,
-			89,
-			true,
-			noop,
-		},
-		{
-			"account not found",
-			func(db *gorm.DB) error {
-				return db.Create(&Account{
-					AccountID: "account-b",
-				}).Error
-			},
-			persistence.RetireAccountQueryByID("account-a"),
-			true,
-			noop,
-		},
-		{
-			"already retired",
-			func(db *gorm.DB) error {
-				return db.Create(&Account{
-					AccountID: "account-a",
-					Retired:   true,
-				}).Error
-			},
-			persistence.RetireAccountQueryByID("account-a"),
-			true,
-			noop,
-		},
 		{
 			"ok",
 			func(db *gorm.DB) error {
@@ -103,7 +73,10 @@ func TestRelationalDAL_UpdateAccount(t *testing.T) {
 				}
 				return nil
 			},
-			persistence.RetireAccountQueryByID("account-a"),
+			&persistence.Account{
+				AccountID: "account-a",
+				Retired:   true,
+			},
 			false,
 			func(db *gorm.DB) error {
 				{

--- a/server/persistence/relational/accounts_test.go
+++ b/server/persistence/relational/accounts_test.go
@@ -1,6 +1,7 @@
 package relational
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -44,6 +45,109 @@ func TestRelationalDAL_CreateAccount(t *testing.T) {
 
 			if err := test.assertion(db); err != nil {
 				t.Errorf("Assertion error when validating database content: %v", err)
+			}
+		})
+	}
+}
+
+func TestRelationalDAL_RetireAccount(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       dbAccess
+		arg         interface{}
+		expectError bool
+		assertion   dbAccess
+	}{
+		{
+			"bad arg",
+			noop,
+			89,
+			true,
+			noop,
+		},
+		{
+			"account not found",
+			func(db *gorm.DB) error {
+				return db.Create(&Account{
+					AccountID: "account-b",
+				}).Error
+			},
+			persistence.RetireAccountQueryByID("account-a"),
+			true,
+			noop,
+		},
+		{
+			"already retired",
+			func(db *gorm.DB) error {
+				return db.Create(&Account{
+					AccountID: "account-a",
+					Retired:   true,
+				}).Error
+			},
+			persistence.RetireAccountQueryByID("account-a"),
+			true,
+			noop,
+		},
+		{
+			"ok",
+			func(db *gorm.DB) error {
+				if err := db.Create(&Account{
+					AccountID: "account-a",
+				}).Error; err != nil {
+					return err
+				}
+				if err := db.Create(&Account{
+					AccountID: "account-b",
+				}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+			persistence.RetireAccountQueryByID("account-a"),
+			false,
+			func(db *gorm.DB) error {
+				{
+
+					var account Account
+					if err := db.Find(&account, "account_id = ?", "account-a").Error; err != nil {
+						return err
+					}
+					if account.Retired != true {
+						return errors.New("expected account to update")
+					}
+				}
+				{
+					var account Account
+					if err := db.Find(&account, "account_id = ?", "account-b").Error; err != nil {
+						return err
+					}
+					if account.Retired != false {
+						return errors.New("unexpected side effect when updating")
+					}
+
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, closeDB := createTestDatabase()
+			defer closeDB()
+			dal := NewRelationalDAL(db)
+
+			if err := test.setup(db); err != nil {
+				t.Fatalf("Error setting up test: %v", err)
+			}
+
+			err := dal.RetireAccount(test.arg)
+
+			if test.expectError != (err != nil) {
+				t.Errorf("Unexpected error value: %v", err)
+			}
+
+			if err := test.assertion(db); err != nil {
+				t.Errorf("Unexpected assertion error: %v", err)
 			}
 		})
 	}

--- a/server/persistence/relational/relationships.go
+++ b/server/persistence/relational/relationships.go
@@ -14,6 +14,18 @@ func (r *relationalDAL) CreateAccountUserRelationship(a *persistence.AccountUser
 	return nil
 }
 
+func (r *relationalDAL) DeleteAccountUserRelationships(q interface{}) error {
+	switch query := q.(type) {
+	case persistence.DeleteAccountUserRelationshipsQueryByAccountID:
+		if err := r.db.Where("account_id = ?", query).Delete(&AccountUserRelationship{}).Error; err != nil {
+			return fmt.Errorf("relational: error deleting relationships for account %s: %w", query, err)
+		}
+		return nil
+	default:
+		return persistence.ErrBadQuery
+	}
+}
+
 func (r *relationalDAL) FindAccountUserRelationships(q interface{}) ([]persistence.AccountUserRelationship, error) {
 	var relationships []AccountUserRelationship
 	switch query := q.(type) {

--- a/server/router/accounts.go
+++ b/server/router/accounts.go
@@ -31,7 +31,8 @@ func (rt *router) getAccount(c *gin.Context) {
 
 	result, err := rt.db.GetAccount(accountID, true, c.Query("since"))
 	if err != nil {
-		if _, ok := err.(persistence.ErrUnknownAccount); ok {
+		var errUnknown persistence.ErrUnknownAccount
+		if errors.As(err, &errUnknown) {
 			newJSONError(
 				fmt.Errorf("router: account %s not found", accountID),
 				http.StatusNotFound,
@@ -69,7 +70,8 @@ func (rt *router) deleteAccount(c *gin.Context) {
 
 	err := rt.db.RetireAccount(accountID)
 	if err != nil {
-		if _, ok := err.(persistence.ErrUnknownAccount); ok {
+		var errUnknown persistence.ErrUnknownAccount
+		if errors.As(err, &errUnknown) {
 			newJSONError(
 				fmt.Errorf("router: account %s not found", accountID),
 				http.StatusNotFound,

--- a/server/router/accounts_test.go
+++ b/server/router/accounts_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/offen/offen/server/persistence"
 )
 
-type mockAccountDatabase struct {
+type mockGetAccountDatabase struct {
 	persistence.Service
 	result persistence.AccountResult
 	err    error
 }
 
-func (m *mockAccountDatabase) GetAccount(string, bool, string) (persistence.AccountResult, error) {
+func (m *mockGetAccountDatabase) GetAccount(string, bool, string) (persistence.AccountResult, error) {
 	return m.result, m.err
 }
 
@@ -33,7 +33,7 @@ func TestRouter_GetAccount(t *testing.T) {
 		{
 			"ok",
 			"account-a",
-			&mockAccountDatabase{
+			&mockGetAccountDatabase{
 				result: persistence.AccountResult{},
 			},
 			http.StatusOK,
@@ -50,7 +50,6 @@ func TestRouter_GetAccount(t *testing.T) {
 			m := gin.New()
 			m.GET("/:accountID", func(c *gin.Context) {
 				c.Set(
-
 					contextKeyAuth,
 					persistence.LoginResult{
 						Accounts: []persistence.LoginAccountResult{
@@ -71,6 +70,61 @@ func TestRouter_GetAccount(t *testing.T) {
 			}
 			if !strings.Contains(w.Body.String(), test.expectedBody) {
 				t.Errorf("Unexpected response body %s", w.Body.String())
+			}
+		})
+	}
+}
+
+type mockDeleteAccountDatabase struct {
+	persistence.Service
+	result error
+}
+
+func (m *mockDeleteAccountDatabase) RetireAccount(string) error {
+	return m.result
+}
+
+func TestRouter_DeleteAccount(t *testing.T) {
+	tests := []struct {
+		name               string
+		accountID          string
+		database           persistence.Service
+		expectedStatusCode int
+	}{
+		{
+			"ok",
+			"account-a",
+			&mockDeleteAccountDatabase{},
+			http.StatusNoContent,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cookieSigner := securecookie.New([]byte("abc123"), nil)
+			auth, _ := cookieSigner.Encode("auth", test.accountID)
+			rt := router{db: test.database, cookieSigner: cookieSigner}
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/%s", test.accountID), nil)
+			m := gin.New()
+			m.DELETE("/:accountID", func(c *gin.Context) {
+				c.Set(
+					contextKeyAuth,
+					persistence.LoginResult{
+						Accounts: []persistence.LoginAccountResult{
+							{AccountID: "account-a"},
+						},
+					},
+				)
+				c.Next()
+
+			}, rt.deleteAccount)
+			r.AddCookie(&http.Cookie{
+				Value: auth,
+				Name:  "auth",
+			})
+			m.ServeHTTP(w, r)
+			if w.Code != test.expectedStatusCode {
+				t.Errorf("Unexpected status code %v", w.Code)
 			}
 		})
 	}

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -183,6 +183,7 @@ func New(opts ...Config) http.Handler {
 		api.POST("/exchange", rt.postUserSecret)
 
 		api.GET("/accounts/:accountID", accountAuth, rt.getAccount)
+		api.DELETE("/accounts/:accountID", accountAuth, rt.deleteAccount)
 		api.POST("/accounts", accountAuth, rt.postAccount)
 
 		api.POST("/deleted/user", userCookie, rt.getDeletedEvents)

--- a/vault/index.js
+++ b/vault/index.js
@@ -39,6 +39,7 @@ register('RESET_PASSWORD', middleware.sameOrigin, callHandler(handler.handleRese
 register('INVITE_USER', middleware.sameOrigin, callHandler(handler.handleInviteUser))
 register('JOIN', middleware.sameOrigin, callHandler(handler.handleJoin))
 register('CREATE_ACCOUNT', middleware.sameOrigin, callHandler(handler.handleCreateAccount))
+register('RETIRE_ACCOUNT', middleware.sameOrigin, callHandler(handler.handleRetireAccount))
 
 module.exports = register
 

--- a/vault/src/api.js
+++ b/vault/src/api.js
@@ -307,3 +307,17 @@ function createAccountWith (createUrl) {
       .then(handleFetchResponse)
   }
 }
+
+exports.retireAccount = retireAccountWith(window.location.origin + '/api/accounts')
+exports.retireAccountWith = retireAccountWith
+
+function retireAccountWith (deleteUrl) {
+  return function (accountId) {
+    return window
+      .fetch(deleteUrl + '/' + accountId, {
+        method: 'DELETE',
+        credentials: 'include'
+      })
+      .then(handleFetchResponse)
+  }
+}

--- a/vault/src/handler.js
+++ b/vault/src/handler.js
@@ -268,6 +268,15 @@ function handleCreateAccountWith (api) {
   })
 }
 
+exports.handleRetireAccount = handleRetireAccountWith(api)
+exports.handleRetireAccountWith = handleRetireAccountWith
+
+function handleRetireAccountWith (api) {
+  return proxyThunk(function (payload) {
+    return api.retireAccount(payload.accountId)
+  })
+}
+
 // proxyThunk can be used to create a handler that simply calls through
 // to an api method without needing any further logic other than signalling
 // success or failure


### PR DESCRIPTION
This allows operators to retire accounts. Accounts that are retired will only be soft deleted as users will still be able to access and manage the data this account keeps.