### PR TITLE
Allow non-base64 encoded cookie secret in heroku environment

### DIFF
--- a/server/config/overrides.go
+++ b/server/config/overrides.go
@@ -10,8 +10,9 @@ import (
 )
 
 type herokuRuntime struct {
-	DatabaseURL string `split_words:"true"`
-	Port        int
+	DatabaseURL        string `split_words:"true"`
+	Port               int
+	HerokuCookieSecret string `split_words:"true"`
 }
 
 func applyHerokuSpecificOverrides(c *Config) error {
@@ -24,6 +25,9 @@ func applyHerokuSpecificOverrides(c *Config) error {
 	}
 	if overrides.Port != 0 {
 		c.Server.Port = overrides.Port
+	}
+	if overrides.HerokuCookieSecret != "" {
+		c.Secrets.CookieExchange = []byte(overrides.HerokuCookieSecret)
 	}
 	return nil
 }


### PR DESCRIPTION
This allows us to have Heroku generate a cookie exchange secret on creating an app from `app.json`, therefore removing another required configuration step.