### PR TITLE
Fix bad memoization function in chart component

### DIFF
--- a/auditorium/src/views/components/auditorium/chart.js
+++ b/auditorium/src/views/components/auditorium/chart.js
@@ -128,6 +128,8 @@ const Chart = (props) => {
 module.exports = memo(
   Chart,
   (prevProps, nextProps) => {
-    return _.isEqual(prevProps, nextProps)
+    const prevPageviews = prevProps.model.pageviews.map((p) => _.omit(p, 'date'))
+    const nextPageviews = nextProps.model.pageviews.map((p) => _.omit(p, 'date'))
+    return _.isEqual(prevPageviews, nextPageviews)
   }
 )


### PR DESCRIPTION
Plotly seems to generate bad height values when it re-renders the exact same svg output, so this PR fixes the broken memoization function that determines whether the chart needs to update or not.