### PR TITLE
Create NOTICE file for packaged distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,11 +195,11 @@ jobs:
           name: Package tarball
           working_directory: ~/offen/bin
           command: |
-            for artifact in $(ls); do
+            md5sum $(find . -perm -111 -type f) > checksums.txt
+
+            for artifact in $(find . -perm -111 -type f); do
               gpg --armor --detach-sign $artifact
             done
-
-            md5sum * > checksums.txt
 
             cp ~/offen/{LICENSE,README.md} .
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ integration/cypress/screenshots
 integration/cypress/videos
 
 docs-site
+
+dependencies.csv

--- a/auditorium/package-lock.json
+++ b/auditorium/package-lock.json
@@ -1031,6 +1031,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -1357,6 +1363,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1406,6 +1418,15 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-done": {
       "version": "1.3.2",
@@ -2566,6 +2587,12 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2769,6 +2796,16 @@
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
+      }
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "diff": {
@@ -4730,6 +4767,18 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+      "dev": true
+    },
+    "github-url-from-username-repo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -5720,6 +5769,18 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "dev": true
+    },
+    "jquery-extend": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jquery-extend/-/jquery-extend-2.0.3.tgz",
+      "integrity": "sha1-aBXNsBqGbdujDm9ND8X7ZnknJzU=",
+      "dev": true
+    },
     "js-base64": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -5752,6 +5813,15 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+      "dev": true,
+      "requires": {
+        "jju": "^1.1.0"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5899,6 +5969,69 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "license-checker": {
+      "version": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "from": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.5.1",
+        "mkdirp": "^0.3.5",
+        "nopt": "^2.2.0",
+        "read-installed": "~3.1.3",
+        "treeify": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
       }
     },
     "liftoff": {
@@ -6569,6 +6702,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6607,6 +6747,27 @@
       "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==",
       "dev": true
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "nopt-defaults": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/nopt-defaults/-/nopt-defaults-0.0.1.tgz",
+      "integrity": "sha1-8VD8yIgjCcv7dhh+Eum8sgaUVYs=",
+      "dev": true
+    },
+    "nopt-usage": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nopt-usage/-/nopt-usage-0.1.0.tgz",
+      "integrity": "sha1-sYuMGD4YEEfKnmO3zefPxwLMpXk=",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6632,6 +6793,23 @@
       "dev": true,
       "requires": {
         "once": "^1.3.2"
+      }
+    },
+    "npm-license-crawler": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/npm-license-crawler/-/npm-license-crawler-0.2.1.tgz",
+      "integrity": "sha512-CRchloUjZk/ZSAkb5JbCKNFojLWtbjxwsB7w48kauHXK+5bjby2HXFvGvicVx7uNBY6HBWEPw20qKc/4jlL+1Q==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "chalk": "^2.4.2",
+        "jquery-extend": "~2.0.3",
+        "license-checker": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+        "mkdirp": "^0.5.1",
+        "nopt": "^3.0.6",
+        "nopt-defaults": "^0.0.1",
+        "nopt-usage": "^0.1.0",
+        "treeify": "^1.1.0"
       }
     },
     "npm-run-path": {
@@ -15897,6 +16075,39 @@
       "integrity": "sha1-cMa6+IQux9FUD5gf0Oau1Mgb1UU=",
       "dev": true
     },
