### PR TITLE
Prevent custom crypto from failing on certain characters

### DIFF
--- a/test-site/index.html
+++ b/test-site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Index</title>
+  <title>Über – Offen - ✔️</title>
   <script async src="http://localhost:8080/script.js" data-account-id="9b63c4d8-65c0-438c-9d30-cc4b01173393"></script>
 </head>
 <body>

--- a/vault/src/web-crypto.test.js
+++ b/vault/src/web-crypto.test.js
@@ -32,13 +32,13 @@ function enqueueCryptoTests (crypto, src) {
           .createSymmetricKey()
           .then(function (_jwk) {
             jwk = _jwk
-            return crypto.encryptSymmetricWith(jwk)('alice and bob')
+            return crypto.encryptSymmetricWith(jwk)('alice – bob ✔️')
           })
           .then(function (cipher) {
             return crypto.decryptSymmetricWith(jwk)(cipher)
           })
           .then(function (result) {
-            assert.strictEqual(result, 'alice and bob')
+            assert.strictEqual(result, 'alice – bob ✔️')
           })
       })
     })
@@ -63,12 +63,12 @@ function enqueueCryptoTests (crypto, src) {
       }
 
       it('encrypts and decrypts string values', function () {
-        return crypto.encryptAsymmetricWith(publicJWK)('alice and bob')
+        return crypto.encryptAsymmetricWith(publicJWK)('alice – bob ✔️')
           .then(function (cipher) {
             return crypto.decryptAsymmetricWith(privateJWK)(cipher)
           })
           .then(function (result) {
-            assert.strictEqual(result, 'alice and bob')
+            assert.strictEqual(result, 'alice – bob ✔️')
           })
       })
     })


### PR DESCRIPTION
forge fails converting some UTF-8 characters to buffers, which is why we need to encode the strings properly before: https://github.com/digitalbazaar/forge/issues/618