### PR TITLE
Rename config value for secret

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       OFFEN_APP_DEVELOPMENT: '1'
       OFFEN_SERVER_REVERSEPROXY: '1'
       OFFEN_SERVER_PORT: 8080
-      OFFEN_SECRETS_COOKIEEXCHANGE: imLcp0dS4OaR6Lvl+z9tbg==
+      OFFEN_SECRET: imLcp0dS4OaR6Lvl+z9tbg==
     command: refresh run
 
   vault:

--- a/server/cmd/offen/cmddemo.go
+++ b/server/cmd/offen/cmddemo.go
@@ -61,7 +61,7 @@ func cmdDemo(subcommand string, flags []string) {
 		if runtime.GOOS == "windows" {
 			cfg.Database.ConnectionString = config.EnvString(fmt.Sprintf("%%Temp%%\\offen-%s.db", dbID.String()))
 		}
-		cfg.Secrets.CookieExchange = mustSecret(16)
+		cfg.Secret = mustSecret(16)
 		a.config = cfg
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -150,7 +150,7 @@ func New(populateMissing bool, override string) (*Config, error) {
 		}
 		update := map[string]string{}
 		for _, val := range []autopopulatedValue{
-			{"OFFEN_SECRETS_COOKIEEXCHANGE", c.Secrets.CookieExchange.IsZero},
+			{"OFFEN_SECRET", c.Secret.IsZero},
 		} {
 			if !val.isEmpty() {
 				fmt.Println("val not empty, skipping")
@@ -174,12 +174,12 @@ func New(populateMissing bool, override string) (*Config, error) {
 		return result, err
 	}
 
-	if c.Secrets.CookieExchange.IsZero() {
+	if c.Secret.IsZero() {
 		cookieSecret, cookieSecretErr := keys.GenerateRandomBytes(keys.DefaultSecretLength)
 		if cookieSecretErr != nil {
 			return &c, fmt.Errorf("config: error creating cookie one-off secret: %w", cookieSecretErr)
 		}
-		c.Secrets.CookieExchange = Bytes(cookieSecret)
+		c.Secret = Bytes(cookieSecret)
 	}
 
 	// some deploy targets have custom overrides for creating the

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -27,7 +27,7 @@ func TestNew(t *testing.T) {
 		t.Errorf("Unexpected AutoTLS config %v", c.Server.AutoTLS)
 	}
 
-	if c.Secrets.CookieExchange == nil {
-		t.Error("Expected cookie exchange secret to be populated")
+	if c.Secret == nil {
+		t.Error("Expected app secret to be populated")
 	}
 }

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -30,10 +30,8 @@ type Config struct {
 		DemoAccount  string `ignored:"true"`
 		DeployTarget DeployTarget
 	}
-	Secrets struct {
-		CookieExchange Bytes
-	}
-	SMTP struct {
+	Secret Bytes
+	SMTP   struct {
 		User     string
 		Password string
 		Host     string

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -30,10 +30,8 @@ type Config struct {
 		DemoAccount  string `ignored:"true"`
 		DeployTarget DeployTarget
 	}
-	Secrets struct {
-		CookieExchange Bytes
-	}
-	SMTP struct {
+	Secret Bytes
+	SMTP   struct {
 		User     string
 		Password string
 		Host     string

--- a/server/config/overrides.go
+++ b/server/config/overrides.go
@@ -10,9 +10,9 @@ import (
 )
 
 type herokuRuntime struct {
-	DatabaseURL        string `split_words:"true"`
-	Port               int
-	HerokuCookieSecret string `split_words:"true"`
+	DatabaseURL string `split_words:"true"`
+	Port        int
+	AppSecret   string `split_words:"true"`
 }
 
 func applyHerokuSpecificOverrides(c *Config) error {
@@ -26,8 +26,8 @@ func applyHerokuSpecificOverrides(c *Config) error {
 	if overrides.Port != 0 {
 		c.Server.Port = overrides.Port
 	}
-	if overrides.HerokuCookieSecret != "" {
-		c.Secrets.CookieExchange = []byte(overrides.HerokuCookieSecret)
+	if overrides.AppSecret != "" {
+		c.Secret = []byte(overrides.AppSecret)
 	}
 	return nil
 }

--- a/server/config/overrides_test.go
+++ b/server/config/overrides_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestApplyHerokuSpecificOverrides(t *testing.T) {
 	fixtures := map[string]string{
-		"DATABASE_URL":         "https://my.postgres:5432",
-		"PORT":                 "9999",
-		"HEROKU_COOKIE_SECRET": "abcdefghijk",
+		"DATABASE_URL": "https://my.postgres:5432",
+		"PORT":         "9999",
+		"APP_SECRET":   "abcdefghijk",
 	}
 	for key, value := range fixtures {
 		defer os.Setenv(key, os.Getenv(key))
@@ -23,7 +23,7 @@ func TestApplyHerokuSpecificOverrides(t *testing.T) {
 	c := &Config{}
 	c.Server.Port = 5555
 	c.Database.ConnectionString = "/tmp/db.sqlite"
-	c.Secrets.CookieExchange = []byte("123456789")
+	c.Secret = []byte("123456789")
 	c.Server.AutoTLS = []string{"www.offen.dev"}
 
 	if err := applyHerokuSpecificOverrides(c); err != nil {
@@ -38,8 +38,8 @@ func TestApplyHerokuSpecificOverrides(t *testing.T) {
 		t.Errorf("Unexpected port value %v", c.Server.Port)
 	}
 
-	if !bytes.Equal(c.Secrets.CookieExchange.Bytes(), []byte("abcdefghijk")) {
-		t.Errorf("Unexpected cookie secret %v", c.Secrets.CookieExchange.Bytes())
+	if !bytes.Equal(c.Secret.Bytes(), []byte("abcdefghijk")) {
+		t.Errorf("Unexpected cookie secret %v", c.Secret.Bytes())
 	}
 
 	if c.Server.AutoTLS[0] != "www.offen.dev" {

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -156,7 +156,7 @@ func New(opts ...Config) http.Handler {
 	}
 
 	rt.sanitizer = bluemonday.StrictPolicy()
-	rt.cookieSigner = securecookie.New(rt.config.Secrets.CookieExchange.Bytes(), nil)
+	rt.cookieSigner = securecookie.New(rt.config.Secret.Bytes(), nil)
 
 	optin := optinMiddleware(optinKey, optinValue)
 	userCookie := userCookieMiddleware(cookieKey, contextKeyCookie)


### PR DESCRIPTION
Right now the only secret still in use is oddly named. This renames it to `OFFEN_SECRET`.

This is a __breaking change__ that requires users to rename their exported `OFFEN_SECRETS_COOKIEEXCHANGE` to `OFFEN_SECRET`.