### PR TITLE
Signed user IDs

### DIFF
--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -22,13 +22,14 @@ type Config struct {
 		ConnectionString EnvString `default:"/var/opt/offen/offen.db"`
 	}
 	App struct {
-		Development  bool     `default:"false"`
-		LogLevel     LogLevel `default:"info"`
-		SingleNode   bool     `default:"true"`
-		Locale       Locale   `default:"en"`
-		RootAccount  string
-		DemoAccount  string `ignored:"true"`
-		DeployTarget DeployTarget
+		Development         bool     `default:"false"`
+		LogLevel            LogLevel `default:"info"`
+		SingleNode          bool     `default:"true"`
+		Locale              Locale   `default:"en"`
+		RootAccount         string
+		DemoAccount         string `ignored:"true"`
+		DeployTarget        DeployTarget
+		AllowUnsignedUserID bool `default:"false"`
 	}
 	Secret Bytes
 	SMTP   struct {

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -22,13 +22,14 @@ type Config struct {
 		ConnectionString EnvString `default:"%Temp%\offen.db"`
 	}
 	App struct {
-		Development  bool     `default:"false"`
-		LogLevel     LogLevel `default:"info"`
-		SingleNode   bool     `default:"true"`
-		Locale       Locale   `default:"en"`
-		RootAccount  string
-		DemoAccount  string `ignored:"true"`
-		DeployTarget DeployTarget
+		Development         bool     `default:"false"`
+		LogLevel            LogLevel `default:"info"`
+		SingleNode          bool     `default:"true"`
+		Locale              Locale   `default:"en"`
+		RootAccount         string
+		DemoAccount         string `ignored:"true"`
+		DeployTarget        DeployTarget
+		AllowUnsignedUserID bool `default:"false"`
 	}
 	Secret Bytes
 	SMTP   struct {

--- a/server/keys/sign.go
+++ b/server/keys/sign.go
@@ -1,0 +1,40 @@
+package keys
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+func sign(value string, secret []byte) ([]byte, error) {
+	h := hmac.New(sha256.New, secret)
+	if _, err := h.Write([]byte(value)); err != nil {
+		return nil, fmt.Errorf("keys: error signing value: %w", err)
+	}
+	return h.Sum(nil), nil
+}
+
+func Sign(value string, secret []byte) (string, error) {
+	bytes, err := sign(value, secret)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(bytes), nil
+}
+
+func Verify(value, mac string, secret []byte) error {
+	compare, err := sign(value, secret)
+	if err != nil {
+		return fmt.Errorf("keys: error computing mac for comparison: %w", err)
+	}
+	macBytes, err := base64.StdEncoding.DecodeString(mac)
+	if err != nil {
+		return fmt.Errorf("keys: error decoding given mac: %w", err)
+	}
+	if !hmac.Equal(macBytes, compare) {
+		return errors.New("keys: signature did not match value")
+	}
+	return nil
+}

--- a/server/keys/sign.go
+++ b/server/keys/sign.go
@@ -1,3 +1,6 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 import (

--- a/server/keys/sign.go
+++ b/server/keys/sign.go
@@ -16,6 +16,8 @@ func sign(value string, secret []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
+// Sign creates a Base64 encoded signature for the given string using the
+// given secret.
 func Sign(value string, secret []byte) (string, error) {
 	bytes, err := sign(value, secret)
 	if err != nil {
@@ -24,12 +26,14 @@ func Sign(value string, secret []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
-func Verify(value, mac string, secret []byte) error {
+// Verify checks whether the given value matches the given Base64 encoded
+// signature when using the given secret.
+func Verify(value, signature string, secret []byte) error {
 	compare, err := sign(value, secret)
 	if err != nil {
 		return fmt.Errorf("keys: error computing mac for comparison: %w", err)
 	}
-	macBytes, err := base64.StdEncoding.DecodeString(mac)
+	macBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
 		return fmt.Errorf("keys: error decoding given mac: %w", err)
 	}

--- a/server/keys/sign_test.go
+++ b/server/keys/sign_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
 package keys
 
 import "testing"

--- a/server/keys/sign_test.go
+++ b/server/keys/sign_test.go
@@ -1,0 +1,28 @@
+package keys
+
+import "testing"
+
+func TestSign_Verify(t *testing.T) {
+	t.Run("not ok", func(t *testing.T) {
+		val := "okidoki"
+		secret := []byte("abc123")
+		verifyErr := Verify(val, "oingo boingo", secret)
+		if verifyErr == nil {
+			t.Errorf("Expected error verifying bad signature, got: %v", verifyErr)
+		}
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		val := "okidoki"
+		secret := []byte("abc123")
+		signature, signErr := Sign(val, secret)
+		if signErr != nil {
+			t.Errorf("Unexpected error signing value: %v", signErr)
+		}
+
+		verifyErr := Verify(val, signature, secret)
+		if verifyErr != nil {
+			t.Errorf("Unexpected error verifying signature: %v", verifyErr)
+		}
+	})
+}

--- a/server/persistence/bootstrap.go
+++ b/server/persistence/bootstrap.go
@@ -91,6 +91,19 @@ func (p *persistenceLayer) Bootstrap(config BootstrapConfig) error {
 			return fmt.Errorf("persistence: error creating account user relationship: %w", err)
 		}
 	}
+	secret, err := keys.GenerateRandomValue(keys.DefaultSecretLength)
+	if err != nil {
+		txn.Rollback()
+		return fmt.Errorf("persistence: error creating signing secret: %w", err)
+	}
+	if err := txn.CreateConfigValue(&ConfigValue{
+		Key:   ConfigValueSigningSecret,
+		Value: secret,
+	}); err != nil {
+		txn.Rollback()
+		return fmt.Errorf("persistence: error persisting signing secret: %w", err)
+	}
+
 	if err := txn.Commit(); err != nil {
 		return fmt.Errorf("persistence: error committing seed data: %w", err)
 	}

--- a/server/persistence/config.go
+++ b/server/persistence/config.go
@@ -1,0 +1,21 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package persistence
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+func (p *persistenceLayer) GetSigningSecret() ([]byte, error) {
+	v, err := p.dal.FindConfigValue(FindConfigValueQueryByKey(ConfigValueSigningSecret))
+	if err != nil {
+		return nil, fmt.Errorf("persistence: error looking up signing secret: %w", err)
+	}
+	b, err := base64.StdEncoding.DecodeString(v.Value)
+	if err != nil {
+		return nil, fmt.Errorf("persistence: error decoding persisted secret: %w", err)
+	}
+	return b, nil
+}

--- a/server/persistence/dal.go
+++ b/server/persistence/dal.go
@@ -25,6 +25,8 @@ type DataAccessLayer interface {
 	UpdateAccountUserRelationship(*AccountUserRelationship) error
 	FindAccountUserRelationships(interface{}) ([]AccountUserRelationship, error)
 	DeleteAccountUserRelationships(interface{}) error
+	FindConfigValue(interface{}) (*ConfigValue, error)
+	CreateConfigValue(*ConfigValue) error
 	Transaction() (Transaction, error)
 	ApplyMigrations() error
 	DropAll() error
@@ -62,6 +64,9 @@ type DeleteEventsQueryOlderThan string
 // DeleteEventsQueryByEventIDs requests deletion of all events contained in the
 // given set.
 type DeleteEventsQueryByEventIDs []string
+
+// FindConfigValueQueryByKey looks up the a config value
+type FindConfigValueQueryByKey string
 
 // DeleteSecretQueryBySecretID requests deletion of the secret record with the given
 // secret id.

--- a/server/persistence/entities.go
+++ b/server/persistence/entities.go
@@ -33,6 +33,18 @@ type Secret struct {
 	EncryptedSecret string
 }
 
+// The signing key is the only config value currently in use.
+const (
+	ConfigValueSigningSecret = "signing_secret"
+)
+
+// ConfigValue can be used by the application to store persistent configuration
+// values like for example secrets for signing cookies in the database.
+type ConfigValue struct {
+	Key   string
+	Value string
+}
+
 // AccountUserAdminLevel is used to describe the privileges granted to an account
 // user. If zero, no admin privileges are given.
 type AccountUserAdminLevel int

--- a/server/persistence/persistence.go
+++ b/server/persistence/persistence.go
@@ -26,6 +26,7 @@ type Service interface {
 	GenerateOneTimeKey(emailAddress string) ([]byte, error)
 	ResetPassword(emailAddress, password string, oneTimeKey []byte) error
 	ShareAccount(inviteeEmailAddress, providerEmailAddress, providerPassword, accountID string, grantAdminPrivileges bool) (ShareAccountResult, error)
+	GetSigningSecret() ([]byte, error)
 	Join(emailAddress, password string) error
 	Expire(retention time.Duration) (int, error)
 	Bootstrap(data BootstrapConfig) error

--- a/server/persistence/relational/config.go
+++ b/server/persistence/relational/config.go
@@ -1,0 +1,38 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package relational
+
+import (
+	"fmt"
+
+	"github.com/jinzhu/gorm"
+	"github.com/offen/offen/server/persistence"
+)
+
+func (r *relationalDAL) CreateConfigValue(v *persistence.ConfigValue) error {
+	local := importConfigValue(v)
+	if err := r.db.Create(&local).Error; err != nil {
+		return fmt.Errorf("relational: error creating config value: %w", err)
+	}
+	return nil
+}
+
+func (r *relationalDAL) FindConfigValue(q interface{}) (*persistence.ConfigValue, error) {
+	var value ConfigValue
+	switch query := q.(type) {
+	case persistence.FindConfigValueQueryByKey:
+		if err := r.db.Where(
+			"key = ?",
+			string(query),
+		).First(&value).Error; err != nil {
+			if gorm.IsRecordNotFoundError(err) {
+				return value.export(), persistence.ErrUnknownSecret("relational: no matching config value found")
+			}
+			return value.export(), fmt.Errorf("relational: error looking up config value: %w", err)
+		}
+		return value.export(), nil
+	default:
+		return value.export(), persistence.ErrBadQuery
+	}
+}

--- a/server/persistence/relational/models.go
+++ b/server/persistence/relational/models.go
@@ -62,6 +62,27 @@ func importSecret(s *persistence.Secret) Secret {
 	}
 }
 
+// ConfigValue can be used by the application to store persistent configuration
+// values like for example secrets for signing cookies in the database.
+type ConfigValue struct {
+	Key   string `gorm:"primary_key"`
+	Value string
+}
+
+func (v *ConfigValue) export() *persistence.ConfigValue {
+	return &persistence.ConfigValue{
+		Key:   v.Key,
+		Value: v.Value,
+	}
+}
+
+func importConfigValue(v *persistence.ConfigValue) ConfigValue {
+	return ConfigValue{
+		Key:   v.Key,
+		Value: v.Value,
+	}
+}
+
 // AccountUser is a person that can log in and access data related to all
 // associated accounts.
 type AccountUser struct {

--- a/server/router/accounts_test.go
+++ b/server/router/accounts_test.go
@@ -50,7 +50,7 @@ func TestRouter_GetAccount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cookieSigner := securecookie.New([]byte("abc123"), nil)
 			auth, _ := cookieSigner.Encode("auth", test.accountID)
-			rt := router{db: test.database, cookieSigner: cookieSigner}
+			rt := router{db: test.database, authenticationSigner: cookieSigner}
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/%s", test.accountID), nil)
 			m := gin.New()
@@ -138,7 +138,7 @@ func TestRouter_DeleteAccount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cookieSigner := securecookie.New([]byte("abc123"), nil)
 			auth, _ := cookieSigner.Encode("auth", test.accountID)
-			rt := router{db: test.database, cookieSigner: cookieSigner}
+			rt := router{db: test.database, authenticationSigner: cookieSigner}
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/%s", test.accountID), nil)
 			m := gin.New()

--- a/server/router/events.go
+++ b/server/router/events.go
@@ -63,11 +63,9 @@ func (rt *router) postEvents(c *gin.Context) {
 	// this handler might be called without a cookie / i.e. receiving an
 	// anonymous event, in which case it is important **NOT** to re-issue
 	// the user cookie.
+	ck, _ := rt.userCookie(userID, c.GetBool(contextKeySecureContext))
 	if userID != "" {
-		http.SetCookie(
-			c.Writer,
-			rt.userCookie(userID, c.GetBool(contextKeySecureContext)),
-		)
+		http.SetCookie(c.Writer, ck)
 	}
 	c.JSON(http.StatusCreated, ackResponse{true})
 }
@@ -135,11 +133,9 @@ func (rt *router) purgeEvents(c *gin.Context) {
 		).Pipe(c)
 		return
 	}
+	ck, _ := rt.userCookie("", c.GetBool(contextKeySecureContext))
 	if c.Query("user") != "" {
-		http.SetCookie(
-			c.Writer,
-			rt.userCookie("", c.GetBool(contextKeySecureContext)),
-		)
+		http.SetCookie(c.Writer, ck)
 	}
 	c.Status(http.StatusNoContent)
 }

--- a/server/router/events_test.go
+++ b/server/router/events_test.go
@@ -222,6 +222,10 @@ func (m *mockPostEventsService) Insert(string, string, string) error {
 	return m.err
 }
 
+func (m *mockPostEventsService) GetSigningSecret() ([]byte, error) {
+	return []byte("ok"), nil
+}
+
 func TestRouter_postEvents(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/server/router/exchange.go
+++ b/server/router/exchange.go
@@ -73,7 +73,14 @@ func (rt *router) postUserSecret(c *gin.Context) {
 		return
 	}
 
-	ck, _ = rt.userCookie(userID, c.GetBool(contextKeySecureContext))
+	ck, err = rt.userCookie(userID, c.GetBool(contextKeySecureContext))
+	if err != nil {
+		newJSONError(
+			fmt.Errorf("router: error creating user cookie: %w", err),
+			http.StatusInternalServerError,
+		).Pipe(c)
+		return
+	}
 	http.SetCookie(c.Writer, ck)
 	c.Status(http.StatusNoContent)
 }

--- a/server/router/exchange.go
+++ b/server/router/exchange.go
@@ -73,9 +73,7 @@ func (rt *router) postUserSecret(c *gin.Context) {
 		return
 	}
 
-	http.SetCookie(
-		c.Writer,
-		rt.userCookie(userID, c.GetBool(contextKeySecureContext)),
-	)
+	ck, _ = rt.userCookie(userID, c.GetBool(contextKeySecureContext))
+	http.SetCookie(c.Writer, ck)
 	c.Status(http.StatusNoContent)
 }

--- a/server/router/exchange_test.go
+++ b/server/router/exchange_test.go
@@ -145,7 +145,7 @@ func TestRouter_PostUserSecret(t *testing.T) {
 				Value: "existing-user-id",
 			},
 			http.StatusNoContent,
-			func(input string) bool { return input == "existing-user-id" },
+			func(input string) bool { return strings.HasPrefix(input, "existing-user-id,") },
 		},
 	}
 	for _, test := range tests {

--- a/server/router/exchange_test.go
+++ b/server/router/exchange_test.go
@@ -86,6 +86,10 @@ func (m *mockUserSecretDatabase) AssociateUserSecret(string, string, string) err
 	return m.err
 }
 
+func (m *mockUserSecretDatabase) GetSigningSecret() ([]byte, error) {
+	return []byte("ok"), nil
+}
+
 func TestRouter_PostUserSecret(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -180,7 +180,7 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 		return
 	}
-	signedCredentials, signErr := rt.cookieSigner.MaxAge(24*60*60).Encode("credentials", forgotPasswordCredentials{
+	signedCredentials, signErr := rt.authenticationSigner.MaxAge(24*60*60).Encode("credentials", forgotPasswordCredentials{
 		Token:        token,
 		EmailAddress: req.EmailAddress,
 	})
@@ -234,7 +234,7 @@ func (rt *router) postResetPassword(c *gin.Context) {
 		return
 	}
 	var credentials forgotPasswordCredentials
-	if err := rt.cookieSigner.Decode("credentials", req.Token, &credentials); err != nil {
+	if err := rt.authenticationSigner.Decode("credentials", req.Token, &credentials); err != nil {
 		newJSONError(
 			fmt.Errorf("error decoding signed token: %w", err),
 			http.StatusBadRequest,

--- a/server/router/login_test.go
+++ b/server/router/login_test.go
@@ -102,7 +102,7 @@ func TestRouter_postLogin(t *testing.T) {
 			rt := router{
 				config:       &config.Config{},
 				db:           &test.db,
-				cookieSigner: securecookie.New([]byte("abc"), nil),
+				authenticationSigner: securecookie.New([]byte("abc"), nil),
 			}
 			m.POST("/", rt.postLogin)
 			r := httptest.NewRequest(http.MethodPost, "/", test.body)
@@ -443,7 +443,7 @@ func TestRouter_postResetPassword(t *testing.T) {
 			rt := router{
 				config:       &config.Config{},
 				db:           &test.db,
-				cookieSigner: signer,
+				authenticationSigner: signer,
 			}
 			m.POST("/", rt.postResetPassword)
 			r := httptest.NewRequest(http.MethodPost, "/", test.body)
@@ -527,7 +527,7 @@ func TestRouter_postForgotPassword(t *testing.T) {
 			rt := router{
 				config:       &config.Config{},
 				db:           &test.db,
-				cookieSigner: securecookie.New([]byte("abc"), nil),
+				authenticationSigner: securecookie.New([]byte("abc"), nil),
 				mailer:       &test.mailer,
 				emails: func() *template.Template {
 					t := template.New("emails")

--- a/server/router/management.go
+++ b/server/router/management.go
@@ -106,7 +106,7 @@ func (rt *router) postShareAccount(c *gin.Context) {
 		bodyErr = rt.emails.ExecuteTemplate(body, "body_existing_user_invite", map[string]interface{}{"accountNames": result.AccountNames})
 		subjectErr = rt.emails.ExecuteTemplate(subject, "subject_existing_user_invite", nil)
 	} else {
-		signedCredentials, signErr := rt.cookieSigner.MaxAge(7*24*60*60).Encode("credentials", req.InviteeEmailAddress)
+		signedCredentials, signErr := rt.authenticationSigner.MaxAge(7*24*60*60).Encode("credentials", req.InviteeEmailAddress)
 		if signErr != nil {
 			rt.logError(signErr, "error signing token")
 			c.Status(http.StatusNoContent)
@@ -152,7 +152,7 @@ func (rt *router) postJoin(c *gin.Context) {
 		return
 	}
 	var email string
-	if err := rt.cookieSigner.Decode("credentials", req.Token, &email); err != nil {
+	if err := rt.authenticationSigner.Decode("credentials", req.Token, &email); err != nil {
 		newJSONError(
 			fmt.Errorf("error decoding signed token: %w", err),
 			http.StatusBadRequest,

--- a/server/router/management_test.go
+++ b/server/router/management_test.go
@@ -311,7 +311,7 @@ func TestRouter_postShareAccount(t *testing.T) {
 			rt := router{
 				config:       &config.Config{},
 				db:           &test.db,
-				cookieSigner: signer,
+				authenticationSigner: signer,
 				mailer:       &test.mailer,
 				emails: func() *template.Template {
 					t := template.New("emails")
@@ -420,7 +420,7 @@ func TestRouter_postJoin(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			rt := router{
 				db:           &test.db,
-				cookieSigner: signer,
+				authenticationSigner: signer,
 			}
 
 			m := gin.New()

--- a/server/router/middleware.go
+++ b/server/router/middleware.go
@@ -61,6 +61,13 @@ func (rt *router) userCookieMiddleware(cookieKey, contextKey string) gin.Handler
 		} else {
 			var signature string
 			chunks := strings.Split(ck.Value, ",")
+			if len(chunks) != 2 {
+				newJSONError(
+					errors.New("user cookie: received malformed identifier"),
+					http.StatusBadRequest,
+				).Pipe(c)
+				return
+			}
 			userID, signature = chunks[0], chunks[1]
 
 			if err := keys.Verify(userID, signature, userCookieSecret); err != nil {

--- a/server/router/middleware_test.go
+++ b/server/router/middleware_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/securecookie"
+	"github.com/offen/offen/server/keys"
 	"github.com/offen/offen/server/persistence"
 )
 
@@ -100,17 +101,18 @@ func TestUserCookieMiddleware(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("Unexpected status code %v", w.Code)
 		}
-		if !strings.Contains(w.Body.String(), "received invalid identifier") {
+		if !strings.Contains(w.Body.String(), "received malformed identifier") {
 			t.Errorf("Unexpected body %s", w.Body.String())
 		}
 	})
 
 	t.Run("ok", func(t *testing.T) {
+		signature, _ := keys.Sign("600bf860-0477-423b-85e3-d5472c99230e", userCookieSecret)
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "/", nil)
 		r.AddCookie(&http.Cookie{
 			Name:  "user",
-			Value: "600bf860-0477-423b-85e3-d5472c99230e",
+			Value: fmt.Sprintf("600bf860-0477-423b-85e3-d5472c99230e,%s", signature),
 		})
 		m.ServeHTTP(w, r)
 		if w.Code != http.StatusOK {

--- a/server/router/middleware_test.go
+++ b/server/router/middleware_test.go
@@ -72,7 +72,8 @@ func TestOptinMiddleware(t *testing.T) {
 
 func TestUserCookieMiddleware(t *testing.T) {
 	m := gin.New()
-	m.GET("/", userCookieMiddleware("user", "1"), func(c *gin.Context) {
+	rt := router{}
+	m.GET("/", rt.userCookieMiddleware("user", "1"), func(c *gin.Context) {
 		value := c.Value("1")
 		c.String(http.StatusOK, "value is %v", value)
 	})

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -22,15 +22,15 @@ import (
 )
 
 type router struct {
-	db           persistence.Service
-	mailer       mailer.Mailer
-	fs           http.FileSystem
-	logger       *logrus.Logger
-	cookieSigner *securecookie.SecureCookie
-	template     *template.Template
-	emails       *template.Template
-	config       *config.Config
-	sanitizer    *bluemonday.Policy
+	db                   persistence.Service
+	mailer               mailer.Mailer
+	fs                   http.FileSystem
+	logger               *logrus.Logger
+	authenticationSigner *securecookie.SecureCookie
+	template             *template.Template
+	emails               *template.Template
+	config               *config.Config
+	sanitizer            *bluemonday.Policy
 }
 
 func (rt *router) logError(err error, message string) {
@@ -81,7 +81,7 @@ func (rt *router) authCookie(userID string, secure bool) (*http.Cookie, error) {
 	if userID == "" {
 		c.Expires = time.Unix(0, 0)
 	} else {
-		value, err := rt.cookieSigner.MaxAge(24*60*60).Encode(authKey, userID)
+		value, err := rt.authenticationSigner.MaxAge(24*60*60).Encode(authKey, userID)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +156,7 @@ func New(opts ...Config) http.Handler {
 	}
 
 	rt.sanitizer = bluemonday.StrictPolicy()
-	rt.cookieSigner = securecookie.New(rt.config.Secret.Bytes(), nil)
+	rt.authenticationSigner = securecookie.New(rt.config.Secret.Bytes(), nil)
 
 	optin := optinMiddleware(optinKey, optinValue)
 	userCookie := userCookieMiddleware(cookieKey, contextKeyCookie)


### PR DESCRIPTION
In order to prevent Event Spam, we can sign the User ID cookies so that attackers cannot create events using arbitrary UUIDs. Instead only IDs that have been signed by the server are being accepted.

This is a **breaking change** requiring upgraded installations to set `OFFEN_APP_ALLOWUNSIGNEDUSERID="true"` in order to enable "legacy" users to access and manage their data. Cookies sent without a signature will be augmented on next write.