### PR TITLE
Fix definition of env vars in circle file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,16 +105,16 @@ jobs:
             - bin/*
 
   integration_sqlite:
+    environment: &integration_env
+      CYPRESS_BASE_URL: http://localhost:3000
+      CYPRESS_OPERATOR_USERNAME: circle@offen.dev
+      CYPRESS_OPERATOR_PASSWORD: secret5ecrets0secret
+      CYPRESS_ACCOUNT_ID: 9b63c4d8-65c0-438c-9d30-cc4b01173393
+      CYPRESS_RUN_LIGHTHOUSE_AUDIT: 1
+      OFFEN_SERVER_PORT: 3000
+      OFFEN_DATABASE_CONNECTIONSTRING: /tmp/offen.sqlite3
     docker:
       - image: circleci/node:14-browsers
-        environment: &integration_env
-          CYPRESS_BASE_URL: http://localhost:3000
-          CYPRESS_OPERATOR_USERNAME: circle@offen.dev
-          CYPRESS_OPERATOR_PASSWORD: secret5ecrets0secret
-          CYPRESS_ACCOUNT_ID: 9b63c4d8-65c0-438c-9d30-cc4b01173393
-          CYPRESS_RUN_LIGHTHOUSE_AUDIT: 1
-          OFFEN_SERVER_PORT: 3000
-          OFFEN_DATABASE_CONNECTIONSTRING: /tmp/offen.sqlite3
     working_directory: ~/offen
     steps:
       - run:
@@ -124,12 +124,12 @@ jobs:
       - run_integration_tests
 
   integration_postgres:
+    environment:
+      <<: *integration_env
+      OFFEN_DATABASE_DIALECT: postgres
+      OFFEN_DATABASE_CONNECTIONSTRING: postgres://circle:test@localhost:5432/circle_test?sslmode=disable
     docker:
       - image: circleci/node:14-browsers
-        environment:
-          <<: *integration_env
-          OFFEN_DATABASE_DIALECT: postgres
-          OFFEN_DATABASE_CONNECTIONSTRING: postgres://circle:test@localhost:5432/circle_test?sslmode=disable
       - image: circleci/postgres:11.2-alpine
         environment:
           POSTGRES_USER: circle
@@ -142,12 +142,12 @@ jobs:
       - run_integration_tests
 
   integration_mysql:
+    environment:
+      <<: *integration_env
+      OFFEN_DATABASE_DIALECT: mysql
+      OFFEN_DATABASE_CONNECTIONSTRING: root:test@tcp(localhost:3306)/circle_test?parseTime=true
     docker:
       - image: circleci/node:14-browsers
-        environment:
-          <<: *integration_env
-          OFFEN_DATABASE_DIALECT: mysql
-          OFFEN_DATABASE_CONNECTIONSTRING: root:test@tcp(localhost:3306)/circle_test?parseTime=true
       - image: circleci/mysql:5.7
         environment:
           MYSQL_DATABASE: circle_test
@@ -160,11 +160,11 @@ jobs:
       - run_integration_tests
 
   release:
+    environment:
+      DOCKER_LOGIN: offen
     docker:
       - image: circleci/python:3.7
     working_directory: ~/offen
-    environment:
-      DOCKER_LOGIN: offen
     steps:
       - checkout
       - setup_remote_docker
@@ -230,11 +230,11 @@ jobs:
           path: /tmp/artifacts
 
   release_docs:
+    environment:
+      BUCKET: offen-docs
+      DISTRIBUTION: E2Q11JP684XRCO
     docker:
       - image: cimg/python:3.7
-        environment:
-          BUCKET: offen-docs
-          DISTRIBUTION: E2Q11JP684XRCO
     working_directory: ~/offen
     steps:
       - checkout
@@ -283,31 +283,18 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - vault:
-          <<: *all_tags_filter
-      - script:
-          <<: *all_tags_filter
-      - auditorium:
-          <<: *all_tags_filter
-      - packages:
-          <<: *all_tags_filter
-      - reuse:
-          <<: *all_tags_filter
-      - build:
-          <<: *all_tags_filter
-      - integration_sqlite:
+      - vault: *all_tags_filter
+      - script: *all_tags_filter
+      - auditorium: *all_tags_filter
+      - packages: *all_tags_filter
+      - reuse: *all_tags_filter
+      - build: *all_tags_filter
+      - integration_sqlite: &integration_filter
           <<: *all_tags_filter
           requires:
             - build
-      - integration_postgres:
-          <<: *all_tags_filter
-          requires:
-            - build
-      - integration_mysql:
-          <<: *all_tags_filter
-          requires:
-            - build
-
+      - integration_postgres: *integration_filter
+      - integration_mysql: *integration_filter
       - release: &default_release_job
           context: AWS
           requires:
@@ -328,8 +315,7 @@ workflows:
               only:
                 - development
                 - master
-      - release_docs:
-          <<: *default_release_job
+      - release_docs: *default_release_job
 
 commands:
   wait_for:


### PR DESCRIPTION
The current way has some weird pitfalls where the environment would only be available to _some_ things in the primary container. Like this, they are available to the entire job.