### PR TITLE
Harden server by applying selective rate limits to routes

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/lestrrat-go/jwx v0.9.0
 	github.com/microcosm-cc/bluemonday v1.0.2
 	github.com/oklog/ulid v1.3.1
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rakyll/statik v0.1.6
 	github.com/sirupsen/logrus v1.4.2

--- a/server/go.sum
+++ b/server/go.sum
@@ -121,6 +121,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/server/ratelimiter/ratelimiter.go
+++ b/server/ratelimiter/ratelimiter.go
@@ -1,0 +1,84 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package ratelimiter
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	errInvalidCache        = errors.New("ratelimiter: invalid value in cache")
+	errWouldExceedDeadline = errors.New("ratelimiter: applicable rate limit would exceed give deadline")
+)
+
+// GetSetter needs to be implemented by any cache that is
+// to be used for storing limits
+type GetSetter interface {
+	Get(key string) (interface{}, bool)
+	Set(key string, value interface{}, expiry time.Duration)
+}
+
+// Throttler needs to be implemented by any rate limiter
+type Throttler interface {
+	Throttle(identifier string) <-chan Result
+}
+
+// Limiter can be used to rate limit operations
+// based on an identifier and a threshold value
+type Limiter struct {
+	threshold time.Duration
+	deadline  time.Duration
+	cache     GetSetter
+}
+
+// Result describes the outcome of a `Throttle` call
+type Result struct {
+	Error error
+	Delay time.Duration
+}
+
+// Throttle returns a channel that blocks until the configured
+// rate limit has been satisfied. The channel will send a `Result` exactly
+// once before closing, containing information on the
+// applied rate limiting or possible errors that occured
+func (l *Limiter) Throttle(identifier string) <-chan Result {
+	out := make(chan Result)
+	go func() {
+		if value, found := l.cache.Get(identifier); found {
+			if timeout, ok := value.(time.Time); ok {
+				remaining := time.Until(timeout)
+				if remaining > l.deadline {
+					out <- Result{Error: errWouldExceedDeadline}
+					return
+				}
+				l.cache.Set(
+					identifier,
+					timeout.Add(l.threshold),
+					remaining,
+				)
+				time.Sleep(remaining)
+				out <- Result{Delay: remaining}
+			} else {
+				out <- Result{Error: errInvalidCache}
+			}
+		} else {
+			l.cache.Set(identifier, time.Now().Add(l.threshold), l.threshold)
+			out <- Result{}
+		}
+		close(out)
+	}()
+	return out
+}
+
+// New creates a new Throttler using Limiter. `threshold` defines the
+// enforced minimum distance between two calls of the
+// instance's `Throttle` method using the same identifier
+func New(threshold, timeout time.Duration, cache GetSetter) Throttler {
+	return &Limiter{
+		cache:     cache,
+		threshold: threshold,
+		deadline:  timeout,
+	}
+}

