### PR TITLE
Tighten lighthouse requirements

### DIFF
--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -4,7 +4,7 @@
   "defaultCommandTimeout": 20000,
   "lighthouse": {
     "performance": 90,
-    "accessibility": 90,
+    "accessibility": 100,
     "best-practices": 80,
     "seo": 0,
     "pwa": 0


### PR DESCRIPTION
Following up on the A11y audit and the improvements, we can now bump the thresholds in the automated Lighthouse audit.