### PR TITLE
Configure Argon2 in a less memory-hungry manner

### DIFF
--- a/server/keys/hash.go
+++ b/server/keys/hash.go
@@ -5,6 +5,7 @@ package keys
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"runtime"
@@ -16,14 +17,14 @@ const (
 	// It turned out that the initial argon2 configuration was _very_ memory
 	// hungry, which is why new users are now receiving an updated config
 	// that is slower, but consumes less memory.
-	passwordAlgoArgon2HighMemoryConsumption = 1
-	passwordAlgoArgon2                      = 2
+	passwordAlgoArgon2HighMemoryConsumptionDEPRECATED = 1
+	passwordAlgoArgon2                                = 2
 )
 
 // DeriveKey wraps package argon2 in order to derive a symmetric key from the
 // given value (most likely a password) and the given salt.
-func DeriveKey(value, encodedSalt string) ([]byte, error) {
-	salt, saltErr := unmarshalVersionedCipher(encodedSalt)
+func DeriveKey(value, versionedSalt string) ([]byte, error) {
+	salt, saltErr := unmarshalVersionedCipher(versionedSalt)
 	if saltErr != nil {
 		return nil, fmt.Errorf("keys: error decoding salt into bytes: %w", saltErr)
 	}
@@ -31,8 +32,8 @@ func DeriveKey(value, encodedSalt string) ([]byte, error) {
 	case passwordAlgoArgon2:
 		key := defaultArgon2Hash([]byte(value), salt.cipher, DefaultEncryptionKeySize)
 		return key, nil
-	case passwordAlgoArgon2HighMemoryConsumption:
-		key := highMemoryArgon2Hash([]byte(value), salt.cipher, DefaultEncryptionKeySize)
+	case passwordAlgoArgon2HighMemoryConsumptionDEPRECATED:
+		key := highMemoryArgon2HashDEPRECATED([]byte(value), salt.cipher, DefaultEncryptionKeySize)
 		return key, nil
 	default:
 		return nil, fmt.Errorf("keys: received unknown algo version %d for deriving key", salt.algoVersion)
@@ -40,52 +41,52 @@ func DeriveKey(value, encodedSalt string) ([]byte, error) {
 }
 
 // NewSalt creates a new salt value of the default length and wraps it in a
-// versioned cipher
-func NewSalt() (*VersionedCipher, error) {
-	b, err := GenerateRandomBytes(DefaultSaltLength)
+// versioned cipher using the latest available algo version
+func NewSalt(len int) (*VersionedCipher, error) {
+	b, err := GenerateRandomBytes(len)
 	if err != nil {
 		return nil, fmt.Errorf("keys: error generating random salt: %w", err)
 	}
 	return newVersionedCipher(b, passwordAlgoArgon2), nil
 }
 
-// HashString hashes the given string using argon2
-func HashString(pw string) (*VersionedCipher, error) {
-	if pw == "" {
+// HashString hashes the given string using argon2 using the latest configuration
+func HashString(s string) (*VersionedCipher, error) {
+	if s == "" {
 		return nil, errors.New("keys: cannot hash an empty string")
 	}
 	salt, saltErr := GenerateRandomBytes(DefaultSecretLength)
 	if saltErr != nil {
 		return nil, fmt.Errorf("keys: error generating random salt for password hash: %w", saltErr)
 	}
-	hash := defaultArgon2Hash([]byte(pw), salt, DefaultPasswordHashSize)
+	hash := defaultArgon2Hash([]byte(s), salt, DefaultPasswordHashSize)
 	return newVersionedCipher(hash, passwordAlgoArgon2).addNonce(salt), nil
 }
 
 // CompareString compares a string with a stored hash
-func CompareString(password, cipher string) error {
-	if cipher == "" {
+func CompareString(s, versionedCipher string) error {
+	if versionedCipher == "" {
 		return errors.New("keys: cannot compare against an empty cipher")
 	}
-	v, err := unmarshalVersionedCipher(cipher)
+	cipher, err := unmarshalVersionedCipher(versionedCipher)
 	if err != nil {
 		return fmt.Errorf("keys: error parsing versioned cipher: %w", err)
 	}
-	switch v.algoVersion {
+	switch cipher.algoVersion {
 	case passwordAlgoArgon2:
-		hash := defaultArgon2Hash([]byte(password), v.nonce, DefaultPasswordHashSize)
-		if bytes.Compare(hash, v.cipher) != 0 {
+		hashedInput := defaultArgon2Hash([]byte(s), cipher.nonce, DefaultPasswordHashSize)
+		if bytes.Compare(hashedInput, cipher.cipher) != 0 {
 			return errors.New("keys: could not match passwords")
 		}
 		return nil
-	case passwordAlgoArgon2HighMemoryConsumption:
-		hash := highMemoryArgon2Hash([]byte(password), v.nonce, DefaultPasswordHashSize)
-		if bytes.Compare(hash, v.cipher) != 0 {
+	case passwordAlgoArgon2HighMemoryConsumptionDEPRECATED:
+		hashedInput := highMemoryArgon2HashDEPRECATED([]byte(s), cipher.nonce, DefaultPasswordHashSize)
+		if bytes.Compare(hashedInput, cipher.cipher) != 0 {
 			return errors.New("keys: could not match passwords")
 		}
 		return nil
 	default:
-		return fmt.Errorf("keys: received unknown algo version %d for comparing passwords", v.algoVersion)
+		return fmt.Errorf("keys: received unknown algo version %d for comparing passwords", cipher.algoVersion)
 	}
 }
 
@@ -93,6 +94,37 @@ func defaultArgon2Hash(val, salt []byte, size uint32) []byte {
 	return argon2.IDKey(val, salt, 4, 16*1024, uint8(runtime.NumCPU()), size)
 }
 
-func highMemoryArgon2Hash(val, salt []byte, size uint32) []byte {
+func highMemoryArgon2HashDEPRECATED(val, salt []byte, size uint32) []byte {
 	return argon2.IDKey(val, salt, 1, 64*1024, 4, size)
+}
+
+const (
+	hashAlgoSHA256 = 1
+)
+
+// HashFast creates a fast (i.e. not suitable for passwords) hash of the given
+// value and the given salt
+func HashFast(value, versionedSalt string) (string, error) {
+	salt, err := unmarshalVersionedCipher(versionedSalt)
+	if err != nil {
+		return "", fmt.Errorf("keys: error unmarshaling given salt: %w", err)
+	}
+	switch salt.algoVersion {
+	case hashAlgoSHA256:
+		joined := append([]byte(value), salt.cipher...)
+		hashed := sha256.Sum256(joined)
+		return fmt.Sprintf("%x", hashed), nil
+	default:
+		return "", fmt.Errorf("keys: received unknown algo version %d for creating hash", salt.algoVersion)
+	}
+}
+
+// NewFastSalt creates a new user salt value of the default length and wraps it in a
+// versioned cipher
+func NewFastSalt(len int) (*VersionedCipher, error) {
+	b, err := GenerateRandomBytes(len)
+	if err != nil {
+		return nil, fmt.Errorf("keys: error generating user salt: %w", err)
+	}
+	return newVersionedCipher(b, hashAlgoSHA256), nil
 }

--- a/server/keys/hash.go
+++ b/server/keys/hash.go
@@ -1,0 +1,98 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package keys
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	// It turned out that the initial argon2 configuration was _very_ memory
+	// hungry, which is why new users are now receiving an updated config
+	// that is slower, but consumes less memory.
+	passwordAlgoArgon2HighMemoryConsumption = 1
+	passwordAlgoArgon2                      = 2
+)
+
+// DeriveKey wraps package argon2 in order to derive a symmetric key from the
+// given value (most likely a password) and the given salt.
+func DeriveKey(value, encodedSalt string) ([]byte, error) {
+	salt, saltErr := unmarshalVersionedCipher(encodedSalt)
+	if saltErr != nil {
+		return nil, fmt.Errorf("keys: error decoding salt into bytes: %w", saltErr)
+	}
+	switch salt.algoVersion {
+	case passwordAlgoArgon2:
+		key := defaultArgon2Hash([]byte(value), salt.cipher, DefaultEncryptionKeySize)
+		return key, nil
+	case passwordAlgoArgon2HighMemoryConsumption:
+		key := highMemoryArgon2Hash([]byte(value), salt.cipher, DefaultEncryptionKeySize)
+		return key, nil
+	default:
+		return nil, fmt.Errorf("keys: received unknown algo version %d for deriving key", salt.algoVersion)
+	}
+}
+
+// NewSalt creates a new salt value of the default length and wraps it in a
+// versioned cipher
+func NewSalt() (*VersionedCipher, error) {
+	b, err := GenerateRandomBytes(DefaultSaltLength)
+	if err != nil {
+		return nil, fmt.Errorf("keys: error generating random salt: %w", err)
+	}
+	return newVersionedCipher(b, passwordAlgoArgon2), nil
+}
+
+// HashString hashes the given string using argon2
+func HashString(pw string) (*VersionedCipher, error) {
+	if pw == "" {
+		return nil, errors.New("keys: cannot hash an empty string")
+	}
+	salt, saltErr := GenerateRandomBytes(DefaultSecretLength)
+	if saltErr != nil {
+		return nil, fmt.Errorf("keys: error generating random salt for password hash: %w", saltErr)
+	}
+	hash := defaultArgon2Hash([]byte(pw), salt, DefaultPasswordHashSize)
+	return newVersionedCipher(hash, passwordAlgoArgon2).addNonce(salt), nil
+}
+
+// CompareString compares a string with a stored hash
+func CompareString(password, cipher string) error {
+	if cipher == "" {
+		return errors.New("keys: cannot compare against an empty cipher")
+	}
+	v, err := unmarshalVersionedCipher(cipher)
+	if err != nil {
+		return fmt.Errorf("keys: error parsing versioned cipher: %w", err)
+	}
+	switch v.algoVersion {
+	case passwordAlgoArgon2:
+		hash := defaultArgon2Hash([]byte(password), v.nonce, DefaultPasswordHashSize)
+		if bytes.Compare(hash, v.cipher) != 0 {
+			return errors.New("keys: could not match passwords")
+		}
+		return nil
+	case passwordAlgoArgon2HighMemoryConsumption:
+		hash := highMemoryArgon2Hash([]byte(password), v.nonce, DefaultPasswordHashSize)
+		if bytes.Compare(hash, v.cipher) != 0 {
+			return errors.New("keys: could not match passwords")
+		}
+		return nil
+	default:
+		return fmt.Errorf("keys: received unknown algo version %d for comparing passwords", v.algoVersion)
+	}
+}
+
+func defaultArgon2Hash(val, salt []byte, size uint32) []byte {
+	return argon2.IDKey(val, salt, 4, 16*1024, uint8(runtime.NumCPU()), size)
+}
+
+func highMemoryArgon2Hash(val, salt []byte, size uint32) []byte {
+	return argon2.IDKey(val, salt, 1, 64*1024, 4, size)
+}

--- a/server/keys/hash_test.go
+++ b/server/keys/hash_test.go
@@ -1,0 +1,19 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package keys
+
+import "testing"
+
+func TestHashString(t *testing.T) {
+	hash, hashErr := HashString("s3cr3t")
+	if hashErr != nil {
+		t.Fatalf("Unexpected error %v", hashErr)
+	}
+	if err := CompareString("s3cr3t", hash.Marshal()); err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if err := CompareString("other", hash.Marshal()); err == nil {
+		t.Errorf("Comparison unexpectedly passed for wrong password")
+	}
+}

--- a/server/keys/symmetric_test.go
+++ b/server/keys/symmetric_test.go
@@ -47,16 +47,3 @@ func TestSymmetricEncryption(t *testing.T) {
 		})
 	}
 }
-
-func TestHashString(t *testing.T) {
-	hash, hashErr := HashString("s3cr3t")
-	if hashErr != nil {
-		t.Fatalf("Unexpected error %v", hashErr)
-	}
-	if err := CompareString("s3cr3t", hash.Marshal()); err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-	if err := CompareString("other", hash.Marshal()); err == nil {
-		t.Errorf("Comparison unexpectedly passed for wrong password")
-	}
-}

--- a/server/keys/symmetric_test.go
+++ b/server/keys/symmetric_test.go
@@ -22,7 +22,7 @@ func TestSymmetricEncryption(t *testing.T) {
 		{
 			"derived",
 			func() ([]byte, error) {
-				return DeriveKey("mypassword", "XqiWf9CdPpmT3bu0aHkzjQ==")
+				return DeriveKey("mypassword", "{1,} XqiWf9CdPpmT3bu0aHkzjQ==")
 			},
 		},
 	}

--- a/server/persistence/accounts.go
+++ b/server/persistence/accounts.go
@@ -73,7 +73,11 @@ func (p *persistenceLayer) AssociateUserSecret(accountID, userID, encryptedUserS
 		return fmt.Errorf(`persistence: error looking up account with id "%s": %w`, accountID, err)
 	}
 
-	hashedUserID := account.HashUserID(userID)
+	hashedUserID, hashErr := account.HashUserID(userID)
+	if hashErr != nil {
+		return fmt.Errorf("persistence: erro hashing user id: %w", err)
+	}
+
 	secret, err := p.dal.FindSecret(FindSecretQueryBySecretID(hashedUserID))
 	if err != nil {
 		var notFound ErrUnknownSecret
@@ -94,7 +98,10 @@ func (p *persistenceLayer) AssociateUserSecret(accountID, userID, encryptedUserS
 		if parkedIDErr != nil {
 			return fmt.Errorf("persistence: error creating identifier for parking events: %v", parkedIDErr)
 		}
-		parkedHash := account.HashUserID(parkedID.String())
+		parkedHash, parkErr := account.HashUserID(parkedID.String())
+		if parkErr != nil {
+			return fmt.Errorf("persistence: error hashing parked id: %v", parkErr)
+		}
 
 		txn, err := p.dal.Transaction()
 		if err != nil {

--- a/server/persistence/bootstrap.go
+++ b/server/persistence/bootstrap.go
@@ -181,7 +181,7 @@ func newAccountUser(email, password string, adminLevel interface{}) (*AccountUse
 	if hashedEmailErr != nil {
 		return nil, hashedEmailErr
 	}
-	salt, saltErr := keys.NewSalt()
+	salt, saltErr := keys.NewSalt(keys.DefaultSaltLength)
 	if saltErr != nil {
 		return nil, saltErr
 	}
@@ -234,7 +234,7 @@ func newAccount(name, accountID string) (*Account, []byte, error) {
 		return nil, nil, encryptedPrivateKeyErr
 	}
 
-	salt, saltErr := keys.GenerateRandomValue(keys.DefaultSecretLength)
+	salt, saltErr := keys.NewFastSalt(keys.DefaultSecretLength)
 	if saltErr != nil {
 		return nil, nil, saltErr
 	}
@@ -244,7 +244,7 @@ func newAccount(name, accountID string) (*Account, []byte, error) {
 		Name:                name,
 		PublicKey:           string(publicKey),
 		EncryptedPrivateKey: encryptedPrivateKey.Marshal(),
-		UserSalt:            salt,
+		UserSalt:            salt.Marshal(),
 		Retired:             false,
 		Created:             time.Now(),
 	}, encryptionKey, nil

--- a/server/persistence/bootstrap.go
+++ b/server/persistence/bootstrap.go
@@ -181,13 +181,13 @@ func newAccountUser(email, password string, adminLevel interface{}) (*AccountUse
 	if hashedEmailErr != nil {
 		return nil, hashedEmailErr
 	}
-	salt, saltErr := keys.GenerateRandomValue(keys.DefaultSaltLength)
+	salt, saltErr := keys.NewSalt()
 	if saltErr != nil {
 		return nil, saltErr
 	}
 	a := &AccountUser{
 		AccountUserID: accountUserID.String(),
-		Salt:          salt,
+		Salt:          salt.Marshal(),
 		AdminLevel:    level,
 		HashedEmail:   hashedEmail.Marshal(),
 	}

--- a/server/persistence/entities.go
+++ b/server/persistence/entities.go
@@ -4,8 +4,6 @@
 package persistence
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -114,11 +112,12 @@ type Account struct {
 
 // HashUserID uses the account's `UserSalt` to create a hashed version of a
 // user identifier that is unique per account.
-func (a *Account) HashUserID(userID string) string {
-	b, _ := base64.StdEncoding.DecodeString(a.UserSalt)
-	joined := append([]byte(userID), b...)
-	hashed := sha256.Sum256(joined)
-	return fmt.Sprintf("%x", hashed)
+func (a *Account) HashUserID(userID string) (string, error) {
+	result, err := keys.HashFast(userID, a.UserSalt)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
 }
 
 // WrapPublicKey returns the public key of an account's keypair in

--- a/server/persistence/entities_test.go
+++ b/server/persistence/entities_test.go
@@ -8,10 +8,10 @@ import "testing"
 func TestAccount_HashUserID(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		account := Account{
-			UserSalt: "some-salt-value",
+			UserSalt: "{1,} b2tpZG9raQ==",
 		}
-		one := account.HashUserID("user-one")
-		two := account.HashUserID("user-two")
+		one, _ := account.HashUserID("user-one")
+		two, _ := account.HashUserID("user-two")
 
 		if one == "" {
 			t.Error("Unexpected empty string")
@@ -26,7 +26,7 @@ func TestAccount_HashUserID(t *testing.T) {
 		otherAccount := Account{
 			UserSalt: "other-salt-value",
 		}
-		otherOne := otherAccount.HashUserID("user-one")
+		otherOne, _ := otherAccount.HashUserID("user-one")
 
 		if one == otherOne {
 			t.Error("Expected different values for same user id on different accounts")

--- a/server/persistence/events.go
+++ b/server/persistence/events.go
@@ -20,7 +20,10 @@ func (p *persistenceLayer) Insert(userID, accountID, payload string) error {
 
 	var hashedUserID *string
 	if userID != "" {
-		hash := account.HashUserID(userID)
+		hash, err := account.HashUserID(userID)
+		if err != nil {
+			return fmt.Errorf("persistence: error hashing user id: %w", err)
+		}
 		hashedUserID = &hash
 	}
 
@@ -144,7 +147,7 @@ func hashUserIDForAccounts(userID string, accounts []Account) []string {
 	// computation is being done concurrently
 	for _, account := range accounts {
 		go func(account Account) {
-			hash := account.HashUserID(userID)
+			hash, _ := account.HashUserID(userID)
 			hashes <- hash
 		}(account)
 	}

--- a/server/persistence/events_test.go
+++ b/server/persistence/events_test.go
@@ -69,7 +69,7 @@ func TestPersistenceLayer_Insert(t *testing.T) {
 			&mockInsertEventDatabase{
 				findAccountResult: Account{
 					Name:     "test",
-					UserSalt: "CaHVhk78uhoPmf5wanA0vg==",
+					UserSalt: "{1,} CaHVhk78uhoPmf5wanA0vg==",
 				},
 				findSecretErr: errors.New("did not work"),
 			},
@@ -99,7 +99,7 @@ func TestPersistenceLayer_Insert(t *testing.T) {
 			&mockInsertEventDatabase{
 				findAccountResult: Account{
 					Name:     "test",
-					UserSalt: "CaHVhk78uhoPmf5wanA0vg==",
+					UserSalt: "{1,} CaHVhk78uhoPmf5wanA0vg==",
 				},
 				createEventErr: errors.New("did not work"),
 			},
@@ -141,7 +141,7 @@ func TestPersistenceLayer_Insert(t *testing.T) {
 			&mockInsertEventDatabase{
 				findAccountResult: Account{
 					Name:     "test",
-					UserSalt: "CaHVhk78uhoPmf5wanA0vg==",
+					UserSalt: "{1,} CaHVhk78uhoPmf5wanA0vg==",
 				},
 			},
 			false,
@@ -182,7 +182,7 @@ func TestPersistenceLayer_Insert(t *testing.T) {
 			&mockInsertEventDatabase{
 				findAccountResult: Account{
 					Name:     "test",
-					UserSalt: "CaHVhk78uhoPmf5wanA0vg==",
+					UserSalt: "{1,} CaHVhk78uhoPmf5wanA0vg==",
 				},
 				findSecretErr: errors.New("did not work"),
 			},

--- a/server/persistence/relational/migrations.go
+++ b/server/persistence/relational/migrations.go
@@ -1,0 +1,214 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package relational
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jinzhu/gorm"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+func (r *relationalDAL) ApplyMigrations() error {
+	m := gormigrate.New(r.db, gormigrate.DefaultOptions, []*gormigrate.Migration{
+		{
+			ID: "001_introduce_admin_level",
+			Migrate: func(db *gorm.DB) error {
+				type AccountUser struct {
+					AccountUserID  string `gorm:"primary_key"`
+					HashedEmail    string
+					HashedPassword string
+					Salt           string
+					AdminLevel     int
+					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
+				}
+				if err := db.AutoMigrate(&AccountUser{}).Error; err != nil {
+					return err
+				}
+				return db.Model(&AccountUser{}).UpdateColumn("admin_level", 1).Error
+			},
+			Rollback: func(db *gorm.DB) error {
+				type AccountUser struct {
+					AccountUserID  string `gorm:"primary_key"`
+					HashedEmail    string
+					HashedPassword string
+					Salt           string
+					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
+				}
+				return db.AutoMigrate(&AccountUser{}).Error
+			},
+		},
+		{
+			ID: "002_mysql_set_column_sizes",
+			Migrate: func(db *gorm.DB) error {
+				type Account struct {
+					AccountID           string `gorm:"primary_key"`
+					Name                string
+					PublicKey           string `gorm:"type:text"`
+					EncryptedPrivateKey string `gorm:"type:text"`
+					UserSalt            string
+					Retired             bool
+					Created             time.Time
+					Events              []Event `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
+				}
+				type AccountUserRelationship struct {
+					RelationshipID                    string `gorm:"primary_key"`
+					AccountUserID                     string
+					AccountID                         string
+					PasswordEncryptedKeyEncryptionKey string `gorm:"type:text"`
+					EmailEncryptedKeyEncryptionKey    string `gorm:"type:text"`
+					OneTimeEncryptedKeyEncryptionKey  string `gorm:"type:text"`
+				}
+				type Event struct {
+					EventID   string `gorm:"primary_key"`
+					AccountID string
+					// the secret id is nullable for anonymous events
+					SecretID *string
+					Payload  string `gorm:"type:text"`
+					Secret   Secret `gorm:"foreignkey:SecretID;association_foreignkey:SecretID"`
+				}
+
+				return db.AutoMigrate(&Account{}, &AccountUserRelationship{}, &Event{}).Error
+			},
+			Rollback: func(db *gorm.DB) error {
+				type Account struct {
+					AccountID           string `gorm:"primary_key"`
+					Name                string
+					PublicKey           string
+					EncryptedPrivateKey string
+					UserSalt            string
+					Retired             bool
+					Created             time.Time
+					Events              []Event `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
+				}
+				type AccountUserRelationship struct {
+					RelationshipID                    string `gorm:"primary_key"`
+					AccountUserID                     string
+					AccountID                         string
+					PasswordEncryptedKeyEncryptionKey string
+					EmailEncryptedKeyEncryptionKey    string
+					OneTimeEncryptedKeyEncryptionKey  string
+				}
+				type Event struct {
+					EventID   string `gorm:"primary_key"`
+					AccountID string
+					// the secret id is nullable for anonymous events
+					SecretID *string
+					Payload  string
+					Secret   Secret `gorm:"foreignkey:SecretID;association_foreignkey:SecretID"`
+				}
+				return db.AutoMigrate(&Account{}, &AccountUserRelationship{}, &Event{}).Error
+			},
+		},
+		{
+			ID: "003_version_salts",
+			Migrate: func(db *gorm.DB) error {
+				type AccountUser struct {
+					AccountUserID  string `gorm:"primary_key"`
+					HashedEmail    string
+					HashedPassword string
+					Salt           string
+					AdminLevel     int
+					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
+				}
+				type Account struct {
+					AccountID           string `gorm:"primary_key"`
+					Name                string
+					PublicKey           string `gorm:"type:text"`
+					EncryptedPrivateKey string `gorm:"type:text"`
+					UserSalt            string
+					Retired             bool
+					Created             time.Time
+					Events              []Event `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
+				}
+
+				var allUsers []*AccountUser
+				if err := db.Find(&allUsers).Error; err != nil {
+					return err
+				}
+				var allAccounts []*Account
+				if err := db.Find(&allAccounts).Error; err != nil {
+					return err
+				}
+
+				txn := db.Begin()
+
+				for _, user := range allUsers {
+					user.Salt = fmt.Sprintf("{1,} %s", user.Salt)
+					if err := txn.Save(user).Error; err != nil {
+						txn.Rollback()
+						return err
+					}
+				}
+
+				for _, account := range allAccounts {
+					account.UserSalt = fmt.Sprintf("{1,} %s", account.UserSalt)
+					if err := txn.Save(account).Error; err != nil {
+						txn.Rollback()
+						return err
+					}
+				}
+
+				return txn.Commit().Error
+			},
+			Rollback: func(db *gorm.DB) error {
+				type AccountUser struct {
+					AccountUserID  string `gorm:"primary_key"`
+					HashedEmail    string
+					HashedPassword string
+					Salt           string
+					AdminLevel     int
+					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
+				}
+				type Account struct {
+					AccountID           string `gorm:"primary_key"`
+					Name                string
+					PublicKey           string `gorm:"type:text"`
+					EncryptedPrivateKey string `gorm:"type:text"`
+					UserSalt            string
+					Retired             bool
+					Created             time.Time
+					Events              []Event `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
+				}
+
+				var allUsers []*AccountUser
+				if err := db.Find(&allUsers).Error; err != nil {
+					return err
+				}
+				var allAccounts []*Account
+				if err := db.Find(&allAccounts).Error; err != nil {
+					return err
+				}
+
+				txn := db.Begin()
+				for _, user := range allUsers {
+					chunks := strings.Split(user.Salt, " ")
+					user.Salt = chunks[1]
+					if err := txn.Save(user).Error; err != nil {
+						txn.Rollback()
+						return err
+					}
+				}
+				for _, account := range allAccounts {
+					chunks := strings.Split(account.UserSalt, " ")
+					account.UserSalt = chunks[1]
+					if err := txn.Save(account).Error; err != nil {
+						txn.Rollback()
+						return err
+					}
+				}
+
+				return txn.Commit().Error
+			},
+		},
+	})
+
+	m.InitSchema(func(db *gorm.DB) error {
+		return db.AutoMigrate(knownTables...).Error
+	})
+
+	return m.Migrate()
+}

--- a/server/persistence/relational/relational.go
+++ b/server/persistence/relational/relational.go
@@ -5,8 +5,6 @@ package relational
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/jinzhu/gorm"
 	"github.com/offen/offen/server/persistence"
@@ -15,7 +13,6 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	gormigrate "gopkg.in/gormigrate.v1"
 )
 
 type relationalDAL struct {
@@ -58,156 +55,6 @@ func (r *relationalDAL) ProbeEmpty() bool {
 		}
 	}
 	return true
-}
-
-func (r *relationalDAL) ApplyMigrations() error {
-	m := gormigrate.New(r.db, gormigrate.DefaultOptions, []*gormigrate.Migration{
-		{
-			ID: "001_introduce_admin_level",
-			Migrate: func(db *gorm.DB) error {
-				type AccountUser struct {
-					AccountUserID  string `gorm:"primary_key"`
-					HashedEmail    string
-					HashedPassword string
-					Salt           string
-					AdminLevel     int
-					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
-				}
-				if err := db.AutoMigrate(&AccountUser{}).Error; err != nil {
-					return err
-				}
-				return db.Model(&AccountUser{}).UpdateColumn("admin_level", 1).Error
-			},
-			Rollback: func(db *gorm.DB) error {
-				type AccountUser struct {
-					AccountUserID  string `gorm:"primary_key"`
-					HashedEmail    string
-					HashedPassword string
-					Salt           string
-					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
-				}
-				return db.AutoMigrate(&AccountUser{}).Error
-			},
-		},
-		{
-			ID: "002_mysql_set_column_sizes",
-			Migrate: func(db *gorm.DB) error {
-				type Account struct {
-					AccountID           string `gorm:"primary_key"`
-					Name                string
-					PublicKey           string `gorm:"type:text"`
-					EncryptedPrivateKey string `gorm:"type:text"`
-					UserSalt            string
-					Retired             bool
-					Created             time.Time
-					Events              []Event `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
-				}
-				type AccountUserRelationship struct {
-					RelationshipID                    string `gorm:"primary_key"`
-					AccountUserID                     string
-					AccountID                         string
-					PasswordEncryptedKeyEncryptionKey string `gorm:"type:text"`
-					EmailEncryptedKeyEncryptionKey    string `gorm:"type:text"`
-					OneTimeEncryptedKeyEncryptionKey  string `gorm:"type:text"`
-				}
-				type Event struct {
-					EventID   string `gorm:"primary_key"`
-					AccountID string
-					// the secret id is nullable for anonymous events
-					SecretID *string
-					Payload  string `gorm:"type:text"`
-					Secret   Secret `gorm:"foreignkey:SecretID;association_foreignkey:SecretID"`
-				}
-
-				return db.AutoMigrate(&Account{}, &AccountUserRelationship{}, &Event{}).Error
-			},
-			Rollback: func(db *gorm.DB) error {
-				type Account struct {
-					AccountID           string `gorm:"primary_key"`
-					Name                string
-					PublicKey           string
-					EncryptedPrivateKey string
-					UserSalt            string
-					Retired             bool
-					Created             time.Time
-					Events              []Event `gorm:"foreignkey:AccountID;association_foreignkey:AccountID"`
-				}
-				type AccountUserRelationship struct {
-					RelationshipID                    string `gorm:"primary_key"`
-					AccountUserID                     string
-					AccountID                         string
-					PasswordEncryptedKeyEncryptionKey string
-					EmailEncryptedKeyEncryptionKey    string
-					OneTimeEncryptedKeyEncryptionKey  string
-				}
-				type Event struct {
-					EventID   string `gorm:"primary_key"`
-					AccountID string
-					// the secret id is nullable for anonymous events
-					SecretID *string
-					Payload  string
-					Secret   Secret `gorm:"foreignkey:SecretID;association_foreignkey:SecretID"`
-				}
-				return db.AutoMigrate(&Account{}, &AccountUserRelationship{}, &Event{}).Error
-			},
-		},
-		{
-			ID: "003_account_user_salt_version",
-			Migrate: func(db *gorm.DB) error {
-				type AccountUser struct {
-					AccountUserID  string `gorm:"primary_key"`
-					HashedEmail    string
-					HashedPassword string
-					Salt           string
-					AdminLevel     int
-					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
-				}
-				var allUsers []*AccountUser
-				if err := db.Find(&allUsers).Error; err != nil {
-					return err
-				}
-				txn := db.Begin()
-				for _, user := range allUsers {
-					user.Salt = fmt.Sprintf("{1,} %s", user.Salt)
-					if err := txn.Save(user).Error; err != nil {
-						txn.Rollback()
-						return err
-					}
-				}
-				return txn.Commit().Error
-			},
-			Rollback: func(db *gorm.DB) error {
-				type AccountUser struct {
-					AccountUserID  string `gorm:"primary_key"`
-					HashedEmail    string
-					HashedPassword string
-					Salt           string
-					AdminLevel     int
-					Relationships  []AccountUserRelationship `gorm:"foreignkey:AccountUserID;association_foreignkey:AccountUserID"`
-				}
-				var allUsers []*AccountUser
-				if err := db.Find(&allUsers).Error; err != nil {
-					return err
-				}
-				txn := db.Begin()
-				for _, user := range allUsers {
-					chunks := strings.Split(user.Salt, " ")
-					user.Salt = chunks[1]
-					if err := txn.Save(user).Error; err != nil {
-						txn.Rollback()
-						return err
-					}
-				}
-				return txn.Commit().Error
-			},
-		},
-	})
-
-	m.InitSchema(func(db *gorm.DB) error {
-		return db.AutoMigrate(knownTables...).Error
-	})
-
-	return m.Migrate()
 }
 
 func (r *relationalDAL) Ping() error {


### PR DESCRIPTION
New account users can be created using an Argon2 setup that is more gentle on low-end VPS configuration (e.g. 512MB RAM).

See: #430 