### PR TITLE
Limit number of open connections when using sqlite

### DIFF
--- a/server/cmd/offen/app.go
+++ b/server/cmd/offen/app.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 
+	"github.com/jinzhu/gorm"
 	"github.com/offen/offen/server/config"
 	"github.com/sirupsen/logrus"
 )
@@ -39,4 +40,16 @@ func newApp(populateMissing, quiet bool, envFileOverride string) *app {
 
 func newLogger() *logrus.Logger {
 	return logrus.New()
+}
+
+func newDB(c *config.Config) (*gorm.DB, error) {
+	gormDB, err := gorm.Open(c.Database.Dialect.String(), c.Database.ConnectionString.String())
+	if err != nil {
+		return nil, err
+	}
+	gormDB.LogMode(c.App.Development)
+	if c.Database.Dialect == "sqlite3" {
+		gormDB.DB().SetMaxOpenConns(1)
+	}
+	return gormDB, nil
 }

--- a/server/cmd/offen/cmddemo.go
+++ b/server/cmd/offen/cmddemo.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/jinzhu/gorm"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/offen/offen/server/config"
 	"github.com/offen/offen/server/keys"
@@ -80,15 +79,10 @@ func cmdDemo(subcommand string, flags []string) {
 	}
 	a.config.App.DemoAccount = accountID.String()
 
-	gormDB, err := gorm.Open(
-		a.config.Database.Dialect.String(),
-		a.config.Database.ConnectionString.String(),
-	)
+	gormDB, err := newDB(a.config)
 	if err != nil {
 		a.logger.WithError(err).Fatal("Unable to establish database connection")
 	}
-	gormDB.LogMode(a.config.App.Development)
-
 	db, err := persistence.New(
 		relational.NewRelationalDAL(gormDB),
 	)

--- a/server/cmd/offen/cmdexpire.go
+++ b/server/cmd/offen/cmdexpire.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/jinzhu/gorm"
 	"github.com/offen/offen/server/config"
 	"github.com/offen/offen/server/persistence"
 	"github.com/offen/offen/server/persistence/relational"
@@ -33,11 +32,10 @@ func cmdExpire(subcommand string, flags []string) {
 	cmd.Parse(flags)
 	a := newApp(false, true, *envFile)
 
-	gormDB, dbErr := gorm.Open(a.config.Database.Dialect.String(), a.config.Database.ConnectionString.String())
+	gormDB, dbErr := newDB(a.config)
 	if dbErr != nil {
 		a.logger.WithError(dbErr).Fatal("Error establishing database connection")
 	}
-	gormDB.LogMode(a.config.App.Development)
 
 	db, err := persistence.New(
 		relational.NewRelationalDAL(gormDB),

--- a/server/cmd/offen/cmdmigrate.go
+++ b/server/cmd/offen/cmdmigrate.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/jinzhu/gorm"
 	"github.com/offen/offen/server/persistence"
 	"github.com/offen/offen/server/persistence/relational"
 )
@@ -33,11 +32,11 @@ func cmdMigrate(subcommand string, flags []string) {
 	cmd.Parse(flags)
 	a := newApp(false, true, *envFile)
 
-	gormDB, dbErr := gorm.Open(a.config.Database.Dialect.String(), a.config.Database.ConnectionString.String())
+	gormDB, dbErr := newDB(a.config)
 	if dbErr != nil {
 		a.logger.WithError(dbErr).Fatal("Error establishing database connection")
 	}
-	gormDB.LogMode(a.config.App.Development)
+
 	db, err := persistence.New(
 		relational.NewRelationalDAL(gormDB),
 	)

--- a/server/cmd/offen/cmdserve.go
+++ b/server/cmd/offen/cmdserve.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jinzhu/gorm"
 	"github.com/offen/offen/server/config"
 	"github.com/offen/offen/server/locales"
 	"github.com/offen/offen/server/persistence"
@@ -53,11 +52,10 @@ func cmdServe(subcommand string, flags []string) {
 	cmd.Parse(flags)
 	a := newApp(false, false, *envFile)
 
-	gormDB, err := gorm.Open(a.config.Database.Dialect.String(), a.config.Database.ConnectionString.String())
+	gormDB, err := newDB(a.config)
 	if err != nil {
 		a.logger.WithError(err).Fatal("Unable to establish database connection")
 	}
-	gormDB.LogMode(a.config.App.Development)
 
 	db, err := persistence.New(
 		relational.NewRelationalDAL(gormDB),

--- a/server/cmd/offen/cmdsetup.go
+++ b/server/cmd/offen/cmdsetup.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	uuid "github.com/gofrs/uuid"
-	"github.com/jinzhu/gorm"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/offen/offen/server/persistence"
 	"github.com/offen/offen/server/persistence/relational"
@@ -133,8 +132,7 @@ func cmdSetup(subcommand string, flags []string) {
 	}
 	conf.Force = *force
 
-	gormDB, dbErr := gorm.Open(a.config.Database.Dialect.String(), a.config.Database.ConnectionString.String())
-	gormDB.LogMode(a.config.App.Development)
+	gormDB, dbErr := newDB(a.config)
 
 	if dbErr != nil {
 		a.logger.WithError(dbErr).Fatal("Error establishing database connection")


### PR DESCRIPTION
This fixes a SQLite specific concurrency we have seen in the security audit.