### PR TITLE
Fix password reset

### DIFF
--- a/auditorium/src/views/reset-password.js
+++ b/auditorium/src/views/reset-password.js
@@ -13,12 +13,15 @@ const useAutofocus = require('./components/_shared/use-autofocus')
 const Form = require('./components/reset-password/form')
 
 const ResetPasswordView = (props) => {
+  const { matches } = props
+  const { token } = matches
   const autofocusRef = useAutofocus()
   return (
     <div class='w-100 mt4 mb2 br0 br2-ns'>
       <Form
-        onResetPassword={props.handleResetPassword}
+        onResetPassword={props.handleReset}
         ref={autofocusRef}
+        token={token}
       />
     </div>
   )

--- a/server/persistence/login.go
+++ b/server/persistence/login.go
@@ -168,7 +168,7 @@ func (p *persistenceLayer) ResetPassword(emailAddress, password string, oneTimeK
 	if err != nil {
 		return fmt.Errorf("persistence: error creating transaction: %w", err)
 	}
-	for _, relationship := range accountUser.Relationships {
+	for index, relationship := range accountUser.Relationships {
 		keyEncryptionKey, decryptionErr := keys.DecryptWith(oneTimeKey, relationship.OneTimeEncryptedKeyEncryptionKey)
 		if decryptionErr != nil {
 			txn.Rollback()
@@ -179,11 +179,7 @@ func (p *persistenceLayer) ResetPassword(emailAddress, password string, oneTimeK
 			return fmt.Errorf("persistence: error adding password encrypted key to relationship: %w", err)
 		}
 		relationship.OneTimeEncryptedKeyEncryptionKey = ""
-
-		if err := txn.UpdateAccountUserRelationship(&relationship); err != nil {
-			txn.Rollback()
-			return fmt.Errorf("persistence: error updating keys on relationship: %w", err)
-		}
+		accountUser.Relationships[index] = relationship
 	}
 	passwordHash, hashErr := keys.HashString(password)
 	if hashErr != nil {


### PR DESCRIPTION
Password reset is currently broken as the password will be updated, yet the updated `AccountUserRelationships` will be reverted to their old state when saving the updated user record's unchanged relationships.