### PR TITLE
Simplify invite flow by autoaccepting pending relationships on login

### DIFF
--- a/auditorium/index.js
+++ b/auditorium/index.js
@@ -84,8 +84,7 @@ const App = () => {
         <SetupView path='/setup/' />
         <ForgotPasswordView path='/forgot-password/' />
         <ResetPasswordView path='/reset-password/:token' />
-        <JoinView path='/join/new/:token' />
-        <JoinView path='/join/addition/:token' isAddition />
+        <JoinView path='/join/:token' />
         <NotFoundView default />
       </Router>
     </Provider>

--- a/auditorium/src/views/components/_shared/share.js
+++ b/auditorium/src/views/components/_shared/share.js
@@ -28,7 +28,7 @@ const Share = (props) => {
         invitee: invitee,
         emailAddress: emailAddress,
         password: formData.password,
-        urlTemplate: window.location.origin + '/join/{userId}/{token}/',
+        urlTemplate: window.location.origin + '/join/{token}/',
         accountId: accountId
       },
       __('An invite email has been sent.'),

--- a/auditorium/src/views/components/console/change-email.js
+++ b/auditorium/src/views/components/console/change-email.js
@@ -14,7 +14,8 @@ const ChangeEmail = (props) => {
     props.onChangeEmail(
       {
         password: formData.get('password'),
-        emailAddress: formData.get('email-address')
+        emailAddress: formData.get('email-address'),
+        emailCurrent: formData.get('email-current')
       },
       __('Please log in again, using your updated email.'),
       __('Could not change email. Try again.')
@@ -27,10 +28,15 @@ const ChangeEmail = (props) => {
       <h4 class='f4 normal mt0 mb3'>
         {__('Change email address')}
       </h4>
-      <p>
-        {__('Warning: Changing your email address will invalidate all pending account invites for your user.')}
-      </p>
       <form class='mw6 center mb4' onsubmit={handleSubmit}>
+        <LabeledInput
+          type='email'
+          name='email-current'
+          required
+          disabled={isDisabled}
+        >
+          {__('Current email address')}
+        </LabeledInput>
         <LabeledInput
           type='email'
           name='email-address'

--- a/auditorium/src/views/components/console/change-password.js
+++ b/auditorium/src/views/components/console/change-password.js
@@ -33,9 +33,6 @@ const ChangePassword = (props) => {
       <h4 class='f4 normal mt0 mb3'>
         {__('Change password')}
       </h4>
-      <p>
-        {__('Warning: Changing your password will invalidate all pending account invites for your user.')}
-      </p>
       <form class='mw6 center mb4' onsubmit={handleSubmit}>
         <LabeledInput
           type='password'

--- a/auditorium/src/views/components/join/form.js
+++ b/auditorium/src/views/components/join/form.js
@@ -8,12 +8,11 @@ const SubmitButton = require('./../_shared/submit-button')
 
 const Form = forwardRef((props, ref) => {
   const [isDisabled, setIsDisabled] = useState(false)
-  const isAddition = props.isAddition
 
   function handleSubmit (e) {
     e.preventDefault()
     var formData = new window.FormData(e.currentTarget)
-    if (!isAddition && formData.get('password') !== formData.get('repeat-password')) {
+    if (formData.get('password') !== formData.get('repeat-password')) {
       return props.onValidationError(new Error(__('Passwords did not match')))
     }
     setIsDisabled(true)
@@ -23,9 +22,7 @@ const Form = forwardRef((props, ref) => {
         password: formData.get('password'),
         token: formData.get('token')
       },
-      isAddition
-        ? __('Log in again to access all accounts.')
-        : __('Your account has been set up, you can now log in.'),
+      __('Your account has been set up, you can now log in.'),
       __('Could not handle your request, please try again.')
     )
       .then(() => setIsDisabled(false))
@@ -33,7 +30,7 @@ const Form = forwardRef((props, ref) => {
   return (
     <div class='pa3 bg-black-05'>
       <h4 class='f4 normal mt0 mb3'>
-        {isAddition ? __('Accept invite') : __('Join Offen')}
+        {__('Join Offen')}
       </h4>
       <form class='mw6 center' onsubmit={handleSubmit}>
         <LabeledInput
@@ -52,16 +49,14 @@ const Form = forwardRef((props, ref) => {
         >
           {__('Password')}
         </LabeledInput>
-        {!isAddition ? (
-          <LabeledInput
-            name='repeat-password'
-            type='password'
-            required
-            disabled={isDisabled}
-          >
-            {__('Repeat password')}
-          </LabeledInput>
-        ) : null}
+        <LabeledInput
+          name='repeat-password'
+          type='password'
+          required
+          disabled={isDisabled}
+        >
+          {__('Repeat password')}
+        </LabeledInput>
         <SubmitButton disabled={isDisabled}>
           {__('Accept invite')}
         </SubmitButton>

--- a/auditorium/src/views/components/reset-password/form.js
+++ b/auditorium/src/views/components/reset-password/form.js
@@ -24,9 +24,6 @@ const Form = forwardRef((props, ref) => {
       <h4 class='f4 normal mt0 mb3'>
         {__('Reset password')}
       </h4>
-      <p>
-        {__('Warning: Resetting your password will invalidate all pending account invites for your user.')}
-      </p>
       <form class='mw6 center' onsubmit={handleSubmit}>
         <LabeledInput
           name='email-address'

--- a/auditorium/src/views/join.js
+++ b/auditorium/src/views/join.js
@@ -10,13 +10,12 @@ const useAutofocus = require('./components/_shared/use-autofocus')
 
 const JoinView = (props) => {
   const autofocusRef = useAutofocus()
-  const { isAddition, handleJoin, handleValidationError, token } = props
+  const { handleJoin, handleValidationError, token } = props
   return (
     <div class='w-100 mt4 mb2 br0 br2-ns'>
       <Form
         onJoin={handleJoin}
         onValidationError={handleValidationError}
-        isAddition={isAddition}
         ref={autofocusRef}
         token={token}
       />

--- a/server/mailer/messages.go
+++ b/server/mailer/messages.go
@@ -27,11 +27,11 @@ missed this deadline, request a new invite.
 var MessageExistingUserInvite MessageTemplate = `
 Hi!
 
-You have been added to {{ .count }} new accounts in Offen.
-To accept this invite, visit the following link:
+You have been added to the following new accounts in Offen:
 
-{{ .url }}
+{{ range .accountNames }}
+- {{ . }}
+{{ end }}
 
-The link is valid for 7 days after this email has been sent. In case you have
-missed this deadline, request a new invite.
+You automatically gain access to these accounts the next time you log in.
 `

--- a/server/persistence/dal.go
+++ b/server/persistence/dal.go
@@ -96,10 +96,6 @@ type FindAccountUserRelationshipsQueryByAccountUserID string
 // with the given account id.
 type DeleteAccountUserRelationshipsQueryByAccountID string
 
-// DeleteAccountUserRelationshipQueryByRelationshipID requests deletion of all relationships
-// with the given relationship id.
-type DeleteAccountUserRelationshipQueryByRelationshipID string
-
 // FindAccountUsersQueryAllAccountUsers requests all account users.
 type FindAccountUsersQueryAllAccountUsers struct {
 	IncludeRelationships bool

--- a/server/persistence/management.go
+++ b/server/persistence/management.go
@@ -10,7 +10,7 @@ func (p *persistenceLayer) InviteUser(inviteeEmailAddress, providerEmailAddress,
 	var result InviteUserResult
 	var invitedAccountUser *AccountUser
 
-	accountUsers, err := p.dal.FindAccountUsers(FindAccountUsersQueryAllAccountUsers{true, true})
+	accountUsers, err := p.dal.FindAccountUsers(FindAccountUsersQueryAllAccountUsers{true, false})
 	if err != nil {
 		return result, fmt.Errorf("persistence: error looking up account users: %w", err)
 	}
@@ -50,11 +50,6 @@ func (p *persistenceLayer) InviteUser(inviteeEmailAddress, providerEmailAddress,
 	var eligibleRelationships []AccountUserRelationship
 outer:
 	for _, relationship := range provider.Relationships {
-		if relationship.PasswordEncryptedKeyEncryptionKey == "" {
-			// the provider might have pending invitations which we do not
-			// want to copy over
-			continue
-		}
 		for _, existingRelationship := range invitedAccountUser.Relationships {
 			if relationship.AccountID == existingRelationship.AccountID {
 				// this makes sure no existing relationship for the accountID
@@ -65,7 +60,11 @@ outer:
 		if accountID == "" || relationship.AccountID == accountID {
 			// with no filter given, the invitee inherits all relationships from
 			// the provider
-			result.AccountIDs = append(result.AccountIDs, relationship.AccountID)
+			account, accountErr := p.dal.FindAccount(FindAccountQueryByID(relationship.AccountID))
+			if accountErr != nil {
+				return result, fmt.Errorf("persistence: error looking up account info for relationship %s: %w", relationship.RelationshipID, err)
+			}
+			result.AccountNames = append(result.AccountNames, account.Name)
 			eligibleRelationships = append(eligibleRelationships, relationship)
 		}
 	}
@@ -111,28 +110,28 @@ func (p *persistenceLayer) Join(emailAddress, password string) error {
 	}
 
 	if match.HashedPassword != "" {
-		if err := keys.CompareString(password, match.HashedPassword); err != nil {
-			return fmt.Errorf("persistence: passwords did not match: %w", err)
-		}
-	} else {
-		cipher, err := keys.HashString(password)
-		if err != nil {
-			return fmt.Errorf("persistence: hashing given password: %w", err)
-		}
-		match.HashedPassword = cipher.Marshal()
-		if err := p.dal.UpdateAccountUser(match); err != nil {
-			return fmt.Errorf("persistence: failed to update account user: %w", err)
-		}
+		return fmt.Errorf("persistence: user with email %s has already joined before", emailAddress)
+	}
+
+	cipher, err := keys.HashString(password)
+	if err != nil {
+		return fmt.Errorf("persistence: hashing given password: %w", err)
+	}
+	match.HashedPassword = cipher.Marshal()
+
+	txn, err := p.dal.Transaction()
+	if err != nil {
+		return fmt.Errorf("persistence: error creating transaction: %w", err)
+	}
+
+	if err := txn.UpdateAccountUser(match); err != nil {
+		txn.Rollback()
+		return fmt.Errorf("persistence: failed to update account user: %w", err)
 	}
 
 	emailDerivedKey, deriveErr := keys.DeriveKey(emailAddress, match.Salt)
 	if deriveErr != nil {
 		return fmt.Errorf("persistence: error deriving key from email: %w", deriveErr)
-	}
-
-	txn, err := p.dal.Transaction()
-	if err != nil {
-		return fmt.Errorf("persistence: error creating transaction: %w", err)
 	}
 
 	for _, relationship := range match.Relationships {

--- a/server/persistence/management_test.go
+++ b/server/persistence/management_test.go
@@ -42,6 +42,10 @@ func (m *mockInviteUserDatabase) Transaction() (Transaction, error) {
 	return m, m.transactionErr
 }
 
+func (m *mockInviteUserDatabase) FindAccount(interface{}) (Account, error) {
+	return Account{Name: "account-name", AccountID: "account-id"}, nil
+}
+
 func TestPersistenceLayer_InviteUser(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -153,7 +157,7 @@ func TestPersistenceLayer_InviteUser(t *testing.T) {
 			"account-id",
 			InviteUserResult{
 				UserExistsWithPassword: true,
-				AccountIDs:             []string{"account-id"},
+				AccountNames:           []string{"account-name"},
 			},
 			false,
 		},
@@ -189,7 +193,7 @@ func TestPersistenceLayer_InviteUser(t *testing.T) {
 			"account-id",
 			InviteUserResult{
 				UserExistsWithPassword: false,
-				AccountIDs:             []string{"account-id"},
+				AccountNames:           []string{"account-name"},
 			},
 			false,
 		},
@@ -354,7 +358,7 @@ func TestPersistenceLayer_Join(t *testing.T) {
 			true,
 		},
 		{
-			"ok - existing user",
+			"not ok - existing user",
 			&mockJoinDatabase{
 				findAccountUsersResult: []AccountUser{
 					(func() AccountUser {
@@ -377,7 +381,7 @@ func TestPersistenceLayer_Join(t *testing.T) {
 			},
 			"foo@bar.com",
 			"secret",
-			false,
+			true,
 		},
 		{
 			"ok - new user",

--- a/server/persistence/persistence.go
+++ b/server/persistence/persistence.go
@@ -19,7 +19,7 @@ type Service interface {
 	Login(email, password string) (LoginResult, error)
 	LookupAccountUser(userID string) (LoginResult, error)
 	ChangePassword(userID, currentPassword, changedPassword string) error
-	ChangeEmail(userID, emailAddress, password string) error
+	ChangeEmail(userID, emailAddress, emailCurrent, password string) error
 	GenerateOneTimeKey(emailAddress string) ([]byte, error)
 	ResetPassword(emailAddress, password string, oneTimeKey []byte) error
 	InviteUser(inviteeEmailAddress, providerEmailAddress, providerPassword, accountID string) (InviteUserResult, error)

--- a/server/persistence/relational/accountuser.go
+++ b/server/persistence/relational/accountuser.go
@@ -18,7 +18,7 @@ func (r *relationalDAL) FindAccountUser(q interface{}) (persistence.AccountUser,
 	var accountUser AccountUser
 	switch query := q.(type) {
 	case persistence.FindAccountUserQueryByAccountUserIDIncludeRelationships:
-		if err := r.db.Preload("Relationships").Where("account_user_id = ?", string(query)).First(&accountUser).Error; err != nil {
+		if err := r.db.Preload("Relationships", "password_encrypted_key_encryption_key <> ?", "").Where("account_user_id = ?", string(query)).First(&accountUser).Error; err != nil {
 			return accountUser.export(), fmt.Errorf("relational: error looking up account user by user id: %w", err)
 		}
 		return accountUser.export(), nil

--- a/server/persistence/relational/relationships.go
+++ b/server/persistence/relational/relationships.go
@@ -21,11 +21,6 @@ func (r *relationalDAL) DeleteAccountUserRelationships(q interface{}) error {
 			return fmt.Errorf("relational: error deleting relationships for account %s: %w", query, err)
 		}
 		return nil
-	case persistence.DeleteAccountUserRelationshipQueryByRelationshipID:
-		if err := r.db.Where("relationship_id = ?", query).Delete(&AccountUserRelationship{}).Error; err != nil {
-			return fmt.Errorf("relational: error deleting relationship %s: %w", query, err)
-		}
-		return nil
 	default:
 		return persistence.ErrBadQuery
 	}

--- a/server/persistence/results.go
+++ b/server/persistence/results.go
@@ -35,16 +35,16 @@ type AccountResult struct {
 	Created             time.Time             `json:"created,omitempty"`
 }
 
+// InviteUserResult is a successful invitation of a user
+type InviteUserResult struct {
+	UserExistsWithPassword bool
+	AccountNames           []string
+}
+
 // LoginResult is a successful account user authentication response.
 type LoginResult struct {
 	AccountUserID string               `json:"accountUserId"`
 	Accounts      []LoginAccountResult `json:"accounts"`
-}
-
-// InviteUserResult is a successful invitation of a user
-type InviteUserResult struct {
-	UserExistsWithPassword bool
-	AccountIDs             []string
 }
 
 // CanAccessAccount checks whether the login result is allowed to access the

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -116,6 +116,7 @@ func (rt *router) postChangePassword(c *gin.Context) {
 
 type changeEmailRequest struct {
 	EmailAddress string `json:"emailAddress"`
+	EmailCurrent string `json:"emailCurrent"`
 	Password     string `json:"password"`
 }
 
@@ -136,7 +137,7 @@ func (rt *router) postChangeEmail(c *gin.Context) {
 		).Pipe(c)
 		return
 	}
-	if err := rt.db.ChangeEmail(accountUser.AccountUserID, req.EmailAddress, req.Password); err != nil {
+	if err := rt.db.ChangeEmail(accountUser.AccountUserID, req.EmailAddress, req.EmailCurrent, req.Password); err != nil {
 		newJSONError(
 			fmt.Errorf("router: error changing email address: %v", err),
 			http.StatusBadRequest,

--- a/vault/src/api.js
+++ b/vault/src/api.js
@@ -214,13 +214,14 @@ exports.changeEmail = changeEmailWith(window.location.origin + '/api/change-emai
 exports.changeEmailWith = changeEmailWith
 
 function changeEmailWith (loginUrl) {
-  return function (emailAddress, password) {
+  return function (emailAddress, emailCurrent, password) {
     return window
       .fetch(loginUrl, {
         method: 'POST',
         credentials: 'include',
         body: JSON.stringify({
           emailAddress: emailAddress,
+          emailCurrent: emailCurrent,
           password: password
         })
       })

--- a/vault/src/handler.js
+++ b/vault/src/handler.js
@@ -214,9 +214,9 @@ function handleChangeCredentialsWith (api) {
       doRequest = function () {
         return api.changePassword(payload.currentPassword, payload.changedPassword)
       }
-    } else if (payload.emailAddress && payload.password) {
+    } else if (payload.emailCurrent && payload.emailAddress && payload.password) {
       doRequest = function () {
-        return api.changeEmail(payload.emailAddress, payload.password)
+        return api.changeEmail(payload.emailAddress, payload.emailCurrent, payload.password)
       }
     }
     return doRequest()


### PR DESCRIPTION
This allows account users to auto accept pending invites on login. There is also no further need to purge pending invites of forgotten password et. al.