### PR TITLE
Upgrade dexie version and further tighten CSP

### DIFF
--- a/server/router/static.go
+++ b/server/router/static.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	defaultCSP             = "default-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'"
+	defaultCSP             = "default-src 'self'; style-src 'self' 'unsafe-inline'"
 	revisionedJSRe         = regexp.MustCompile("-[0-9a-z]{10}\\.js$")
 	webfontRe              = regexp.MustCompile("\\.(woff|woff2|ttf)$")
 	scriptRe               = regexp.MustCompile("script\\.js$")

--- a/vault/package-lock.json
+++ b/vault/package-lock.json
@@ -2004,9 +2004,9 @@
       }
     },
     "dexie": {
-      "version": "3.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.0.0-rc.6.tgz",
-      "integrity": "sha512-0YytFSFfz6Zldyg8/ajIZRNtlkuKe2Owj+ZAZuI2AIGvGXTKjschO+i7IygHABS/384A6BndyJMWAb4geDwfFg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.0.1.tgz",
+      "integrity": "sha512-/s4KzlaerQnCad/uY1ZNdFckTrbdMVhLlziYQzz62Ff9Ick1lHGomvTXNfwh4ApEZATyXRyVk5F6/y8UU84B0w=="
     },
     "diff": {
       "version": "3.5.0",

--- a/vault/package.json
+++ b/vault/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "date-fns": "^1.30.1",
-    "dexie": "^3.0.0-alpha.8",
+    "dexie": "^3.0.1",
     "jwk-to-pem": "2.0.2",
     "nanohtml": "^1.8.1",
     "node-forge": "^0.9.1",


### PR DESCRIPTION
Newer Dexie versions allow us to remove `unsafe-eval` from our CSP.

See: https://github.com/dfahlander/Dexie.js/issues/722