### PR TITLE
Print help on unknown subcommand

### DIFF
--- a/server/cmd/offen/main.go
+++ b/server/cmd/offen/main.go
@@ -59,6 +59,8 @@ func main() {
 	case "version":
 		cmdVersion("version", flags)
 	default:
-		newLogger().Fatalf("Unknown subcommand %s\n", os.Args[1])
+		fmt.Fprintf(flag.CommandLine.Output(), "Error: unknown subcommand \"%s\"\n", os.Args[1])
+		fmt.Fprint(flag.CommandLine.Output(), mainUsage)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Improving the UX for typos on subcommands (e.g. `offen dmeo`)