--- a/server/ratelimiter/ratelimiter.go
+++ b/server/ratelimiter/ratelimiter.go
@@ -4,12 +4,11 @@
 package ratelimiter
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/offen/offen/server/keys"
 )
 
 var (
@@ -89,8 +88,8 @@ func (l *Limiter) Throttlef(format string, args ...interface{}) <-chan Result {
 // New creates a new Throttler using Limiter. `threshold` defines the
 // enforced minimum distance between two calls of the
 // instance's `Throttle` method using the same identifier
-func New(threshold, timeout time.Duration, cache GetSetter) Throttler {
-	salt, err := keys.GenerateRandomBytes(keys.DefaultSaltLength)
+func New(threshold, timeout time.Duration, cache GetSetter) *Limiter {
+	salt, err := randomBytes(16)
 	if err != nil {
 		panic("cannot initialize rate limiter")
 	}
@@ -100,4 +99,13 @@ func New(threshold, timeout time.Duration, cache GetSetter) Throttler {
 		deadline:  timeout,
 		salt:      salt,
 	}
+}
+
+func randomBytes(size int) ([]byte, error) {
+	b := make([]byte, size)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("ratelimiter: error reading random bytes: %w", err)
+	}
+	return b, nil
 }

--- a/server/ratelimiter/ratelimiter.go
+++ b/server/ratelimiter/ratelimiter.go
@@ -27,6 +27,7 @@ type GetSetter interface {
 // Throttler needs to be implemented by any rate limiter
 type Throttler interface {
 	Throttle(identifier string) <-chan Result
+	Throttlef(format string, args ...interface{}) <-chan Result
 }
 
 // Limiter can be used to rate limit operations
@@ -78,6 +79,11 @@ func (l *Limiter) Throttle(rawIdentifier string) <-chan Result {
 		close(out)
 	}()
 	return out
+}
+
+// Throttlef calls Throttle while applying the given args to the format
+func (l *Limiter) Throttlef(format string, args ...interface{}) <-chan Result {
+	return l.Throttle(fmt.Sprintf(format, args...))
 }
 
 // New creates a new Throttler using Limiter. `threshold` defines the

--- a/server/ratelimiter/ratelimiter_test.go
+++ b/server/ratelimiter/ratelimiter_test.go
@@ -76,22 +76,6 @@ func TestThrottle(t *testing.T) {
 	}
 }
 
-func TestThrottle_BadCache(t *testing.T) {
-	t.Run("bad cache", func(t *testing.T) {
-		mock := &mockGetSetter{}
-		limiter := New(time.Second, time.Hour, mock)
-		limiter.Throttle("zalgo")
-		mock.Set("zalgo", "zalgo corrupted ur cache", time.Minute)
-		result := <-limiter.Throttle("zalgo")
-		if result.Error == nil {
-			t.Errorf("Expected error, got %v", result)
-		}
-		if result.Delay > 0 {
-			t.Error("Expected error not to block")
-		}
-	})
-}
-
 func ExampleNew() {
 	limiter := New(time.Second*2, time.Hour, &mockGetSetter{})
 

--- a/server/ratelimiter/ratelimiter_test.go
+++ b/server/ratelimiter/ratelimiter_test.go
@@ -1,0 +1,116 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package ratelimiter
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type mockGetSetter struct {
+	values map[string]value
+	lock   sync.Mutex
+}
+
+type value struct {
+	value  interface{}
+	expiry time.Time
+}
+
+func (m *mockGetSetter) Get(key string) (interface{}, bool) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	v, ok := m.values[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(v.expiry) {
+		delete(m.values, key)
+		return nil, false
+	}
+	return v.value, true
+}
+
+func (m *mockGetSetter) Set(key string, v interface{}, expiry time.Duration) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.values == nil {
+		m.values = map[string]value{}
+	}
+	m.values[key] = value{v, time.Now().Add(expiry)}
+}
+
+func TestThrottle(t *testing.T) {
+	tests := []struct {
+		name               string
+		sleep              time.Duration
+		threshold          time.Duration
+		expectedThrottling bool
+	}{
+		{
+			"default",
+			time.Second,
+			time.Millisecond,
+			false,
+		},
+		{
+			"hit",
+			time.Millisecond,
+			time.Second,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			limiter := New(test.threshold, time.Hour, &mockGetSetter{})
+			<-limiter.Throttle(test.name)
+			time.Sleep(test.sleep)
+			result := <-limiter.Throttle(test.name)
+			if result.Delay > 0 != test.expectedThrottling {
+				t.Errorf("Expected %v, got %v", test.expectedThrottling, result.Delay)
+			}
+		})
+	}
+}
+
+func TestThrottle_BadCache(t *testing.T) {
+	t.Run("bad cache", func(t *testing.T) {
+		mock := &mockGetSetter{}
+		limiter := New(time.Second, time.Hour, mock)
+		limiter.Throttle("zalgo")
+		mock.Set("zalgo", "zalgo corrupted ur cache", time.Minute)
+		result := <-limiter.Throttle("zalgo")
+		if result.Error == nil {
+			t.Errorf("Expected error, got %v", result)
+		}
+		if result.Delay > 0 {
+			t.Error("Expected error not to block")
+		}
+	})
+}
+
+func ExampleNew() {
+	limiter := New(time.Second*2, time.Hour, &mockGetSetter{})
+
+	r1 := <-limiter.Throttle("example")
+	fmt.Println(r1.Delay > 0)
+
+	time.Sleep(time.Second * 3)
+	r2 := <-limiter.Throttle("example")
+	fmt.Println(r2.Delay > 0)
+
+	time.Sleep(time.Second)
+	r3 := <-limiter.Throttle("example")
+	other := <-limiter.Throttle("other")
+	fmt.Println(r3.Delay > 0)
+	fmt.Println(other.Delay > 0)
+
+	// Output:
+	// false
+	// false
+	// true
+	// false
+}

