### PR TITLE
Use latest channel for actual releases, use development for development builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,17 +176,20 @@ jobs:
           command: |
             if [ -z "$CIRCLE_TAG" ]; then
               if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                echo 'export DOCKER_IMAGE_TAG="stable"' >> $BASH_ENV
+                echo 'export DOCKER_IMAGE_TAGS=(stable)' >> $BASH_ENV
               else
-                echo 'export DOCKER_IMAGE_TAG="latest"' >> $BASH_ENV
+                echo 'export DOCKER_IMAGE_TAGS=(development)' >> $BASH_ENV
               fi
             else
-              echo 'export DOCKER_IMAGE_TAG=$CIRCLE_TAG' >> $BASH_ENV
+              echo 'export DOCKER_IMAGE_TAGS=(${CIRCLE_TAG} latest) >> $BASH_ENV
             fi
       - run:
           name: Build Docker image
           command: |
             make build-docker
+            for tag in $DOCKER_IMAGE_TAGS; do
+              docker tag offen/offen:local offen/offen:$tag
+            done
       - run:
           name: Download and import signing key
           command: |
@@ -205,17 +208,24 @@ jobs:
             cp ~/offen/{LICENSE,README.md} .
 
             mkdir -p /tmp/artifacts
-            tar -czvf /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz $(ls -A)
+            for tag in $DOCKER_IMAGE_TAGS; do
+              tar -czvf /tmp/artifacts/offen-$tag.tar.gz $(ls -A)
+            done
       - run:
           name: Upload to S3
-          command: aws s3 cp /tmp/artifacts/offen-$DOCKER_IMAGE_TAG.tar.gz s3://offen/binaries/offen-$DOCKER_IMAGE_TAG.tar.gz
+          command: |
+            for tag in $DOCKER_IMAGE_TAGS; do
+              aws s3 cp /tmp/artifacts/offen-$tag.tar.gz s3://offen/binaries/offen-$tag.tar.gz
+            done
       - docker/install-docker-credential-helper
       - docker/configure-docker-credentials-store
       - run:
           name: Push offen/offen to Docker Hub
           command: |
             echo "$DOCKER_ACCESSTOKEN" | docker login --username $DOCKER_LOGIN --password-stdin
-            docker push offen/offen:$DOCKER_IMAGE_TAG
+            for tag in $DOCKER_IMAGE_TAGS; do
+              docker push offen/offen:$tag
+            done
       - store_artifacts:
           path: /tmp/artifacts
 
@@ -241,11 +251,11 @@ jobs:
                 aws s3api put-object --bucket $BUCKET --key /v/stable/
                 aws s3 sync --delete ./docs-site/. s3://$BUCKET/v/stable/
               else
-                echo "offen_version: latest" >> ./docs/_override.yml
-                echo "baseurl: v/latest" >> ./docs/_override.yml
+                echo "offen_version: development" >> ./docs/_override.yml
+                echo "baseurl: v/development" >> ./docs/_override.yml
                 make build-docs
-                aws s3api put-object --bucket $BUCKET --key /v/latest/
-                aws s3 sync --delete ./docs-site/. s3://$BUCKET/v/latest/
+                aws s3api put-object --bucket $BUCKET --key /v/development/
+                aws s3 sync --delete ./docs-site/. s3://$BUCKET/v/development/
               fi
             else
               # a tagged build gets built an deployed twice:

--- a/docs/docs/running-offen/downloads-distributions.md
+++ b/docs/docs/running-offen/downloads-distributions.md
@@ -41,10 +41,10 @@ In case you want to deploy Offen, this channel is what you are most likely going
 
 The `stable` channel gives you the most recent build from the `master` branch of our repository. These are usually stable and ready to use. Be aware that there is not necessarily an upgrade path in between `stable` versions.
 
-### Latest channel
+### Development channel
 {: .no_toc }
 
-The `latest` channel gives you the most recent build from the `development` branch of our repository. This is likely to contain things that are not production ready or bring other kinds of caveats. __You probably should not use this__ unless you are participating in the development of Offen.
+The `development` channel gives you the most recent build from the `development` branch of our repository. This is likely to contain things that are not production ready or bring other kinds of caveats. __You probably should not use this__ unless you are participating in the development of Offen.
 
 ---
 
@@ -56,11 +56,11 @@ Downloading `https://get.offen.dev` will give you a tarball containing the most 
 
 ```sh
 # most recent release
-curl -L https://get.offen.dev
-# most recent build from the latest channel
-curl -L https://get.offen.dev/latest
+curl -sSL https://get.offen.dev
+# most recent build from the development channel
+curl -sSL https://get.offen.dev/development
 # build for {{ site.offen_version }}
-curl -L https://get.offen.dev/{{ site.offen_version }}
+curl -sSL https://get.offen.dev/{{ site.offen_version }}
 ```
 
 ---
@@ -84,7 +84,7 @@ gpg --verify offen-linux-amd64.asc offen-linux-amd64
 
 ## Pulling the Docker image
 
-Docker images are available as `offen/offen` on [Docker Hub][docker-hub]. Tagged releases are available under the respective tag (e.g. `offen/offen:v0.1.0`). The `stable` and `latest` channel are available as image tags as well.
+Docker images are available as `offen/offen` on [Docker Hub][docker-hub]. Tagged releases are available under the respective tag (e.g. `offen/offen:v0.1.0`). The `stable` and `development` channel are available as image tags as well. As per Docker convention `latest` maps to the latest tagged release.
 
 ```sh
 # {{ site.offen_version }} release
@@ -98,7 +98,7 @@ docker pull offen/offen:latest
 __Heads Up__
 {: .label .label-red }
 
-While our version tags on Docker Hub are immutable and __will always return the same build__, it is important to note that both `stable` and `latest` will be updated on a rolling basis. If you deploy Offen using Docker, make sure to use a version tag or pin your image's revision.
+While our version tags on Docker Hub are immutable and __will always return the same build__, it is important to note that `development`, `stable` and `latest` will be updated on a rolling basis. If you deploy Offen using Docker, make sure to use a version tag or pin your image's revision.
 
 [docker-hub]: https://hub.docker.com/r/offen/offen
 


### PR DESCRIPTION
This makes using the docker image far less confusing as it now follows the
default docker hub convention of having a production ready latest tag.