### PR TITLE
Anonymize status codes in access logs

### DIFF
--- a/docs/docs/running-offen/monitoring-offen.md
+++ b/docs/docs/running-offen/monitoring-offen.md
@@ -2,7 +2,7 @@
 layout: default
 title: Monitoring an Offen instance
 nav_order: 8
-description: "How to set up monitoring for your Offen instance"
+description: "How to set up monitoring for your Offen instance and what is being logged"
 permalink: /running-offen/monitoring-offen/
 parent: Running Offen
 ---
@@ -14,6 +14,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # Monitoring an Offen instance
 {: .no_toc }
+
+## Instance health
 
 If you want to make sure your Offen instance is always up and running by monitoring it - either yourself, or using a service such as Pingdom or similar - you can use the `/healthz/` endpoint that should always respond with a `200` status code:
 
@@ -33,3 +35,18 @@ and a payload like this:
 $ curl -X GET https://offen.yoursite.org/healthz
 {"ok":true}
 ```
+
+## Log output
+
+Offen logs all HTTP requests to `stdout` using the [Common Log Format][clf]. Fields that contain privacy sensitive data (IPs, User-Agent Strings, Referrers) are left blank intentionally.
+
+__Heads Up__
+{: .label .label-red }
+
+Also, all successful status codes (i.e. 200-399) will appear as `200` as caching behavior could also leak information about users. This also means the body size is stripped.
+
+[clf]: https://en.wikipedia.org/wiki/Common_Log_Format
+
+---
+
+All non-access log lines will be printed to `stderr`.

--- a/server/go.sum
+++ b/server/go.sum
@@ -204,6 +204,7 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -249,7 +249,7 @@ func New(opts ...Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		metrics := httpsnoop.CaptureMetrics(withGzip, w, r)
 		fmt.Printf(
-			"%s %s %s [%s] \"%s %s %s\" %d %d\n",
+			"%s %s %s [%s] \"%s %s %s\" %d %s\n",
 			"-",
 			"-",
 			"-",
@@ -257,8 +257,18 @@ func New(opts ...Config) http.Handler {
 			r.Method,
 			r.RequestURI,
 			r.Proto,
-			metrics.Code,
-			metrics.Written,
+			anonymizeStatusCode(metrics.Code),
+			"-",
 		)
 	})
+}
+
+// anonymizeStatusCode turns all non-error status codes into http.StatusOK
+// in order not to leak information about returning visitors that have opted
+// out while still providing information about failing requests
+func anonymizeStatusCode(code int) int {
+	if http.StatusOK <= code && code < http.StatusBadRequest {
+		return http.StatusOK
+	}
+	return code
 }


### PR DESCRIPTION
3xx responses could be used to infer information about users that have
opted out which is why it's preferrable to print success or failure only,
which makes them indistinguishable from other users.