### PR TITLE
Use boolean format to display mobile count to users

### DIFF
--- a/auditorium/src/views/components/auditorium/format.js
+++ b/auditorium/src/views/components/auditorium/format.js
@@ -11,6 +11,9 @@ const Format = (props) => {
   const source = Number.isFinite(children) ? children : 0
   let value = null
   switch (formatAs) {
+    case 'boolean':
+      value = source === 0 ? __('No') : __('Yes')
+      break
     case 'duration':
       value = formatDuration(source)
       break

--- a/auditorium/src/views/components/auditorium/metrics.js
+++ b/auditorium/src/views/components/auditorium/metrics.js
@@ -69,9 +69,9 @@ const RowMetrics = (props) => {
       </div>
       <div class='flex flex-wrap'>
         <KeyMetric
-          name={__('Mobile users')}
+          name={isOperator ? __('Mobile users') : __('Mobile user')}
           value={model.mobileShare}
-          formatAs='percentage'
+          formatAs={isOperator ? 'percentage' : 'boolean'}
           small
         />
         <KeyMetric


### PR DESCRIPTION
The Mobile Users value will always be 100% or 0% for users. Instead of displaying these values like this, display Yes / No.