### PR TITLE
Move flash messages into "toast" style layout

### DIFF
--- a/auditorium/index.js
+++ b/auditorium/index.js
@@ -25,6 +25,7 @@ const flashReducer = require('./src/reducers/flash')
 const staleReducer = require('./src/reducers/stale')
 const modelReducer = require('./src/reducers/model')
 const redirectMiddleware = require('./src/middleware/redirect')
+const flashMessagesMiddleware = require('./src/middleware/flash-messages')
 const navigation = require('./src/action-creators/navigation')
 const errors = require('./src/action-creators/errors')
 
@@ -39,7 +40,8 @@ const middlewares = [
   thunk.withExtraArgument(
     msg => vaultInstance.then(postMessage => postMessage(msg))
   ),
-  redirectMiddleware
+  redirectMiddleware,
+  flashMessagesMiddleware
 ]
 
 if (process.env.NODE_ENV !== 'production') {
@@ -67,7 +69,7 @@ const App = () => {
   const previousPath = useRef(null)
   const handleRouteChange = (e) => {
     if (previousPath.current !== e.current.props.path) {
-      store.dispatch(navigation.navigate(e.url, e.current.props.persistFlash))
+      store.dispatch(navigation.navigate(e.url))
       window.scrollTo(0, 0)
     }
     previousPath.current = e.current.props.path
@@ -76,8 +78,8 @@ const App = () => {
   return (
     <Provider store={store}>
       <Router onChange={handleRouteChange}>
-        <IndexView path='/' persistFlash />
-        <LoginView path='/login/' persistFlash />
+        <IndexView path='/' />
+        <LoginView path='/login/' />
         <Auditorium.UserView path='/auditorium/' />
         <Auditorium.OperatorView path='/auditorium/:accountId' isOperator />
         <ConsoleView path='/console/' />

--- a/auditorium/src/action-creators/authentication.js
+++ b/auditorium/src/action-creators/authentication.js
@@ -42,7 +42,7 @@ exports.login = (username, password, onFailureMessage) => (dispatch, getState, p
     .catch((err) => dispatch(errors.unrecoverable(err)))
 }
 
-exports.logout = (onFailureMessage) => (dispatch, getState, postMessage) => {
+exports.logout = (onSuccessMessage, onFailureMessage) => (dispatch, getState, postMessage) => {
   dispatch({
     type: 'LOGOUT_REQUEST',
     payload: null
@@ -57,7 +57,9 @@ exports.logout = (onFailureMessage) => (dispatch, getState, postMessage) => {
         case 'LOGOUT_SUCCESS':
           dispatch({
             type: 'LOGOUT_SUCCESS',
-            payload: null
+            payload: {
+              flash: onSuccessMessage
+            }
           })
           return
         case 'LOGOUT_FAILURE':

--- a/auditorium/src/action-creators/authentication.test.js
+++ b/auditorium/src/action-creators/authentication.test.js
@@ -234,7 +234,7 @@ describe('src/action-creators/authentication.js', function () {
       const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
       const store = mockStore({})
 
-      return store.dispatch(authentication.logout('nope'))
+      return store.dispatch(authentication.logout('yup', 'nope'))
         .then(function () {
           const actions = store.getActions()
           assert.strictEqual(actions.length, 2)
@@ -246,7 +246,9 @@ describe('src/action-creators/authentication.js', function () {
 
           assert.deepStrictEqual(actions[1], {
             type: 'LOGOUT_SUCCESS',
-            payload: null
+            payload: {
+              flash: 'yup'
+            }
           })
 
           assert(mockPostMessage.calledOnce)
@@ -266,7 +268,7 @@ describe('src/action-creators/authentication.js', function () {
       const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
       const store = mockStore({})
 
-      return store.dispatch(authentication.logout('nope'))
+      return store.dispatch(authentication.logout('yup', 'nope'))
         .then(function () {
           const actions = store.getActions()
           assert.strictEqual(actions.length, 2)
@@ -299,7 +301,7 @@ describe('src/action-creators/authentication.js', function () {
       const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
       const store = mockStore({})
 
-      return store.dispatch(authentication.logout('nope'))
+      return store.dispatch(authentication.logout('yup', 'nope'))
         .then(function () {
           const actions = store.getActions()
           assert.strictEqual(actions.length, 2)
@@ -325,7 +327,7 @@ describe('src/action-creators/authentication.js', function () {
       const mockStore = configureMockStore([thunk.withExtraArgument(mockPostMessage)])
       const store = mockStore({})
 
-      return store.dispatch(authentication.logout('nope'))
+      return store.dispatch(authentication.logout('yup', 'nope'))
         .then(function () {
           const actions = store.getActions()
           assert.strictEqual(actions.length, 2)

--- a/auditorium/src/action-creators/flash.js
+++ b/auditorium/src/action-creators/flash.js
@@ -1,0 +1,4 @@
+exports.expire = (flashId) => ({
+  type: 'EXPIRE_FLASH',
+  payload: { flashId }
+})

--- a/auditorium/src/action-creators/flash.test.js
+++ b/auditorium/src/action-creators/flash.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert')
+
+const flash = require('./flash')
+
+describe('src/action-creators/flash.js', function () {
+  describe('expire(error)', function () {
+    it('creates a flash expiry action', function () {
+      const action = flash.expire('abc123')
+      assert.deepStrictEqual(action, {
+        type: 'EXPIRE_FLASH',
+        payload: {
+          flashId: 'abc123'
+        }
+      })
+    })
+  })
+})

--- a/auditorium/src/action-creators/management.js
+++ b/auditorium/src/action-creators/management.js
@@ -1,5 +1,12 @@
 const errors = require('./errors')
 
+exports.handleCopy = (message) => ({
+  type: 'COPY_SUCCESS',
+  payload: {
+    flash: message
+  }
+})
+
 exports.shareAccount = (payload, onSuccessMessage, onFailureMessage) => (dispatch, getState, postMessage) => {
   dispatch({
     type: 'SHARE_ACCOUNT_REQUEST',

--- a/auditorium/src/action-creators/navigation.js
+++ b/auditorium/src/action-creators/navigation.js
@@ -1,4 +1,4 @@
-exports.navigate = (url, persistFlash) => ({
+exports.navigate = (url) => ({
   type: 'NAVIGATE',
-  payload: { url, persistFlash }
+  payload: { url }
 })

--- a/auditorium/src/action-creators/navigation.test.js
+++ b/auditorium/src/action-creators/navigation.test.js
@@ -5,10 +5,10 @@ const navigation = require('./navigation')
 describe('src/action-creators/navigation.js', function () {
   describe('navigate(url)', function () {
     it('creates a navigation action', function () {
-      const action = navigation.navigate('/foo', true)
+      const action = navigation.navigate('/foo')
       assert.deepStrictEqual(action, {
         type: 'NAVIGATE',
-        payload: { url: '/foo', persistFlash: true }
+        payload: { url: '/foo' }
       })
     })
   })

--- a/auditorium/src/middleware/flash-messages.js
+++ b/auditorium/src/middleware/flash-messages.js
@@ -1,0 +1,12 @@
+const flash = require('./../action-creators/flash')
+
+module.exports = (store) => (next) => (action) => {
+  if (action.payload && action.payload.flash) {
+    const id = Math.random().toString(36).slice(2)
+    action.payload.flashId = id
+    setTimeout(() => {
+      store.dispatch(flash.expire(id))
+    }, 10000)
+  }
+  next(action)
+}

--- a/auditorium/src/reducers/flash.js
+++ b/auditorium/src/reducers/flash.js
@@ -1,4 +1,4 @@
-module.exports = (state = null, action) => {
+module.exports = (state = [], action) => {
   switch (action.type) {
     case 'AUTHENTICATION_FAILURE':
     case 'SHARE_ACCOUNT_SUCCESS':
@@ -21,18 +21,24 @@ module.exports = (state = null, action) => {
     case 'SETUP_FAILURE':
     case 'SETUP_STATUS_HASDATA':
     case 'LOGOUT_SUCCESS':
+    case 'LOGOUT_FAILURE':
+    case 'COPY_SUCCESS':
       if (action.payload && action.payload.flash) {
-        return action.payload.flash
+        return [
+          {
+            content: action.payload.flash,
+            id: action.payload.flashId
+          },
+          ...state
+        ]
       }
       return state
-    case 'AUTHENTICATION_SUCCESS':
-    case 'QUERY_SUCCESS':
-      return null
-    case 'NAVIGATE':
-      if (action.payload && action.payload.persistFlash) {
-        return state
-      }
-      return null
+    case 'LOGIN_SUCCESS':
+      return []
+    case 'EXPIRE_FLASH':
+      return state.filter((message) => {
+        return message.id !== action.payload.flashId
+      })
     default:
       return state
   }

--- a/auditorium/src/reducers/flash.test.js
+++ b/auditorium/src/reducers/flash.test.js
@@ -6,205 +6,45 @@ describe('src/reducers/flash.js', function () {
   describe('flash(state, action)', function () {
     it('returns the initial state', function () {
       const next = flash(undefined, {})
-      assert.strictEqual(next, null)
+      assert.deepStrictEqual(next, [])
     })
 
-    it('handles NAVIGATE', function () {
-      const next = flash('fake state', {
-        type: 'NAVIGATE',
-        payload: null
-      })
-      assert.strictEqual(next, null)
+    it('adds flash messages at the head of the list', function () {
+      const next = flash(
+        [{ content: 'hey', id: '1' }],
+        { type: 'JOIN_SUCCESS', payload: { flash: 'ho', flashId: '2' } }
+      )
+      assert.deepStrictEqual(next, [
+        { content: 'ho', id: '2' },
+        { content: 'hey', id: '1' }
+      ])
     })
 
-    it('handles AUTHENTICATION_FAILURE', function () {
-      const next = flash(null, {
-        type: 'AUTHENTICATION_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
+    it('removes flash messages by id', function () {
+      const next = flash(
+        [
+          { content: 'ho', id: '2' },
+          { content: 'hey', id: '1' },
+          { content: 'lets go', id: '3' }
+        ],
+        { type: 'EXPIRE_FLASH', payload: { flashId: '1' } }
+      )
+      assert.deepStrictEqual(next, [
+        { content: 'ho', id: '2' },
+        { content: 'lets go', id: '3' }
+      ])
     })
 
-    it('handles SHARE_ACCOUNT_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'SHARE_ACCOUNT_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles SHARE_ACCOUNT_FAILURE', function () {
-      const next = flash(null, {
-        type: 'SHARE_ACCOUNT_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles JOIN_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'JOIN_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles JOIN_FAILURE', function () {
-      const next = flash(null, {
-        type: 'JOIN_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles CREATE_ACCOUNT_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'CREATE_ACCOUNT_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles CREATE_ACCOUNT_FAILURE', function () {
-      const next = flash(null, {
-        type: 'CREATE_ACCOUNT_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles FORM_VALIDATION_ERROR', function () {
-      const next = flash(null, {
-        type: 'FORM_VALIDATION_ERROR',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles FORGOT_PASSWORD_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'FORGOT_PASSWORD_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles FORGOT_PASSWORD_FAILURE', function () {
-      const next = flash(null, {
-        type: 'FORGOT_PASSWORD_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles CHANGE_CREDENTIALS_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'CHANGE_CREDENTIALS_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles CHANGE_CREDENTIALS_FAILURE', function () {
-      const next = flash(null, {
-        type: 'CHANGE_CREDENTIALS_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles RESET_PASSWORD_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'RESET_PASSWORD_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles RESET_PASSWORD_FAILURE', function () {
-      const next = flash(null, {
-        type: 'RESET_PASSWORD_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles RETIRE_ACCOUNT_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'RETIRE_ACCOUNT_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles RETIRE_ACCOUNT_FAILURE', function () {
-      const next = flash(null, {
-        type: 'RETIRE_ACCOUNT_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles SETUP_SUCCESS', function () {
-      const next = flash(null, {
-        type: 'SETUP_SUCCESS',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles SETUP_FAILURE', function () {
-      const next = flash(null, {
-        type: 'SETUP_FAILURE',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
-    })
-
-    it('handles SETUP_STATUS_HASDATA', function () {
-      const next = flash(null, {
-        type: 'SETUP_STATUS_HASDATA',
-        payload: {
-          flash: 'msg'
-        }
-      })
-      assert.strictEqual(next, 'msg')
+    it('handles LOGIN_SUCCESS', function () {
+      const next = flash(
+        [
+          { content: 'ho', id: '2' },
+          { content: 'hey', id: '1' },
+          { content: 'lets go', id: '3' }
+        ],
+        { type: 'LOGIN_SUCCESS', payload: null }
+      )
+      assert.deepStrictEqual(next, [])
     })
   })
 })

--- a/auditorium/src/views/auditorium.js
+++ b/auditorium/src/views/auditorium.js
@@ -28,7 +28,7 @@ const management = require('./../action-creators/management')
 
 const AuditoriumView = (props) => {
   const { matches, authenticatedUser, model, isOperator, consentStatus, stale } = props
-  const { handlePurge, handleQuery, expressConsent, getConsentStatus, handleShare, handleValidationError, handleRetire } = props
+  const { handlePurge, handleQuery, expressConsent, getConsentStatus, handleShare, handleValidationError, handleRetire, handleCopy } = props
   const { accountId, range, resolution } = matches
   const [focus, setFocus] = useState(true)
 
@@ -117,7 +117,7 @@ const AuditoriumView = (props) => {
                 )
                 : (
                   <div class='w-70-l w-100 flex br0 br2-ns mb2'>
-                    <EmbedCode model={model} expand />
+                    <EmbedCode model={model} onCopy={handleCopy} />
                   </div>
                 )}
             </Fragment>
@@ -175,6 +175,7 @@ const AuditoriumView = (props) => {
                     <EmbedCode
                       key={`embed-${accountId}`}
                       model={model}
+                      onCopy={handleCopy}
                       collapsible
                     />
                   </div>
@@ -227,7 +228,8 @@ const mapDispatchToProps = {
   expressConsent: consent.express,
   handleValidationError: errors.formValidation,
   handleShare: management.shareAccount,
-  handleRetire: management.retireAccount
+  handleRetire: management.retireAccount,
+  handleCopy: management.handleCopy
 }
 
 const ConnectedAuditoriumView = connect(mapStateToProps, mapDispatchToProps)(AuditoriumView)

--- a/auditorium/src/views/components/_shared/multi-step-form.js
+++ b/auditorium/src/views/components/_shared/multi-step-form.js
@@ -4,7 +4,7 @@ const { useState, useRef, useEffect } = require('preact/hooks')
 const { forwardRef } = require('preact/compat')
 
 const MultiStepForm = (props) => {
-  const { onsubmit, children, ...otherProps } = props
+  const { onsubmit, children, steps, ...otherProps } = props
 
   const autofocusRef = useRef(null)
   const [step, setStep] = useState(0)
@@ -29,14 +29,14 @@ const MultiStepForm = (props) => {
       values[key] = value
     })
     Object.assign(formData.current, values)
-    if (step < props.steps.length - 1) {
+    if (step < steps.length - 1) {
       setStep(step + 1)
     } else {
       onsubmit(formData.current, handleCancel)
     }
   }
 
-  const current = forwardRef(props.steps[step])({
+  const current = forwardRef(steps[step])({
     onCancel: handleCancel,
     ref: autofocusRef
   })

--- a/auditorium/src/views/components/_shared/share.js
+++ b/auditorium/src/views/components/_shared/share.js
@@ -31,7 +31,7 @@ const Share = (props) => {
         urlTemplate: window.location.origin + '/join/{token}/',
         accountId: accountId
       },
-      __('An invite email has been sent.'),
+      __('An invite email has been sent to <strong>%s</strong>.', invitee),
       __('There was an error inviting the user, please try again.')
     )
       .then(() => {

--- a/auditorium/src/views/components/_shared/with-layout.js
+++ b/auditorium/src/views/components/_shared/with-layout.js
@@ -3,6 +3,7 @@ const { h, Fragment } = require('preact')
 const { connect } = require('react-redux')
 
 const HighlightBox = require('./highlight-box')
+const flash = require('./../../../action-creators/flash')
 
 const Layout = (props) => (
   <div class='f5 roboto dark-gray'>
@@ -15,14 +16,6 @@ const Layout = (props) => (
       </div>
     </div>
     <div class='mw8 center ph0 ph3-ns pb4'>
-      {props.flash
-        ? (
-          <div>
-            <p class='dib pa2 br2 ma0 mt3 ml3 ml0-ns mr3 mr0-ns bg-light-yellow'>
-              {props.flash}
-            </p>
-          </div>
-        ) : null}
       {props.error
         ? (
           <Fragment>
@@ -37,24 +30,41 @@ const Layout = (props) => (
     <div class='mw8 center flex flex-column flex-row-ns justify-between ph3 pb5 moon-gray'>
       <div>
         <p class='b ma0 mb1'>
-          Offen
+        Offen
         </p>
         <p class='ma0 mb2' dangerouslySetInnerHTML={{ __html: __('Transparent web analytics<br>for everyone') }} />
       </div>
       <div>
         <a href='https://www.offen.dev/' class='normal link dim moon-gray' target='_blank' rel='noopener noreferrer'>
-          www.offen.dev
+        www.offen.dev
         </a>
       </div>
     </div>
+    {props.flash.length
+      ? (
+        <div class='fixed bottom-0 bottom-2-ns w-100 ph4-ns'>
+          {props.flash.map((message) => (
+            <p
+              key={message.id}
+              class='pointer mw6 mv0 mt3-ns center ph3 pv4 bg-light-yellow shadow-1-ns b--black-10 bt bn-ns flex items-center'
+              onclick={() => props.handleExpire(message.id)}
+            >
+              <img src='/offen-icon-black.svg' alt='Offen logo' height='30' class='ma0 mr3' />
+              <span
+                dangerouslySetInnerHTML={{ __html: message.content }}
+              />
+            </p>
+          ))}
+        </div>
+      ) : null}
   </div>
 )
 
 const withLayout = () => (OriginalComponent) => {
   const WrappedComponent = (props) => {
-    const { error, flash, ...otherProps } = props
+    const { error, flash, handleExpire, ...otherProps } = props
     return (
-      <Layout error={error} flash={flash}>
+      <Layout error={error} flash={flash} handleExpire={handleExpire}>
         <OriginalComponent {...otherProps} />
       </Layout>
     )
@@ -65,7 +75,11 @@ const withLayout = () => (OriginalComponent) => {
     flash: state.flash
   })
 
-  return connect(mapStateToProps)(WrappedComponent)
+  const mapDispatchToProps = {
+    handleExpire: flash.expire
+  }
+
+  return connect(mapStateToProps, mapDispatchToProps)(WrappedComponent)
 }
 
 module.exports = withLayout

--- a/auditorium/src/views/components/auditorium/embed-code.js
+++ b/auditorium/src/views/components/auditorium/embed-code.js
@@ -6,7 +6,11 @@ const classnames = require('classnames')
 const Collapsible = require('./../_shared/collapsible')
 
 const EmbedCode = (props) => {
-  const { model, collapsible } = props
+  const { model, collapsible, onCopy } = props
+
+  function handleCopy () {
+    onCopy(__('Successfully copied embed code to clipboard.'))
+  }
 
   const renderHeader = (props = {}) => {
     const { handleToggle = null, isCollapsed } = props
@@ -39,6 +43,7 @@ const EmbedCode = (props) => {
         />
       </div>
       <CopyToClipboard
+        onCopy={handleCopy}
         text={
          `<script async src="${window.location.origin}/script.js" data-account-id="${model.account.accountId}"></script>`
         }

--- a/auditorium/src/views/components/console/create-account.js
+++ b/auditorium/src/views/components/console/create-account.js
@@ -16,7 +16,7 @@ const CreateAccount = (props) => {
         emailAddress: formData['email-address'],
         password: formData.password
       },
-      __('Log in again to use the newly created account.'),
+      __('Log in again to use the newly created account <strong>"%s"</strong>.', formData['account-name']),
       __('There was an error creating the account, please try again.')
     )
       .then(() => {

--- a/auditorium/src/views/console.js
+++ b/auditorium/src/views/console.js
@@ -69,7 +69,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = {
   handleChangeEmail: authentication.changeCredentials,
   handleChangePassword: authentication.changeCredentials,
-  handleShare: management.handleShare,
+  handleShare: management.shareAccount,
   handleLogout: authentication.logout,
   handleCreateAccount: management.createAccount,
   handleValidationError: errors.formValidation


### PR DESCRIPTION
Previously, flash messages about error and success states were shown at the top of the page which made them hard to follow when scrolled down. This PR puts them into a "toast" style layout:

![Peek 2020-03-05 20-29](https://user-images.githubusercontent.com/1662740/76018183-1ee2e580-5f20-11ea-8169-70f24adf2912.gif)
