### PR TITLE
Normalize trailing slashes on URLs

### DIFF
--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -246,12 +246,20 @@ function validateAndParseEvent (event) {
   }
   var clone = JSON.parse(JSON.stringify(event))
   if (clone.payload.href) {
-    clone.payload.href = new window.URL(clone.payload.href)
+    clone.payload.href = normalizedURL(clone.payload.href)
   }
   if (clone.payload.referrer) {
-    clone.payload.referrer = new window.URL(clone.payload.referrer)
+    clone.payload.referrer = normalizedURL(clone.payload.referrer)
   }
   return clone
+}
+
+function normalizedURL (urlString) {
+  var url = new window.URL(urlString)
+  if (!/\/$/.test(url.pathname)) {
+    url.pathname += '/'
+  }
+  return url
 }
 
 function toUpperBound (date) {

--- a/vault/src/queries.test.js
+++ b/vault/src/queries.test.js
@@ -483,13 +483,13 @@ describe('src/queries.js', function () {
       const result = queries.validateAndParseEvent({
         payload: {
           type: 'PAGEVIEW',
-          href: 'https://www.offen.dev/foo',
+          href: 'https://www.offen.dev/foo/',
           timestamp: new Date().toJSON(),
           sessionId: 'session'
         }
       })
       assert(result.payload.href instanceof window.URL)
-      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo')
+      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo/')
     })
 
     it('skips bad href values', function () {
@@ -509,7 +509,7 @@ describe('src/queries.js', function () {
       const result = queries.validateAndParseEvent({
         payload: {
           type: 'ZALGO',
-          href: 'https://www.offen.dev/foo',
+          href: 'https://www.offen.dev/foo/',
           timestamp: new Date().toJSON(),
           sessionId: 'session'
         }
@@ -521,12 +521,54 @@ describe('src/queries.js', function () {
       const result = queries.validateAndParseEvent({
         payload: {
           type: 'PAGEVIEW',
-          href: 'https://www.offen.dev/foo',
+          href: 'https://www.offen.dev/foo/',
           timestamp: 8192,
           sessionId: 'session'
         }
       })
       assert.strictEqual(result, null)
+    })
+
+    it('normalizes trailing slashes on URLs', function () {
+      let result = queries.validateAndParseEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          href: 'https://www.offen.dev/foo',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
+        }
+      })
+      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo/')
+
+      result = queries.validateAndParseEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          href: 'https://www.offen.dev/foo/',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
+        }
+      })
+      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo/')
+
+      result = queries.validateAndParseEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          href: 'https://www.offen.dev/foo/?bar-baz',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
+        }
+      })
+      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo/?bar-baz')
+
+      result = queries.validateAndParseEvent({
+        payload: {
+          type: 'PAGEVIEW',
+          href: 'https://www.offen.dev/foo?bar-baz',
+          timestamp: new Date().toJSON(),
+          sessionId: 'session'
+        }
+      })
+      assert.strictEqual(result.payload.href.toString(), 'https://www.offen.dev/foo/?bar-baz')
     })
   })
 })


### PR DESCRIPTION
Closes #420 

Currently `/about` and `/about/` would be considered different URLs, which
is very unlikely to be what operators expect. Instead we can always use
`/about/`.