+    "read-installed": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-3.1.5.tgz",
+      "integrity": "sha1-SuNgga/T4iBNwuJ5gHqqUsMMjAw=",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "graceful-fs": "2 || 3",
+        "read-package-json": "1",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "natives": "^1.1.3"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
+      }
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -15904,6 +16115,60 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
+      }
+    },
+    "read-package-json": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.3.3.tgz",
+      "integrity": "sha1-73nf2kbhZTdu6KV++/7dTRsCm6Q=",
+      "dev": true,
+      "requires": {
+        "glob": "^5.0.3",
+        "graceful-fs": "2 || 3",
+        "json-parse-helpfulerror": "^1.0.2",
+        "normalize-package-data": "^1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "natives": "^1.1.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
+          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
+          "dev": true,
+          "requires": {
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "^1.0.0",
+            "semver": "2 || 3 || 4"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -15978,6 +16243,18 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -16656,6 +16933,12 @@
           "dev": true
         }
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -17581,6 +17864,12 @@
         }
       }
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -17942,6 +18231,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "v8-compile-cache": {

--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -10,7 +10,8 @@
     "posttest": "standard",
     "fix": "standard --fix",
     "build": "gulp",
-    "extract-strings": "gulp extract-strings"
+    "extract-strings": "gulp extract-strings",
+    "licenses": "npm-license-crawler --production --onlyDirectDependencies --omitVersion --csv dependencies.csv"
   },
   "aliasify": {
     "aliases": {
@@ -50,6 +51,7 @@
     "gulp-rev": "^9.0.0",
     "gulp-uglify": "^3.0.2",
     "mochify": "^6.3.0",
+    "npm-license-crawler": "^0.2.1",
     "redux-mock-store": "^1.5.4",
     "sheetify": "^8.0.0",
     "sinon": "^8.1.1",

--- a/banner.txt
+++ b/banner.txt
@@ -1,6 +1,9 @@
 Copyright 2020 - Offen Authors <hioffen@posteo.de>
 SPDX-License-Identifier: Apache-2.0
 ///////////////////////////////////////////////////////////////////////
+License information about 3rd party JavaScript included in this
+bundle can found at /NOTICE.txt under the same domain as this file.
+///////////////////////////////////////////////////////////////////////
 Offen is a fair alternative to common web analytics tools.
 Find out more about why we are building Offen at https://www.offen.dev.
 All source code is available at https://github.com/offen/offen.

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -65,16 +65,34 @@ RUN go get github.com/rakyll/statik
 RUN statik -dest public -src public
 RUN statik -dest locales -src locales
 
-FROM python:3.7-alpine as notice
+
+FROM ruby:2.7-alpine AS server_licenses
+
+COPY --from=golang:1.14-alpine /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN gem install license_finder
+
+WORKDIR /code/server
+COPY ./server /code/server
+RUN go mod tidy
+RUN go mod download
+
+RUN echo "repository,version,licenses" > dependencies.csv
+RUN license_finder report | tail -n +2 >> dependencies.csv
+RUN cat dependencies.csv
+
+FROM python:3.8-alpine as notice
 
 WORKDIR /code
-COPY ./create_notice.py .
+COPY ./create_notice.py /code
 
 COPY --from=script /code/script/dependencies.csv /code/script.csv
 COPY --from=vault /code/vault/dependencies.csv /code/vault.csv
 COPY --from=auditorium /code/auditorium/dependencies.csv /code/auditorium.csv
+COPY --from=server_licenses /code/server/dependencies.csv /code/server.csv
 
-RUN python ./create_notice.py script.csv vault.csv auditorium.csv > NOTICE
+RUN python ./create_notice.py script.csv vault.csv auditorium.csv server.csv > NOTICE
 
 
 FROM techknowlogick/xgo:go-1.14.x as compiler

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -16,6 +16,7 @@ WORKDIR /code/auditorium
 RUN cp -a /code/deps/node_modules /code/auditorium/
 ENV NODE_ENV production
 RUN npm run build
+RUN npm run licenses
 
 FROM node:14 as script
 
@@ -32,6 +33,7 @@ WORKDIR /code/script
 RUN cp -a /code/deps/node_modules /code/script/
 ENV NODE_ENV production
 RUN npm run build
+RUN npm run licenses
 
 FROM node:14 as vault
 
@@ -48,6 +50,7 @@ WORKDIR /code/vault
 RUN cp -a /code/deps/node_modules /code/vault/
 ENV NODE_ENV production
 RUN npm run build
+RUN npm run licenses
 
 FROM golang:1.14 as statik
 
@@ -61,6 +64,18 @@ COPY --from=auditorium /code/auditorium/dist /code/server/public
 RUN go get github.com/rakyll/statik
 RUN statik -dest public -src public
 RUN statik -dest locales -src locales
+
+FROM python:3.7-alpine as notice
+
+WORKDIR /code
+COPY ./create_notice.py .
+
+COPY --from=script /code/script/dependencies.csv /code/script.csv
+COPY --from=vault /code/vault/dependencies.csv /code/vault.csv
+COPY --from=auditorium /code/auditorium/dependencies.csv /code/auditorium.csv
+
+RUN python ./create_notice.py script.csv vault.csv auditorium.csv > NOTICE
+
 
 FROM techknowlogick/xgo:go-1.14.x as compiler
 
@@ -76,3 +91,5 @@ ENV GOPATH /go
 WORKDIR /build
 
 RUN xgo --targets=$TARGETS --tags 'osusergo netgo static_build sqlite_omit_load_extension' --ldflags="-linkmode external -extldflags '$LDFLAGS' -s -w -X github.com/offen/offen/server/config.Revision=$GIT_REVISION" github.com/offen/offen/server/cmd/offen
+
+COPY --from=notice /code/NOTICE ./

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -52,19 +52,20 @@ ENV NODE_ENV production
 RUN npm run build
 RUN npm run licenses
 
-FROM golang:1.14 as statik
-
-WORKDIR /code/server
-COPY ./server /code/server
-
-COPY --from=script /code/script/dist /code/server/public
-COPY --from=vault /code/vault/dist /code/server/public
-COPY --from=auditorium /code/auditorium/dist /code/server/public
-
-RUN go get github.com/rakyll/statik
-RUN statik -dest public -src public
-RUN statik -dest locales -src locales
-
+# packages does not have a build step but we need to derive license information
+FROM node:14 as packages
+COPY ./packages/package.json ./packages/package-lock.json /code/deps/
+COPY ./packages /code/packages
+WORKDIR /code/deps
+ENV ADBLOCK true
+ENV DISABLE_OPENCOLLECTIVE true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+RUN npm ci
+COPY ./packages /code/packages
+WORKDIR /code/packages
+RUN cp -a /code/deps/node_modules /code/packages/
+ENV NODE_ENV production
+RUN npm run licenses
 
 FROM ruby:2.7-alpine AS server_licenses
 
@@ -80,7 +81,6 @@ RUN go mod download
 
 RUN echo "repository,version,licenses" > dependencies.csv
 RUN license_finder report | tail -n +2 >> dependencies.csv
-RUN cat dependencies.csv
 
 FROM python:3.8-alpine as notice
 
@@ -90,10 +90,29 @@ COPY ./create_notice.py /code
 COPY --from=script /code/script/dependencies.csv /code/script.csv
 COPY --from=vault /code/vault/dependencies.csv /code/vault.csv
 COPY --from=auditorium /code/auditorium/dependencies.csv /code/auditorium.csv
+COPY --from=packages /code/packages/dependencies.csv /code/packages.csv
 COPY --from=server_licenses /code/server/dependencies.csv /code/server.csv
 
-RUN python ./create_notice.py script.csv vault.csv auditorium.csv server.csv > NOTICE
+RUN python ./create_notice.py \
+  --client script.csv \
+  --client vault.csv \
+  --client packages.csv \
+  --client auditorium.csv \
+  --server server.csv > NOTICE
 
+FROM golang:1.14 as statik
+
+WORKDIR /code/server
+COPY ./server /code/server
+
+COPY --from=script /code/script/dist /code/server/public
+COPY --from=vault /code/vault/dist /code/server/public
+COPY --from=auditorium /code/auditorium/dist /code/server/public
+COPY --from=notice /code/NOTICE /code/server/public/NOTICE.txt
+
+RUN go get github.com/rakyll/statik
+RUN statik -dest public -src public
+RUN statik -dest locales -src locales
 
 FROM techknowlogick/xgo:go-1.14.x as compiler
 

--- a/create_notice.py
+++ b/create_notice.py
@@ -78,7 +78,7 @@ Client side:
             """
 Server side:
 ============
-        """
+"""
         )
         for dep in server_deps:
             print(
@@ -86,6 +86,13 @@ Server side:
                     dep["name"].strip(), dep["licenses"].strip(), dep["source"].strip(),
                 )
             )
+
+    print(
+        """
+This file is generated automatically and - even if we try to prevent it - may
+contain errors and mistakes. If you found any, send us an email
+at hioffen@posteo.de containing details about what is incorrect or missing."""
+    )
 
 
 if __name__ == "__main__":

--- a/create_notice.py
+++ b/create_notice.py
@@ -1,25 +1,39 @@
 # Copyright 2020 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import csv
+import argparse
+
+"""
+This script is used to automatically generate a NOTICE file from different
+csv sources. Right now, input from `npm-license-crawler` [0] (for npm managed
+dependencies) and `license_finder` (for Go modules) [1] is supported.
+
+[0]: https://www.npmjs.com/package/npm-license-crawler
+[1]: https://github.com/pivotal/LicenseFinder
+"""
 
 def normalize_row(row):
     result = {}
     try:
-        result['name'] = row['module name']
+        result["name"] = row["module name"]
     except KeyError:
-        result['name'] = row['repository']
+        result["name"] = row["repository"].rsplit("/", 1)[-1]
 
-    result['licenses'] = row['licenses']
-    result['source'] = row['repository']
+    result["licenses"] = row["licenses"]
+
+    result["source"] = (
+        row["repository"]
+        if row["repository"].startswith("http")
+        else "https://{}".format(row["repository"])
+    )
 
     return result
 
 
 def read_file(filename):
     result = []
-    with open(filename, 'r') as csv_file:
+    with open(filename, "r") as csv_file:
         csv_reader = csv.DictReader(csv_file)
         for row in csv_reader:
             result.append(normalize_row(row))
@@ -29,26 +43,54 @@ def read_file(filename):
 def dedupe(dependencies):
     result = []
     for dep in dependencies:
-        if not any(existing['name'] == dep['name'] for existing in result):
+        if not any(existing["name"] == dep["name"] for existing in result):
             result.append(dep)
     return result
 
 
-def main(*sources):
-    all_deps = []
-    for source in sources:
-        all_deps += read_file(source)
-    all_deps = dedupe(all_deps)
+def main(app='Offen', server=[], client=[]):
+    client_deps = []
+    for source in client:
+        client_deps += read_file(source)
+    client_deps = dedupe(client_deps)
 
-    print("""Offen bundles the following 3rd party software:
-    """)
-    for dep in all_deps:
+    server_deps = []
+    for source in server:
+        server_deps += read_file(source)
+    server_deps = dedupe(server_deps)
+
+    print("{} bundles the following 3rd party software:".format(app))
+    if client_deps:
         print(
-            "\"{}\" licensed under {}, available at {}".format(
-                dep['name'], dep['licenses'], dep['source'],
-            )
+            """
+Client side:
+============
+"""
         )
+        for dep in client_deps:
+            print(
+                '"{}" licensed under {}, available at {}'.format(
+                    dep["name"].strip(), dep["licenses"].strip(), dep["source"].strip(),
+                )
+            )
+    if server_deps:
+        print(
+            """
+Server side:
+============
+        """
+        )
+        for dep in server_deps:
+            print(
+                '"{}" licensed under {}, available at {}'.format(
+                    dep["name"].strip(), dep["licenses"].strip(), dep["source"].strip(),
+                )
+            )
 
 
 if __name__ == "__main__":
-    main(*sys.argv[1:])
+    parser = argparse.ArgumentParser(description="Create a NOTICE file")
+    parser.add_argument("--client", dest="client", action="append", default=[])
+    parser.add_argument("--server", dest="server", action="append", default=[])
+    args = parser.parse_args()
+    main(server=args.server, client=args.client)

--- a/create_notice.py
+++ b/create_notice.py
@@ -4,19 +4,32 @@
 import sys
 import csv
 
+def normalize_row(row):
+    result = {}
+    try:
+        result['name'] = row['module name']
+    except KeyError:
+        result['name'] = row['repository']
+
+    result['licenses'] = row['licenses']
+    result['source'] = row['repository']
+
+    return result
+
+
 def read_file(filename):
     result = []
     with open(filename, 'r') as csv_file:
         csv_reader = csv.DictReader(csv_file)
         for row in csv_reader:
-            result.append(row)
+            result.append(normalize_row(row))
     return result
 
 
 def dedupe(dependencies):
     result = []
     for dep in dependencies:
-        if not any(existing['module name'] == dep['module name'] for existing in result):
+        if not any(existing['name'] == dep['name'] for existing in result):
             result.append(dep)
     return result
 
@@ -32,7 +45,7 @@ def main(*sources):
     for dep in all_deps:
         print(
             "\"{}\" licensed under {}, available at {}".format(
-                dep['module name'], dep['licenses'], dep['repository'],
+                dep['name'], dep['licenses'], dep['source'],
             )
         )
 

--- a/create_notice.py
+++ b/create_notice.py
@@ -1,0 +1,41 @@
+# Copyright 2020 - Offen Authors <hioffen@posteo.de>
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import csv
+
+def read_file(filename):
+    result = []
+    with open(filename, 'r') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        for row in csv_reader:
+            result.append(row)
+    return result
+
+
+def dedupe(dependencies):
+    result = []
+    for dep in dependencies:
+        if not any(existing['module name'] == dep['module name'] for existing in result):
+            result.append(dep)
+    return result
+
+
+def main(*sources):
+    all_deps = []
+    for source in sources:
+        all_deps += read_file(source)
+    all_deps = dedupe(all_deps)
+
+    print("""Offen bundles the following 3rd party software:
+    """)
+    for dep in all_deps:
+        print(
+            "\"{}\" licensed under {}, available at {}".format(
+                dep['module name'], dep['licenses'], dep['repository'],
+            )
+        )
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -1181,6 +1181,12 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1234,6 +1240,15 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-each": {
       "version": "1.0.3",
@@ -2434,6 +2449,12 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -2632,6 +2653,16 @@
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
+      }
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "diff": {
@@ -4224,6 +4255,18 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+      "dev": true
+    },
+    "github-url-from-username-repo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -4303,6 +4346,23 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -4892,6 +4952,18 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "dev": true
+    },
+    "jquery-extend": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jquery-extend/-/jquery-extend-2.0.3.tgz",
+      "integrity": "sha1-aBXNsBqGbdujDm9ND8X7ZnknJzU=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4942,6 +5014,15 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+      "dev": true,
+      "requires": {
+        "jju": "^1.1.0"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5274,6 +5355,75 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "license-checker": {
+      "version": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "from": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.5.1",
+        "mkdirp": "^0.3.5",
+        "nopt": "^2.2.0",
+        "read-installed": "~3.1.3",
+        "treeify": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
       }
     },
     "listen": {
@@ -6153,6 +6303,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6219,6 +6376,18 @@
         "abbrev": "1"
       }
     },
+    "nopt-defaults": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/nopt-defaults/-/nopt-defaults-0.0.1.tgz",
+      "integrity": "sha1-8VD8yIgjCcv7dhh+Eum8sgaUVYs=",
+      "dev": true
+    },
+    "nopt-usage": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nopt-usage/-/nopt-usage-0.1.0.tgz",
+      "integrity": "sha1-sYuMGD4YEEfKnmO3zefPxwLMpXk=",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6238,6 +6407,34 @@
       "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-license-crawler": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/npm-license-crawler/-/npm-license-crawler-0.2.1.tgz",
+      "integrity": "sha512-CRchloUjZk/ZSAkb5JbCKNFojLWtbjxwsB7w48kauHXK+5bjby2HXFvGvicVx7uNBY6HBWEPw20qKc/4jlL+1Q==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "chalk": "^2.4.2",
+        "jquery-extend": "~2.0.3",
+        "license-checker": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+        "mkdirp": "^0.5.1",
+        "nopt": "^3.0.6",
+        "nopt-defaults": "^0.0.1",
+        "nopt-usage": "^0.1.0",
+        "treeify": "^1.1.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
       }
     },
     "npm-normalize-package-bin": {
@@ -6833,6 +7030,75 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "read-installed": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-3.1.5.tgz",
+      "integrity": "sha1-SuNgga/T4iBNwuJ5gHqqUsMMjAw=",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "graceful-fs": "2 || 3",
+        "read-package-json": "1",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "natives": "^1.1.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
+          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
+          "dev": true,
+          "requires": {
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "^1.0.0",
+            "semver": "2 || 3 || 4"
+          }
+        },
+        "read-package-json": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.3.3.tgz",
+          "integrity": "sha1-73nf2kbhZTdu6KV++/7dTRsCm6Q=",
+          "dev": true,
+          "requires": {
+            "glob": "^5.0.3",
+            "graceful-fs": "2 || 3",
+            "json-parse-helpfulerror": "^1.0.2",
+            "normalize-package-data": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
+      }
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -6972,6 +7238,18 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -7439,6 +7717,12 @@
           "dev": true
         }
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -8261,6 +8545,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -8488,6 +8778,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/packages/package.json
+++ b/packages/package.json
@@ -9,7 +9,8 @@
     "server": "ws -d __fixtures__ -p 9876",
     "pretest": "dependency-check package.json",
     "posttest": "standard",
-    "fix": "standard --fix"
+    "fix": "standard --fix",
+    "licenses": "npm-license-crawler --production --onlyDirectDependencies --omitVersion --csv dependencies.csv"
   },
   "dependencies": {
     "envify": "^4.1.0",
@@ -24,6 +25,7 @@
     "fetch-mock": "^7.3.3",
     "local-web-server": "^4.0.0",
     "mochify": "^6.2.0",
+    "npm-license-crawler": "^0.2.1",
     "standard": "^14.3.1"
   },
   "standard": {

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -175,6 +175,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -526,6 +532,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -575,6 +587,15 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-done": {
       "version": "1.3.2",
@@ -1887,6 +1908,12 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2166,6 +2193,16 @@
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
+      }
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "diff": {
@@ -4163,6 +4200,18 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+      "dev": true
+    },
+    "github-url-from-username-repo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -5178,6 +5227,18 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "dev": true
+    },
+    "jquery-extend": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jquery-extend/-/jquery-extend-2.0.3.tgz",
+      "integrity": "sha1-aBXNsBqGbdujDm9ND8X7ZnknJzU=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5199,6 +5260,15 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+      "dev": true,
+      "requires": {
+        "jju": "^1.1.0"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5568,6 +5638,35 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "license-checker": {
+      "version": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "from": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.5.1",
+        "mkdirp": "^0.3.5",
+        "nopt": "^2.2.0",
+        "read-installed": "~3.1.3",
+        "treeify": "^1.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
       }
     },
     "liftoff": {
@@ -6570,6 +6669,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6611,6 +6717,27 @@
         }
       }
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "nopt-defaults": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/nopt-defaults/-/nopt-defaults-0.0.1.tgz",
+      "integrity": "sha1-8VD8yIgjCcv7dhh+Eum8sgaUVYs=",
+      "dev": true
+    },
+    "nopt-usage": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nopt-usage/-/nopt-usage-0.1.0.tgz",
+      "integrity": "sha1-sYuMGD4YEEfKnmO3zefPxwLMpXk=",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6636,6 +6763,54 @@
       "dev": true,
       "requires": {
         "once": "^1.3.2"
+      }
+    },
+    "npm-license-crawler": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/npm-license-crawler/-/npm-license-crawler-0.2.1.tgz",
+      "integrity": "sha512-CRchloUjZk/ZSAkb5JbCKNFojLWtbjxwsB7w48kauHXK+5bjby2HXFvGvicVx7uNBY6HBWEPw20qKc/4jlL+1Q==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "chalk": "^2.4.2",
+        "jquery-extend": "~2.0.3",
+        "license-checker": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+        "mkdirp": "^0.5.1",
+        "nopt": "^3.0.6",
+        "nopt-defaults": "^0.0.1",
+        "nopt-usage": "^0.1.0",
+        "treeify": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "npm-normalize-package-bin": {
@@ -14125,6 +14300,75 @@
       "integrity": "sha1-cMa6+IQux9FUD5gf0Oau1Mgb1UU=",
       "dev": true
     },
+    "read-installed": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-3.1.5.tgz",
+      "integrity": "sha1-SuNgga/T4iBNwuJ5gHqqUsMMjAw=",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "graceful-fs": "2 || 3",
+        "read-package-json": "1",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "natives": "^1.1.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
+          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
+          "dev": true,
+          "requires": {
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "^1.0.0",
+            "semver": "2 || 3 || 4"
+          }
+        },
+        "read-package-json": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.3.3.tgz",
+          "integrity": "sha1-73nf2kbhZTdu6KV++/7dTRsCm6Q=",
+          "dev": true,
+          "requires": {
+            "glob": "^5.0.3",
+            "graceful-fs": "2 || 3",
+            "json-parse-helpfulerror": "^1.0.2",
+            "normalize-package-data": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
+      }
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -14232,6 +14476,18 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -14801,6 +15057,12 @@
           "dev": true
         }
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -15705,6 +15967,12 @@
         }
       }
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -16018,6 +16286,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "v8-compile-cache": {

--- a/script/package.json
+++ b/script/package.json
@@ -12,7 +12,8 @@
     "posttest": "standard",
     "fix": "standard --fix",
     "build": "gulp",
-    "extract-strings": "gulp extract-strings"
+    "extract-strings": "gulp extract-strings",
+    "licenses": "npm-license-crawler --production --onlyDirectDependencies --omitVersion --csv dependencies.csv"
   },
   "dependencies": {
     "history-events": "^1.0.4",
@@ -29,6 +30,7 @@
     "gulp-clean": "^0.4.0",
     "local-web-server": "^4.0.0",
     "mochify": "^6.3.0",
+    "npm-license-crawler": "^0.2.1",
     "standard": "^14.3.1",
     "tinyify": "^2.5.0",
     "vinyl-buffer": "^1.0.1",

--- a/server/go.sum
+++ b/server/go.sum
@@ -113,6 +113,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/offen/offen v0.1.0-alpha.10 h1:pilsg8vNY8LYudzUlFWgPZjWzqslOCBZc4qu7qNAicI=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/vault/package-lock.json
+++ b/vault/package-lock.json
@@ -185,6 +185,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -509,6 +515,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -557,6 +569,15 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-done": {
       "version": "1.3.2",
@@ -1770,6 +1791,12 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2007,6 +2034,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.0.1.tgz",
       "integrity": "sha512-/s4KzlaerQnCad/uY1ZNdFckTrbdMVhLlziYQzz62Ff9Ick1lHGomvTXNfwh4ApEZATyXRyVk5F6/y8UU84B0w=="
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff": {
       "version": "3.5.0",
@@ -4018,6 +4055,18 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
+      "dev": true
+    },
+    "github-url-from-username-repo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz",
+      "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -5164,6 +5213,18 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "dev": true
+    },
+    "jquery-extend": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jquery-extend/-/jquery-extend-2.0.3.tgz",
+      "integrity": "sha1-aBXNsBqGbdujDm9ND8X7ZnknJzU=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5185,6 +5246,15 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+      "dev": true,
+      "requires": {
+        "jju": "^1.1.0"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5328,6 +5398,84 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "license-checker": {
+      "version": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "from": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.5.1",
+        "mkdirp": "^0.3.5",
+        "nopt": "^2.2.0",
+        "read-installed": "~3.1.3",
+        "treeify": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^0.2.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
       }
     },
     "liftoff": {
@@ -6011,6 +6159,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natives": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6081,6 +6236,27 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
       "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "nopt-defaults": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/nopt-defaults/-/nopt-defaults-0.0.1.tgz",
+      "integrity": "sha1-8VD8yIgjCcv7dhh+Eum8sgaUVYs=",
+      "dev": true
+    },
+    "nopt-usage": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nopt-usage/-/nopt-usage-0.1.0.tgz",
+      "integrity": "sha1-sYuMGD4YEEfKnmO3zefPxwLMpXk=",
+      "dev": true
+    },
     "normalize-html-whitespace": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-0.2.0.tgz",
@@ -6111,6 +6287,54 @@
       "dev": true,
       "requires": {
         "once": "^1.3.2"
+      }
+    },
+    "npm-license-crawler": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/npm-license-crawler/-/npm-license-crawler-0.2.1.tgz",
+      "integrity": "sha512-CRchloUjZk/ZSAkb5JbCKNFojLWtbjxwsB7w48kauHXK+5bjby2HXFvGvicVx7uNBY6HBWEPw20qKc/4jlL+1Q==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "chalk": "^2.4.2",
+        "jquery-extend": "~2.0.3",
+        "license-checker": "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
+        "mkdirp": "^0.5.1",
+        "nopt": "^3.0.6",
+        "nopt-defaults": "^0.0.1",
+        "nopt-usage": "^0.1.0",
+        "treeify": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "npm-normalize-package-bin": {
@@ -13611,6 +13835,75 @@
       "integrity": "sha1-cMa6+IQux9FUD5gf0Oau1Mgb1UU=",
       "dev": true
     },
+    "read-installed": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-3.1.5.tgz",
+      "integrity": "sha1-SuNgga/T4iBNwuJ5gHqqUsMMjAw=",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "graceful-fs": "2 || 3",
+        "read-package-json": "1",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "natives": "^1.1.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz",
+          "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
+          "dev": true,
+          "requires": {
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "^1.0.0",
+            "semver": "2 || 3 || 4"
+          }
+        },
+        "read-package-json": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.3.3.tgz",
+          "integrity": "sha1-73nf2kbhZTdu6KV++/7dTRsCm6Q=",
+          "dev": true,
+          "requires": {
+            "glob": "^5.0.3",
+            "graceful-fs": "2 || 3",
+            "json-parse-helpfulerror": "^1.0.2",
+            "normalize-package-data": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        }
+      }
+    },
     "read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -13692,6 +13985,18 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "readdirp": {
@@ -14217,6 +14522,12 @@
           "dev": true
         }
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -15104,6 +15415,12 @@
         "nanobench": "^2.1.1"
       }
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -15451,6 +15768,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",

--- a/vault/package.json
+++ b/vault/package.json
@@ -10,7 +10,8 @@
     "posttest": "standard",
     "fix": "standard --fix",
     "build": "gulp",
-    "extract-strings": "gulp extract-strings"
+    "extract-strings": "gulp extract-strings",
+    "licenses": "npm-license-crawler --production --onlyDirectDependencies --omitVersion --csv dependencies.csv"
   },
   "dependencies": {
     "date-fns": "^1.30.1",
@@ -41,6 +42,7 @@
     "gulp-sri-hash": "^2.2.0",
     "gulp-uglify": "^3.0.2",
     "mochify": "^6.2.0",
+    "npm-license-crawler": "^0.2.1",
     "sinon": "^7.3.2",
     "standard": "^14.3.1",
     "tinyify": "^2.5.1",


### PR DESCRIPTION
After input from FSFE on the topic, this introduces a relatively arcane mechanism for creating a NOTICE file to include alongside the binary distribution(s).

A current run would create a NOTICE like this
```
Offen bundles the following 3rd party software:

Client side:
============

"history-events" licensed under MIT, available at https://github.com/xpepermint/history-events
"on-idle" licensed under MIT*, available at https://github.com/choojs/on-idle
"date-fns" licensed under MIT, available at https://github.com/date-fns/date-fns
"dexie" licensed under Apache-2.0, available at https://github.com/dfahlander/Dexie.js
"jwk-to-pem" licensed under Apache-2.0, available at https://github.com/Brightspace/node-jwk-to-pem
"nanohtml" licensed under MIT, available at https://github.com/choojs/nanohtml
"node-forge" licensed under (BSD-3-Clause OR GPL-2.0), available at https://github.com/digitalbazaar/forge
"split-require" licensed under MIT, available at https://github.com/goto-bus-stop/split-require
"underscore" licensed under MIT, available at https://github.com/jashkenas/underscore
"unfetch" licensed under MIT, available at https://github.com/developit/unfetch
"unibabel" licensed under (MIT OR Apache-2.0), available at https://git.coolaj86.com/coolaj86/unibabel.js
"url-polyfill" licensed under MIT, available at https://github.com/lifaon74/url-polyfill
"uuid" licensed under MIT, available at https://github.com/uuidjs/uuid
"envify" licensed under MIT, available at https://github.com/hughsk/envify
"glob" licensed under ISC, available at https://github.com/isaacs/node-glob
"jscodeshift" licensed under BSD-3-Clause, available at https://github.com/facebook/jscodeshift
"pofile" licensed under MIT*, available at http://github.com/rubenv/pofile
"through2" licensed under MIT, available at https://github.com/rvagg/through2
"touch" licensed under ISC, available at https://github.com/isaacs/node-touch
"classnames" licensed under MIT, available at https://github.com/JedWatson/classnames
"plotly.js-basic-dist" licensed under MIT, available at https://github.com/plotly/plotly.js
"preact-router" licensed under MIT, available at https://github.com/developit/preact-router
"preact" licensed under MIT, available at https://github.com/preactjs/preact
"react-copy-to-clipboard" licensed under MIT, available at https://github.com/nkbt/react-copy-to-clipboard
"react-plotly.js" licensed under MIT, available at https://github.com/plotly/react-plotly.js
"react-redux" licensed under MIT, available at https://github:reduxjs/react-redux
"redux-logger" licensed under MIT, available at https://github.com/theaqua/redux-logger
"redux-thunk" licensed under MIT, available at https://github:reduxjs/redux-thunk
"redux" licensed under MIT, available at https://github:reduxjs/redux
"zxcvbn" licensed under MIT, available at https://github.com/dropbox/zxcvbn

Server side:
============
        
"go" licensed under "Apache 2.0", available at https://cloud.google.com/go
"toml" licensed under MIT, available at https://github.com/BurntSushi/toml
"gziphandler" licensed under "Apache 2.0", available at https://github.com/NYTimes/gziphandler
"sarama" licensed under MIT, available at https://github.com/Shopify/sarama
"toxiproxy" licensed under MIT, available at https://github.com/Shopify/toxiproxy
"template" licensed under "New BSD", available at https://github.com/alecthomas/template
"units" licensed under MIT, available at https://github.com/alecthomas/units
"thrift" licensed under "Apache 2.0", available at https://github.com/apache/thrift
"perks" licensed under MIT, available at https://github.com/beorn7/perks
"misspell" licensed under MIT, available at https://github.com/client9/misspell
"go-spew" licensed under ISC, available at https://github.com/davecgh/go-spew
"go-mssqldb" licensed under "New BSD", available at https://github.com/denisenkom/go-mssqldb
"go-resiliency" licensed under MIT, available at https://github.com/eapache/go-resiliency
"go-xerial-snappy" licensed under MIT, available at https://github.com/eapache/go-xerial-snappy
"queue" licensed under MIT, available at https://github.com/eapache/queue
"go-testdb" licensed under "Simplified BSD", available at https://github.com/erikstmartin/go-testdb
"httpsnoop" licensed under MIT, available at https://github.com/felixge/httpsnoop
"fsnotify" licensed under "New BSD", available at https://github.com/fsnotify/fsnotify
"location" licensed under MIT, available at https://github.com/gin-contrib/location
"sse" licensed under MIT, available at https://github.com/gin-contrib/sse
"gin" licensed under MIT, available at https://github.com/gin-gonic/gin
"gomail" licensed under MIT, available at https://github.com/go-gomail/gomail
"kit" licensed under MIT, available at https://github.com/go-kit/kit
"logfmt" licensed under MIT, available at https://github.com/go-logfmt/logfmt
"mysql" licensed under "Mozilla Public License 2.0", available at https://github.com/go-sql-driver/mysql
"stack" licensed under MIT, available at https://github.com/go-stack/stack
"uuid" licensed under MIT, available at https://github.com/gofrs/uuid
"protobuf" licensed under "New BSD", available at https://github.com/gogo/protobuf
"glog" licensed under "Apache 2.0", available at https://github.com/golang/glog
"mock" licensed under "Apache 2.0", available at https://github.com/golang/mock
"snappy" licensed under "New BSD", available at https://github.com/golang/snappy
"btree" licensed under "Apache 2.0", available at https://github.com/google/btree
"go-cmp" licensed under "New BSD", available at https://github.com/google/go-cmp
"martian" licensed under "Apache 2.0", available at https://github.com/google/martian
"pprof" licensed under "Apache 2.0", available at https://github.com/google/pprof
"v2" licensed under "New BSD", available at https://github.com/googleapis/gax-go/v2
"context" licensed under "New BSD", available at https://github.com/gorilla/context
"mux" licensed under "New BSD", available at https://github.com/gorilla/mux
"securecookie" licensed under "New BSD", available at https://github.com/gorilla/securecookie
"golang-lru" licensed under "Mozilla Public License 2.0", available at https://github.com/hashicorp/golang-lru
"tail" licensed under MIT, available at https://github.com/hpcloud/tail
"gorm" licensed under MIT, available at https://github.com/jinzhu/gorm
"inflection" licensed under MIT, available at https://github.com/jinzhu/inflection
"now" licensed under MIT, available at https://github.com/jinzhu/now
"godotenv" licensed under MIT, available at https://github.com/joho/godotenv
"go-junit-report" licensed under MIT, available at https://github.com/jstemmer/go-junit-report
"httprouter" licensed under unknown, available at https://github.com/julienschmidt/httprouter
"envconfig" licensed under MIT, available at https://github.com/kelseyhightower/envconfig
"gotool" licensed under MIT, available at https://github.com/kisielk/gotool
"go-windows-terminal-sequences" licensed under MIT, available at https://github.com/konsorten/go-windows-terminal-sequences
"pretty" licensed under MIT, available at https://github.com/kr/pretty
"pty" licensed under MIT, available at https://github.com/kr/pty
"text" licensed under MIT, available at https://github.com/kr/text
"gotext" licensed under MIT, available at https://github.com/leonelquinteros/gotext
"jwx" licensed under MIT, available at https://github.com/lestrrat-go/jwx
"pq" licensed under MIT, available at https://github.com/lib/pq
"go-isatty" licensed under MIT, available at https://github.com/mattn/go-isatty
"go-sqlite3" licensed under MIT, available at https://github.com/mattn/go-sqlite3
"golang_protobuf_extensions" licensed under "Apache 2.0", available at https://github.com/matttproud/golang_protobuf_extensions
"bluemonday" licensed under "New BSD", available at https://github.com/microcosm-cc/bluemonday
"concurrent" licensed under "Apache 2.0", available at https://github.com/modern-go/concurrent
"reflect2" licensed under "Apache 2.0", available at https://github.com/modern-go/reflect2
"go-conntrack" licensed under "Apache 2.0", available at https://github.com/mwitkow/go-conntrack
"ulid" licensed under "Apache 2.0", available at https://github.com/oklog/ulid
"ginkgo" licensed under MIT, available at https://github.com/onsi/ginkgo
"gomega" licensed under MIT, available at https://github.com/onsi/gomega
"zipkin-go" licensed under "Apache 2.0", available at https://github.com/openzipkin/zipkin-go
"go-cache" licensed under MIT, available at https://github.com/patrickmn/go-cache
"freeport" licensed under "New BSD", available at https://github.com/phayes/freeport
"lz4" licensed under "New BSD", available at https://github.com/pierrec/lz4
"errors" licensed under "Simplified BSD", available at https://github.com/pkg/errors
"go-difflib" licensed under "New BSD", available at https://github.com/pmezard/go-difflib
"client_golang" licensed under "Apache 2.0", available at https://github.com/prometheus/client_golang
"client_model" licensed under "Apache 2.0", available at https://github.com/prometheus/client_model
"common" licensed under "Apache 2.0, available at https://github.com/prometheus/common
"procfs" licensed under "Apache 2.0", available at https://github.com/prometheus/procfs
"statik" licensed under "Apache 2.0", available at https://github.com/rakyll/statik
"go-metrics" licensed under unknown, available at https://github.com/rcrowley/go-metrics
"logrus" licensed under MIT, available at https://github.com/sirupsen/logrus
"objx" licensed under MIT, available at https://github.com/stretchr/objx
"testify" licensed under MIT, available at https://github.com/stretchr/testify
"go.opencensus.io" licensed under "Apache 2.0", available at https://go.opencensus.io
"crypto" licensed under "New BSD", available at https://golang.org/x/crypto
"exp" licensed under "New BSD", available at https://golang.org/x/exp
"lint" licensed under "New BSD", available at https://golang.org/x/lint
"net" licensed under "New BSD", available at https://golang.org/x/net
"oauth2" licensed under "New BSD", available at https://golang.org/x/oauth2
"sync" licensed under "New BSD", available at https://golang.org/x/sync
"sys" licensed under "New BSD", available at https://golang.org/x/sys
"time" licensed under "New BSD", available at https://golang.org/x/time
"tools" licensed under "Apache 2.0, available at https://golang.org/x/tools
"api" licensed under "MIT, available at https://google.golang.org/api
"appengine" licensed under "Apache 2.0", available at https://google.golang.org/appengine
"genproto" licensed under "Apache 2.0", available at https://google.golang.org/genproto
"grpc" licensed under "Apache 2.0", available at https://google.golang.org/grpc
"kingpin.v2" licensed under MIT, available at https://gopkg.in/alecthomas/kingpin.v2
"quotedprintable.v3" licensed under MIT, available at https://gopkg.in/alexcesaro/quotedprintable.v3
"check.v1" licensed under "Simplified BSD", available at https://gopkg.in/check.v1
"fsnotify.v1" licensed under "New BSD", available at https://gopkg.in/fsnotify.v1
"assert.v1" licensed under MIT, available at https://gopkg.in/go-playground/assert.v1
"validator.v8" licensed under MIT, available at https://gopkg.in/go-playground/validator.v8
"gomail.v2" licensed under MIT, available at https://gopkg.in/gomail.v2
"gormigrate.v1" licensed under MIT, available at https://gopkg.in/gormigrate.v1
"tomb.v1" licensed under "New BSD", available at https://gopkg.in/tomb.v1
"yaml.v2" licensed under "Apache 2.0, available at https://gopkg.in/yaml.v2

This file is generated automatically and - even if we try to prevent it - may
contain errors and mistakes. If you found any, send us an email
at hioffen@posteo.de containing details about what is incorrect or missing.
```