### PR TITLE
When using root account feature, do not display banner and only collect on consent

### DIFF
--- a/auditorium/index.js
+++ b/auditorium/index.js
@@ -31,6 +31,7 @@ const flashReducer = require('./src/reducers/flash')
 const staleReducer = require('./src/reducers/stale')
 const modelReducer = require('./src/reducers/model')
 const redirectMiddleware = require('./src/middleware/redirect')
+const pushStateMiddleware = require('./src/middleware/push-state')
 const flashMessagesMiddleware = require('./src/middleware/flash-messages')
 const navigation = require('./src/action-creators/navigation')
 const errors = require('./src/action-creators/errors')
@@ -47,6 +48,7 @@ const middlewares = [
   thunk.withExtraArgument(
     msg => vaultInstance.then(postMessage => postMessage(msg))
   ),
+  pushStateMiddleware,
   redirectMiddleware,
   flashMessagesMiddleware
 ]

--- a/auditorium/src/middleware/push-state.js
+++ b/auditorium/src/middleware/push-state.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020 - Offen Authors <hioffen@posteo.de>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const { route } = require('preact-router')
+
+module.exports = (store) => (next) => (action) => {
+  switch (action.type) {
+    case 'EXPRESS_CONSENT_SUCCESS':
+      route(window.location.pathname)
+      next(action)
+      break
+    default:
+      next(action)
+  }
+}

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -4,6 +4,7 @@ account_users:
     admin_level: 1
     accounts:
       - 9b63c4d8-65c0-438c-9d30-cc4b01173393
+      - 3c8e3495-17c5-4be3-836c-e56fc562ace0
       - 78403940-ae4f-4aff-a395-1e90f145cf62
   - email: other@offen.dev
     password: other
@@ -14,5 +15,7 @@ account_users:
 accounts:
   - name: develop
     id: 9b63c4d8-65c0-438c-9d30-cc4b01173393
+  - name: auditorium
+    id: 3c8e3495-17c5-4be3-836c-e56fc562ace0
   - name: other
     id: 78403940-ae4f-4aff-a395-1e90f145cf62

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       OFFEN_SERVER_REVERSEPROXY: '1'
       OFFEN_SERVER_PORT: 8080
       OFFEN_SECRET: imLcp0dS4OaR6Lvl+z9tbg==
+      OFFEN_APP_ROOTACCOUNT: 3c8e3495-17c5-4be3-836c-e56fc562ace0
     command: refresh run
 
   vault:

--- a/script/index.js
+++ b/script/index.js
@@ -13,6 +13,8 @@ var events = require('./src/events')
 // again when being accessed from inside a function body
 var accountId = document.currentScript && document.currentScript.dataset.accountId
 var scriptHost = document.currentScript && document.currentScript.src
+var noBanner = document.currentScript && 'noBanner' in document.currentScript.dataset
+
 var scriptUrl = ''
 try {
   scriptUrl = new window.URL(scriptHost).origin
@@ -26,6 +28,9 @@ function main () {
       payload: {
         accountId: accountId,
         event: events.pageview(context === 'initial')
+      },
+      meta: {
+        noBanner: noBanner
       }
     }
     send(message)

--- a/server/public/index.go.html
+++ b/server/public/index.go.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="/tachyons.min.css">
     {{ template "meta" . }}
     {{ with .rootAccount }}
-      <script src="/script.js" data-account-id="{{ . }}"></script>
+      <script src="/script.js" data-no-banner data-account-id="{{ . }}"></script>
     {{ end }}
   </head>
   <body class="bg-washed-yellow">

--- a/vault/src/middleware.js
+++ b/vault/src/middleware.js
@@ -14,6 +14,9 @@ function optIn (event, respond, next) {
       if (status) {
         return status
       }
+      if (event.data.meta && event.data.meta.noBanner) {
+        return consentStatus.DENY
+      }
       function styleHost (payload) {
         return respond({
           type: 'STYLES',


### PR DESCRIPTION
This PR allows using the "Root Account" feature for collecting usage stats in an Auditorium in a sensible way. When `OFFEN_APP_ROOTACCOUNT` is now set the following happens:

- the script will be included in the Auditorium using the given Account ID
- when consent has been given already, usage data is being collected
- in case consent has not been given, no data is being collected
- in case the user uses the index page of the auditorium to opt in, a push state event is triggered, thus triggering a page view event

![Peek 2020-05-28 16-12](https://user-images.githubusercontent.com/1662740/83152998-b8c0c580-a0fe-11ea-8cf2-21804ec8acbf.gif)