--- a/server/router/accounts.go
+++ b/server/router/accounts.go
@@ -15,7 +15,7 @@ import (
 
 func (rt *router) getAccount(c *gin.Context) {
 	accountID := c.Param("accountID")
-	if l := <-rt.limiter(time.Second).Throttlef("getAccount-%s", accountID); l.Error != nil {
+	if l := <-rt.limiter(time.Second).LinearThrottle(fmt.Sprintf("getAccount-%s", accountID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -61,7 +61,7 @@ func (rt *router) getAccount(c *gin.Context) {
 func (rt *router) deleteAccount(c *gin.Context) {
 	accountID := c.Param("accountID")
 
-	if l := <-rt.limiter(time.Second).Throttlef("deleteAccount-%s", accountID); l.Error != nil {
+	if l := <-rt.limiter(time.Second).LinearThrottle(fmt.Sprintf("deleteAccount-%s", accountID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -130,7 +130,7 @@ func (rt *router) postAccount(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second*5).Throttlef("postAccount-%s", req.EmailAddress); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).LinearThrottle(fmt.Sprintf("postAccount-%s", req.EmailAddress)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,

--- a/server/router/accounts.go
+++ b/server/router/accounts.go
@@ -18,8 +18,8 @@ func (rt *router) getAccount(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("getAccount-%s", accountID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 	accountUser, ok := c.Value(contextKeyAuth).(persistence.LoginResult)
@@ -64,8 +64,8 @@ func (rt *router) deleteAccount(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("deleteAccount-%s", accountID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 
@@ -133,8 +133,8 @@ func (rt *router) postAccount(c *gin.Context) {
 	if l := <-rt.limiter(time.Second*5).Throttlef("postAccount-%s", req.EmailAddress); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 

--- a/server/router/accounts.go
+++ b/server/router/accounts.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/offen/offen/server/persistence"
@@ -14,7 +15,13 @@ import (
 
 func (rt *router) getAccount(c *gin.Context) {
 	accountID := c.Param("accountID")
-
+	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("getAccount-%s", accountID)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
+		return
+	}
 	accountUser, ok := c.Value(contextKeyAuth).(persistence.LoginResult)
 	if !ok {
 		newJSONError(
@@ -53,6 +60,14 @@ func (rt *router) getAccount(c *gin.Context) {
 
 func (rt *router) deleteAccount(c *gin.Context) {
 	accountID := c.Param("accountID")
+
+	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("deleteAccount-%s", accountID)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
+		return
+	}
 
 	accountUser, ok := c.Value(contextKeyAuth).(persistence.LoginResult)
 	if !ok {
@@ -112,6 +127,14 @@ func (rt *router) postAccount(c *gin.Context) {
 			fmt.Errorf("router: error decoding response body: %w", err),
 			http.StatusBadRequest,
 		).Pipe(c)
+		return
+	}
+
+	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postAccount-%s", req.EmailAddress)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
 		return
 	}
 

--- a/server/router/accounts.go
+++ b/server/router/accounts.go
@@ -15,7 +15,7 @@ import (
 
 func (rt *router) getAccount(c *gin.Context) {
 	accountID := c.Param("accountID")
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("getAccount-%s", accountID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("getAccount-%s", accountID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -61,7 +61,7 @@ func (rt *router) getAccount(c *gin.Context) {
 func (rt *router) deleteAccount(c *gin.Context) {
 	accountID := c.Param("accountID")
 
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("deleteAccount-%s", accountID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("deleteAccount-%s", accountID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -130,7 +130,7 @@ func (rt *router) postAccount(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postAccount-%s", req.EmailAddress)); l.Error != nil {
+	if l := <-rt.limiter(time.Second*5).Throttlef("postAccount-%s", req.EmailAddress); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,

--- a/server/router/events.go
+++ b/server/router/events.go
@@ -29,8 +29,8 @@ func (rt *router) postEvents(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("postEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 	evt := inboundEventPayload{}
@@ -89,8 +89,8 @@ func (rt *router) getEvents(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("getEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 	result, err := rt.db.Query(persistence.Query{
@@ -121,8 +121,8 @@ func (rt *router) getDeletedEvents(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("getDeletedEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 	query := deletedQuery{}
@@ -152,8 +152,8 @@ func (rt *router) purgeEvents(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("purgeEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 	if err := rt.db.Purge(userID); err != nil {

--- a/server/router/events.go
+++ b/server/router/events.go
@@ -26,7 +26,7 @@ var errBadRequestContext = errors.New("could not use user id in request context"
 
 func (rt *router) postEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttlef("postEvents-%s", userID); l.Error != nil {
+	if l := <-rt.limiter(time.Second / 2).LinearThrottle(fmt.Sprintf("postEvents-%s", userID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -86,7 +86,7 @@ type getResponse struct {
 
 func (rt *router) getEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttlef("getEvents-%s", userID); l.Error != nil {
+	if l := <-rt.limiter(time.Second).LinearThrottle(fmt.Sprintf("getEvents-%s", userID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -118,7 +118,7 @@ type deletedQuery struct {
 
 func (rt *router) getDeletedEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttlef("getDeletedEvents-%s", userID); l.Error != nil {
+	if l := <-rt.limiter(time.Second).LinearThrottle(fmt.Sprintf("getDeletedEvents-%s", userID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -149,7 +149,7 @@ func (rt *router) getDeletedEvents(c *gin.Context) {
 
 func (rt *router) purgeEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttlef("purgeEvents-%s", userID); l.Error != nil {
+	if l := <-rt.limiter(time.Second).LinearThrottle(fmt.Sprintf("purgeEvents-%s", userID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,

--- a/server/router/events.go
+++ b/server/router/events.go
@@ -26,7 +26,7 @@ var errBadRequestContext = errors.New("could not use user id in request context"
 
 func (rt *router) postEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("postEvents-%s", userID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("postEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -86,7 +86,7 @@ type getResponse struct {
 
 func (rt *router) getEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("getEvents-%s", userID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("getEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -118,7 +118,7 @@ type deletedQuery struct {
 
 func (rt *router) getDeletedEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("getDeletedEvents-%s", userID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("getDeletedEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -149,7 +149,7 @@ func (rt *router) getDeletedEvents(c *gin.Context) {
 
 func (rt *router) purgeEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("purgeEvents-%s", userID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("purgeEvents-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,

--- a/server/router/events.go
+++ b/server/router/events.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/offen/offen/server/persistence"
@@ -25,6 +26,13 @@ var errBadRequestContext = errors.New("could not use user id in request context"
 
 func (rt *router) postEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
+	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("postEvents-%s", userID)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
+		return
+	}
 	evt := inboundEventPayload{}
 	if err := c.BindJSON(&evt); err != nil {
 		newJSONError(
@@ -78,6 +86,13 @@ type getResponse struct {
 
 func (rt *router) getEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
+	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("getEvents-%s", userID)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
+		return
+	}
 	result, err := rt.db.Query(persistence.Query{
 		UserID: userID,
 		Since:  c.Query("since"),
@@ -103,7 +118,13 @@ type deletedQuery struct {
 
 func (rt *router) getDeletedEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
-
+	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("getDeletedEvents-%s", userID)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
+		return
+	}
 	query := deletedQuery{}
 	if err := c.BindJSON(&query); err != nil {
 		newJSONError(
@@ -128,6 +149,13 @@ func (rt *router) getDeletedEvents(c *gin.Context) {
 
 func (rt *router) purgeEvents(c *gin.Context) {
 	userID := c.GetString(contextKeyCookie)
+	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("purgeEvents-%s", userID)); l.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error rate limiting request: %w", l.Error),
+			http.StatusGatewayTimeout,
+		)
+		return
+	}
 	if err := rt.db.Purge(userID); err != nil {
 		newJSONError(
 			fmt.Errorf("router: error purging user events: %v", err),

--- a/server/router/exchange.go
+++ b/server/router/exchange.go
@@ -66,7 +66,7 @@ func (rt *router) postUserSecret(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("postUserSecret-%s", userID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("postUserSecret-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusGatewayTimeout,

--- a/server/router/exchange.go
+++ b/server/router/exchange.go
@@ -69,8 +69,8 @@ func (rt *router) postUserSecret(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("postUserSecret-%s", userID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 

--- a/server/router/exchange.go
+++ b/server/router/exchange.go
@@ -66,7 +66,7 @@ func (rt *router) postUserSecret(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second).Throttlef("postUserSecret-%s", userID); l.Error != nil {
+	if l := <-rt.limiter(time.Second).LinearThrottle(fmt.Sprintf("postUserSecret-%s", userID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
 			http.StatusTooManyRequests,

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -44,7 +44,7 @@ func (rt *router) postLogin(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("postLogin-%s", credentials.Username)); l.Error != nil {
+	if l := <-rt.limiter(time.Second).Throttlef("postLogin-%s", credentials.Username); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -112,7 +112,7 @@ func (rt *router) postChangePassword(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangePassword-%s", user.AccountUserID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second*5).Throttlef("postChangePassword-%s", user.AccountUserID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -156,7 +156,7 @@ func (rt *router) postChangeEmail(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangeEmail-%s", accountUser.AccountUserID)); l.Error != nil {
+	if l := <-rt.limiter(time.Second*5).Throttlef("postChangeEmail-%s", accountUser.AccountUserID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -207,7 +207,7 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second * 10).Throttle(fmt.Sprintf("postForgotPassword-%s", req.EmailAddress)); l.Error != nil {
+	if l := <-rt.limiter(time.Second*10).Throttlef("postForgotPassword-%s", req.EmailAddress); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusGatewayTimeout,
@@ -292,7 +292,7 @@ func (rt *router) postResetPassword(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postResetPassword-%s", credentials.EmailAddress)); l.Error != nil {
+	if l := <-rt.limiter(time.Second*5).Throttlef("postResetPassword-%s", credentials.EmailAddress); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusGatewayTimeout,

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/offen/offen/server/persistence"
@@ -22,11 +23,10 @@ type loginCredentials struct {
 func (rt *router) postLogout(c *gin.Context) {
 	authCookie, authCookieErr := rt.authCookie("", c.GetBool(contextKeySecureContext))
 	if authCookieErr != nil {
-		jsonErr := newJSONError(
+		newJSONError(
 			fmt.Errorf("router: error creating auth cookie: %w", authCookieErr),
 			http.StatusInternalServerError,
-		)
-		c.JSON(jsonErr.Status, jsonErr)
+		).Pipe(c)
 		return
 	}
 
@@ -37,31 +37,37 @@ func (rt *router) postLogout(c *gin.Context) {
 func (rt *router) postLogin(c *gin.Context) {
 	var credentials loginCredentials
 	if err := c.BindJSON(&credentials); err != nil {
-		jsonErr := newJSONError(
+		newJSONError(
 			fmt.Errorf("router: error decoding request payload: %w", err),
 			http.StatusBadRequest,
-		)
-		c.JSON(jsonErr.Status, jsonErr)
+		).Pipe(c)
+		return
+	}
+
+	limiterResult := <-rt.limiter(time.Second * 1).Throttle(fmt.Sprintf("postLogin-%s", credentials.Username))
+	if limiterResult.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
+			http.StatusBadRequest,
+		).Pipe(c)
 		return
 	}
 
 	result, err := rt.db.Login(credentials.Username, credentials.Password)
 	if err != nil {
-		jsonErr := newJSONError(
+		newJSONError(
 			fmt.Errorf("router: error logging in: %w", err),
 			http.StatusUnauthorized,
-		)
-		c.JSON(jsonErr.Status, jsonErr)
+		).Pipe(c)
 		return
 	}
 
 	authCookie, authCookieErr := rt.authCookie(result.AccountUserID, c.GetBool(contextKeySecureContext))
 	if authCookieErr != nil {
-		jsonErr := newJSONError(
+		newJSONError(
 			fmt.Errorf("router: error creating auth cookie: %w", authCookieErr),
 			http.StatusInternalServerError,
-		)
-		c.JSON(jsonErr.Status, jsonErr)
+		).Pipe(c)
 		return
 	}
 
@@ -97,6 +103,16 @@ func (rt *router) postChangePassword(c *gin.Context) {
 		).Pipe(c)
 		return
 	}
+
+	limiterResult := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangePassword-%s", user.AccountUserID))
+	if limiterResult.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
+			http.StatusBadRequest,
+		).Pipe(c)
+		return
+	}
+
 	var req changePasswordRequest
 	if err := c.BindJSON(&req); err != nil {
 		newJSONError(
@@ -132,6 +148,16 @@ func (rt *router) postChangeEmail(c *gin.Context) {
 		).Pipe(c)
 		return
 	}
+
+	limiterResult := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangeEmail-%s", accountUser.AccountUserID))
+	if limiterResult.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
+			http.StatusBadRequest,
+		).Pipe(c)
+		return
+	}
+
 	var req changeEmailRequest
 	if err := c.BindJSON(&req); err != nil {
 		newJSONError(
@@ -174,6 +200,16 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 		).Pipe(c)
 		return
 	}
+
+	limiterResult := <-rt.limiter(time.Second * 10).Throttle(fmt.Sprintf("postForgotPassword-%s", req.EmailAddress))
+	if limiterResult.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
+			http.StatusBadRequest,
+		).Pipe(c)
+		return
+	}
+
 	token, err := rt.db.GenerateOneTimeKey(req.EmailAddress)
 	if err != nil {
 		rt.logError(err, "error generating one time key")
@@ -241,6 +277,16 @@ func (rt *router) postResetPassword(c *gin.Context) {
 		).Pipe(c)
 		return
 	}
+
+	limiterResult := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postResetPassword-%s", credentials.EmailAddress))
+	if limiterResult.Error != nil {
+		newJSONError(
+			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
+			http.StatusBadRequest,
+		).Pipe(c)
+		return
+	}
+
 	if credentials.EmailAddress != req.EmailAddress {
 		newJSONError(
 			errors.New("given email address did not match token"),

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -44,11 +44,10 @@ func (rt *router) postLogin(c *gin.Context) {
 		return
 	}
 
-	limiterResult := <-rt.limiter(time.Second * 1).Throttle(fmt.Sprintf("postLogin-%s", credentials.Username))
-	if limiterResult.Error != nil {
+	if l := <-rt.limiter(time.Second * 1).Throttle(fmt.Sprintf("postLogin-%s", credentials.Username)); l.Error != nil {
 		newJSONError(
-			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
-			http.StatusBadRequest,
+			fmt.Errorf("router: error applying rate limit: %w", l.Error),
+			http.StatusGatewayTimeout,
 		).Pipe(c)
 		return
 	}
@@ -104,11 +103,10 @@ func (rt *router) postChangePassword(c *gin.Context) {
 		return
 	}
 
-	limiterResult := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangePassword-%s", user.AccountUserID))
-	if limiterResult.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangePassword-%s", user.AccountUserID)); l.Error != nil {
 		newJSONError(
-			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
-			http.StatusBadRequest,
+			fmt.Errorf("router: error applying rate limit: %w", l.Error),
+			http.StatusGatewayTimeout,
 		).Pipe(c)
 		return
 	}
@@ -149,11 +147,10 @@ func (rt *router) postChangeEmail(c *gin.Context) {
 		return
 	}
 
-	limiterResult := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangeEmail-%s", accountUser.AccountUserID))
-	if limiterResult.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postChangeEmail-%s", accountUser.AccountUserID)); l.Error != nil {
 		newJSONError(
-			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
-			http.StatusBadRequest,
+			fmt.Errorf("router: error applying rate limit: %w", l.Error),
+			http.StatusGatewayTimeout,
 		).Pipe(c)
 		return
 	}
@@ -201,11 +198,10 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 		return
 	}
 
-	limiterResult := <-rt.limiter(time.Second * 10).Throttle(fmt.Sprintf("postForgotPassword-%s", req.EmailAddress))
-	if limiterResult.Error != nil {
+	if l := <-rt.limiter(time.Second * 10).Throttle(fmt.Sprintf("postForgotPassword-%s", req.EmailAddress)); l.Error != nil {
 		newJSONError(
-			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
-			http.StatusBadRequest,
+			fmt.Errorf("router: error applying rate limit: %w", l.Error),
+			http.StatusGatewayTimeout,
 		).Pipe(c)
 		return
 	}
@@ -278,11 +274,10 @@ func (rt *router) postResetPassword(c *gin.Context) {
 		return
 	}
 
-	limiterResult := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postResetPassword-%s", credentials.EmailAddress))
-	if limiterResult.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).Throttle(fmt.Sprintf("postResetPassword-%s", credentials.EmailAddress)); l.Error != nil {
 		newJSONError(
-			fmt.Errorf("router: error applying rate limit: %w", limiterResult.Error),
-			http.StatusBadRequest,
+			fmt.Errorf("router: error applying rate limit: %w", l.Error),
+			http.StatusGatewayTimeout,
 		).Pipe(c)
 		return
 	}

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -47,7 +47,7 @@ func (rt *router) postLogin(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttlef("postLogin-%s", credentials.Username); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}
@@ -56,7 +56,7 @@ func (rt *router) postLogin(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttle("postLogin-*"); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}
@@ -115,7 +115,7 @@ func (rt *router) postChangePassword(c *gin.Context) {
 	if l := <-rt.limiter(time.Second*5).Throttlef("postChangePassword-%s", user.AccountUserID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}
@@ -159,7 +159,7 @@ func (rt *router) postChangeEmail(c *gin.Context) {
 	if l := <-rt.limiter(time.Second*5).Throttlef("postChangeEmail-%s", accountUser.AccountUserID); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}
@@ -210,7 +210,7 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 	if l := <-rt.limiter(time.Second*10).Throttlef("postForgotPassword-%s", req.EmailAddress); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}
@@ -219,7 +219,7 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 	if l := <-rt.limiter(time.Second * 1).Throttle("postForgotPassword-*"); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}
@@ -295,7 +295,7 @@ func (rt *router) postResetPassword(c *gin.Context) {
 	if l := <-rt.limiter(time.Second*5).Throttlef("postResetPassword-%s", credentials.EmailAddress); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}

--- a/server/router/login.go
+++ b/server/router/login.go
@@ -44,7 +44,7 @@ func (rt *router) postLogin(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second).Throttlef("postLogin-%s", credentials.Username); l.Error != nil {
+	if l := <-rt.limiter(time.Second).ExponentialThrottle(fmt.Sprintf("postLogin-%s", credentials.Username)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -52,8 +52,8 @@ func (rt *router) postLogin(c *gin.Context) {
 		return
 	}
 
-	// we rate limit this twice to prevent floodding with arbitrary emails
-	if l := <-rt.limiter(time.Second).Throttle("postLogin-*"); l.Error != nil {
+	// we rate limit this twice to prevent flooding with arbitrary emails
+	if l := <-rt.limiter(time.Second / 2).LinearThrottle("postLogin-*"); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -112,7 +112,7 @@ func (rt *router) postChangePassword(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second*5).Throttlef("postChangePassword-%s", user.AccountUserID); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).LinearThrottle(fmt.Sprintf("postChangePassword-%s", user.AccountUserID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -156,7 +156,7 @@ func (rt *router) postChangeEmail(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second*5).Throttlef("postChangeEmail-%s", accountUser.AccountUserID); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).LinearThrottle(fmt.Sprintf("postChangeEmail-%s", accountUser.AccountUserID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -207,7 +207,7 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second*10).Throttlef("postForgotPassword-%s", req.EmailAddress); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).ExponentialThrottle(fmt.Sprintf("postForgotPassword-%s", req.EmailAddress)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -216,7 +216,7 @@ func (rt *router) postForgotPassword(c *gin.Context) {
 	}
 
 	// we rate limit this twice to prevent floodding with arbitrary emails
-	if l := <-rt.limiter(time.Second * 1).Throttle("postForgotPassword-*"); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 1).LinearThrottle("postForgotPassword-*"); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,
@@ -292,7 +292,7 @@ func (rt *router) postResetPassword(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second*5).Throttlef("postResetPassword-%s", credentials.EmailAddress); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).ExponentialThrottle(fmt.Sprintf("postResetPassword-%s", credentials.EmailAddress)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,

--- a/server/router/management.go
+++ b/server/router/management.go
@@ -56,8 +56,8 @@ func (rt *router) postShareAccount(c *gin.Context) {
 	if l := <-rt.limiter(time.Second).Throttle(fmt.Sprintf("postShareAccount-%s", accountUser.AccountUserID)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 
@@ -179,8 +179,8 @@ func (rt *router) postJoin(c *gin.Context) {
 	if l := <-rt.limiter(5 * time.Second).Throttle(fmt.Sprintf("postJoin-%s", req.EmailAddress)); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error rate limiting request: %w", l.Error),
-			http.StatusGatewayTimeout,
-		)
+			http.StatusTooManyRequests,
+		).Pipe(c)
 		return
 	}
 	if err := rt.db.Join(req.EmailAddress, req.Password); err != nil {

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -34,14 +34,14 @@ type router struct {
 	emails       *template.Template
 	config       *config.Config
 	sanitizer    *bluemonday.Policy
-	limiters     map[time.Duration]ratelimiter.Throttler
+	limiters     map[time.Duration]*ratelimiter.Limiter
 	cache        ratelimiter.GetSetter
 	limiterLock  sync.Mutex
 }
 
-func (rt *router) limiter(rate time.Duration) ratelimiter.Throttler {
+func (rt *router) limiter(rate time.Duration) *ratelimiter.Limiter {
 	if rt.limiters == nil {
-		rt.limiters = map[time.Duration]ratelimiter.Throttler{}
+		rt.limiters = map[time.Duration]*ratelimiter.Limiter{}
 	}
 	// multiple requests might access this simultaneously
 	rt.limiterLock.Lock()

--- a/server/router/setup.go
+++ b/server/router/setup.go
@@ -39,7 +39,7 @@ func (rt *router) postSetup(c *gin.Context) {
 	if l := <-rt.limiter(time.Second * 5).Throttle("postSetup-*"); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
-			http.StatusGatewayTimeout,
+			http.StatusTooManyRequests,
 		).Pipe(c)
 		return
 	}

--- a/server/router/setup.go
+++ b/server/router/setup.go
@@ -36,7 +36,7 @@ func (rt *router) postSetup(c *gin.Context) {
 		return
 	}
 
-	if l := <-rt.limiter(time.Second * 5).Throttle("postSetup-*"); l.Error != nil {
+	if l := <-rt.limiter(time.Second * 5).LinearThrottle("postSetup-*"); l.Error != nil {
 		newJSONError(
 			fmt.Errorf("router: error applying rate limit: %w", l.Error),
 			http.StatusTooManyRequests,


### PR DESCRIPTION
Brute force attacks were one of the main concerns raised in the recent security audit. This PR introduces a remedy by selectively applying rate limits to all routes that access the persistence layer at some point.

For now, we actively decided against putting a Captcha in front of the login as this a. comes with serious privacy implications when done by a 3rd party or b. is very hard to implement in-app. This should be added to the roadmap when we revisit auth and add things like OTP for example.

The implementation of this feature could probably be a lot more declarative, but this requires care as all routes have special rules for how to rate limit. It is important to note that the current implementation **never looks at IP adresses** which means they also do not get stored in memory for longer than a request lifecycle.