### PR TITLE
Use alpine based images in build

### DIFF
--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,7 +1,8 @@
 # Copyright 2020 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:14 as auditorium
+FROM node:14-alpine as auditorium
+RUN apk add git
 
 COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -18,7 +19,8 @@ ENV NODE_ENV production
 RUN npm run build
 RUN npm run licenses
 
-FROM node:14 as script
+FROM node:14-alpine as script
+RUN apk add git
 
 COPY ./script/package.json ./script/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -35,7 +37,8 @@ ENV NODE_ENV production
 RUN npm run build
 RUN npm run licenses
 
-FROM node:14 as vault
+FROM node:14-alpine as vault
+RUN apk add git
 
 COPY ./vault/package.json ./vault/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -53,7 +56,9 @@ RUN npm run build
 RUN npm run licenses
 
 # packages does not have a build step but we need to derive license information
-FROM node:14 as packages
+FROM node:14-alpine as packages
+RUN apk add git
+
 COPY ./packages/package.json ./packages/package-lock.json /code/deps/
 COPY ./packages /code/packages
 WORKDIR /code/deps
@@ -100,7 +105,7 @@ RUN python ./create_notice.py \
   --client auditorium.csv \
   --server server.csv >> NOTICE
 
-FROM golang:1.14 as statik
+FROM golang:1.14-alpine as statik
 
 WORKDIR /code/server
 COPY ./server /code/server

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -3,6 +3,7 @@
 
 FROM node:14-alpine as auditorium
 RUN apk add git
+RUN apk add --no-cache --virtual .gyp python make g++
 
 COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -21,6 +22,7 @@ RUN npm run licenses
 
 FROM node:14-alpine as script
 RUN apk add git
+RUN apk add --no-cache --virtual .gyp python make g++
 
 COPY ./script/package.json ./script/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -39,6 +41,7 @@ RUN npm run licenses
 
 FROM node:14-alpine as vault
 RUN apk add git
+RUN apk add --no-cache --virtual .gyp python make g++
 
 COPY ./vault/package.json ./vault/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -58,6 +61,7 @@ RUN npm run licenses
 # packages does not have a build step but we need to derive license information
 FROM node:14-alpine as packages
 RUN apk add git
+RUN apk add --no-cache --virtual .gyp python make g++
 
 COPY ./packages/package.json ./packages/package-lock.json /code/deps/
 COPY ./packages /code/packages


### PR DESCRIPTION
There's no real need for an Ubuntu based image when all we want to do is create bundles. This cuts roughly 1 minute from the current build time.