### PR TITLE
Set plotly dragmode to false

### DIFF
--- a/auditorium/src/views/components/auditorium/chart.js
+++ b/auditorium/src/views/components/auditorium/chart.js
@@ -79,6 +79,7 @@ const Chart = (props) => {
   ]
 
   const layout = {
+    dragmode: false,
     autosize: true,
     yaxis: {
       fixedrange: true,


### PR DESCRIPTION
Allows mobile users to scroll through the page when touching the Plotly plot itself:

![Peek 2020-02-29 08-46](https://user-images.githubusercontent.com/1662740/75603586-1d549000-5ad0-11ea-81e1-884e70d66341.gif)
