### PR TITLE
Collect raw href value in case it differs from canonical value

### DIFF
--- a/script/src/events.js
+++ b/script/src/events.js
@@ -7,9 +7,10 @@ exports.pageview = pageview
 
 function pageview (initial) {
   var canonicalLink = document.head.querySelector('link[rel="canonical"]')
-  return {
+  var canonicalHref = canonicalLink && canonicalLink.getAttribute('href')
+  var event = {
     type: 'PAGEVIEW',
-    href: (canonicalLink && canonicalLink.getAttribute('href')) || window.location.href,
+    href: canonicalHref || window.location.href,
     title: document.title,
     referrer: document.referrer,
     pageload: (function () {
@@ -24,4 +25,8 @@ function pageview (initial) {
     // some point in the future. Find a more robust feature detect.
     isMobile: typeof window.onorientationchange !== 'undefined'
   }
+  if (canonicalHref && canonicalHref !== window.location.href) {
+    event.rawHref = window.location.href
+  }
+  return event
 }

--- a/vault/src/payload.schema
+++ b/vault/src/payload.schema
@@ -39,6 +39,11 @@
       "type": "string",
       "format": "uri",
       "maxLength": 2000
+    },
+    "rawHref": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 2000
     }
   }
 }

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -248,6 +248,9 @@ function validateAndParseEvent (event) {
   if (clone.payload.href) {
     clone.payload.href = normalizedURL(clone.payload.href)
   }
+  if (clone.payload.rawHref) {
+    clone.payload.href = normalizedURL(clone.payload.rawHref)
+  }
   if (clone.payload.referrer) {
     clone.payload.referrer = normalizedURL(clone.payload.referrer)
   }

--- a/vault/src/stats.js
+++ b/vault/src/stats.js
@@ -75,7 +75,9 @@ function _queryParam (key) {
       .map(function (event) {
         return {
           sessionId: event.payload.sessionId,
-          value: event.payload.href.searchParams.get(key)
+          value: event.payload.rawHref
+            ? event.payload.rawHref.searchParams.get(key)
+            : event.payload.href.searchParams.get(key)
         }
       })
       .uniq(false, JSON.stringify)

--- a/vault/src/stats.test.js
+++ b/vault/src/stats.test.js
@@ -243,7 +243,7 @@ describe('src/stats.js', function () {
         { payload: { sessionId: 'session-b', href: new window.URL('https://www.example.net/bar?something=12&utm_campaign=boop') } },
         { payload: { sessionId: 'session-b', href: new window.URL('https://www.example.net/baz') } },
         { payload: { sessionId: 'session-c', href: new window.URL('https://www.example.net/baz') } },
-        { payload: { sessionId: 'session-d', href: new window.URL('https://beep.boop/site?utm_campaign=beep') } },
+        { payload: { sessionId: 'session-d', href: new window.URL('https://beep.boop/site'), rawHref: new window.URL('https://beep.boop/site?utm_campaign=beep') } },
         { payload: { sessionId: 'session-e', href: new window.URL('https://www.mysite.com/a') } }
       ])
         .then(function (result) {


### PR DESCRIPTION
Using the canonical value for pages is cleaner, but will eat possible
campaigns and sources from the original url. In case they differ, save
both so the stats can analyze both the query string as well as the clean
value.