### PR TITLE
Use positional args for login api method

### DIFF
--- a/vault/src/api.js
+++ b/vault/src/api.js
@@ -130,13 +130,16 @@ exports.login = loginWith(window.location.origin + '/api/login')
 exports.loginWith = loginWith
 
 function loginWith (loginUrl) {
-  return function (credentials) {
-    return credentials
+  return function (username, password) {
+    return (username && password)
       ? window
         .fetch(loginUrl, {
           method: 'POST',
           credentials: 'include',
-          body: JSON.stringify(credentials)
+          body: JSON.stringify({
+            username: username,
+            password: password
+          })
         })
         .then(handleFetchResponse)
       : window

--- a/vault/src/handler.js
+++ b/vault/src/handler.js
@@ -166,8 +166,8 @@ exports.handleLoginWith = handleLoginWith
 function handleLoginWith (api, get, set) {
   return function (message) {
     var credentials = (message.payload && message.payload.credentials) || null
-
-    return api.login(credentials)
+    var args = credentials ? [credentials.username, credentials.password] : []
+    return api.login.apply(api, args)
       .then(function (response) {
         if (credentials) {
           return set(response)


### PR DESCRIPTION
All other API methods use positional args, so this just hoists unwrapping of args a level higher.