### PR TITLE
Tighten event validation and parsing

### DIFF
--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -463,10 +463,38 @@ function getEncryptedSecretsWith (getDatabase) {
   }
 }
 
+var knownEventTypes = {
+  PAGEVIEW: true
+}
+
 exports.parseAndValidateEvent = parseAndValidateEvent
 function parseAndValidateEvent (event) {
   if (event.secretId === null || !event.payload) {
     return event
+  }
+
+  if (!knownEventTypes[event.payload.type]) {
+    return null
+  }
+
+  if (event.payload.pageload !== null && !_.isFinite(event.payload.pageload)) {
+    event.payload.pageload = null
+  }
+
+  if (!_.isBoolean(event.payload.isMobile)) {
+    event.payload.isMobile = false
+  }
+
+  if (!_.isString(event.payload.title)) {
+    event.payload.title = ''
+  }
+
+  if (!_.isString(event.payload.sessionId)) {
+    return null
+  }
+
+  if (!isValidJSONDate(event.payload.timestamp)) {
+    return null
   }
 
   try {
@@ -482,4 +510,8 @@ function parseAndValidateEvent (event) {
   }
 
   return event
+}
+
+function isValidJSONDate (dateString) {
+  return _.isString(dateString) && !_.isNaN(new Date(dateString).getTime())
 }

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -111,14 +111,7 @@ function getDefaultStatsWith (getDatabase) {
             : events
         })
         .then(function (events) {
-          return events.map(function (event) {
-            if (event.secretId === null || !event.payload) {
-              return event
-            }
-            event.payload.referrer = event.payload.referrer && new window.URL(event.payload.referrer)
-            event.payload.href = event.payload.href && new window.URL(event.payload.href)
-            return event
-          })
+          return events.map(parseAndValidateEvent).filter(_.identity)
         })
     })
     var decryptedEvents = decryptions[0]
@@ -468,4 +461,25 @@ function getEncryptedSecretsWith (getDatabase) {
         return []
       })
   }
+}
+
+exports.parseAndValidateEvent = parseAndValidateEvent
+function parseAndValidateEvent (event) {
+  if (event.secretId === null || !event.payload) {
+    return event
+  }
+
+  try {
+    event.payload.referrer = event.payload.referrer && new window.URL(event.payload.referrer)
+  } catch (err) {
+    return null
+  }
+
+  try {
+    event.payload.href = event.payload.href && new window.URL(event.payload.href)
+  } catch (err) {
+    return null
+  }
+
+  return event
 }

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -518,4 +518,51 @@ describe('src/queries.js', function () {
       })
     })
   })
+
+  describe('parseAndValidateEvent', function () {
+    it('parses referrer values into a URL', function () {
+      const result = queries.parseAndValidateEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          referrer: 'https://blog.foo.bar',
+          href: 'https://www.offen.dev/foo'
+        }
+      })
+      assert(result.payload.referrer instanceof window.URL)
+      // handling as a URL appends a trailing slash
+      assert.strictEqual(result.payload.referrer.toString(), 'https://blog.foo.bar/')
+    })
+    it('skips bad referrer values', function () {
+      const result = queries.parseAndValidateEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          referrer: '<script>alert("ZALGO")</script>',
+          href: 'https://shady.business'
+        }
+      })
+      assert.strictEqual(result, null)
+    })
+
+    it('parses href values into a URL', function () {
+      const result = queries.parseAndValidateEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          href: 'https://www.offen.dev/foo'
+        }
+      })
+      assert(result.payload.href instanceof window.URL)
+      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo')
+    })
+
+    it('skips bad href values', function () {
+      const result = queries.parseAndValidateEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          referrer: 'https://shady.business',
+          href: '<script>alert("ZALGO")</script>'
+        }
+      })
+      assert.strictEqual(result, null)
+    })
+  })
 })

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -525,7 +525,9 @@ describe('src/queries.js', function () {
         payload: {
           type: 'PAGEVIEW',
           referrer: 'https://blog.foo.bar',
-          href: 'https://www.offen.dev/foo'
+          href: 'https://www.offen.dev/foo',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
         }
       })
       assert(result.payload.referrer instanceof window.URL)
@@ -537,7 +539,9 @@ describe('src/queries.js', function () {
         payload: {
           type: 'PAGEVIEW',
           referrer: '<script>alert("ZALGO")</script>',
-          href: 'https://shady.business'
+          href: 'https://shady.business',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
         }
       })
       assert.strictEqual(result, null)
@@ -547,7 +551,9 @@ describe('src/queries.js', function () {
       const result = queries.parseAndValidateEvent({
         payload: {
           type: 'PAGEVIEW',
-          href: 'https://www.offen.dev/foo'
+          href: 'https://www.offen.dev/foo',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
         }
       })
       assert(result.payload.href instanceof window.URL)
@@ -559,10 +565,36 @@ describe('src/queries.js', function () {
         payload: {
           type: 'PAGEVIEW',
           referrer: 'https://shady.business',
-          href: '<script>alert("ZALGO")</script>'
+          href: '<script>alert("ZALGO")</script>',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
         }
       })
       assert.strictEqual(result, null)
     })
+  })
+
+  it('skips unkown event types', function () {
+    const result = queries.parseAndValidateEvent({
+      payload: {
+        type: 'ZALGO',
+        href: 'https://www.offen.dev/foo',
+        timestamp: new Date().toJSON(),
+        sessionId: 'session'
+      }
+    })
+    assert.strictEqual(result, null)
+  })
+
+  it('skips bad timestamps', function () {
+    const result = queries.parseAndValidateEvent({
+      payload: {
+        type: 'PAGEVIEW',
+        href: 'https://www.offen.dev/foo',
+        timestamp: 8192,
+        sessionId: 'session'
+      }
+    })
+    assert.strictEqual(result, null)
   })
 })


### PR DESCRIPTION
As there is no way for the server to detect invalid or tampered events, we need to be extra sure everything that has been decrypted is valid before we start calculating stats off it (to prevent XSS and similar).

---

Fixes one of the issues that were raised during the security audit performed by ROS.