### PR TITLE
Fixup v0.1.8 release

### DIFF
--- a/server/persistence/relational/migrations.go
+++ b/server/persistence/relational/migrations.go
@@ -283,7 +283,7 @@ func (r *relationalDAL) ApplyMigrations() error {
 					EventID   string  `gorm:"primary_key"`
 					AccountID string  `gorm:"size:36"`
 					SecretID  *string `gorm:"size:64"`
-					Sequence  string  `gorm:"size:24"`
+					Sequence  string  `gorm:"size:26"`
 				}
 				type Secret struct {
 					SecretID        string `gorm:"primary_key;size:64;unique"`

--- a/server/persistence/relational/models.go
+++ b/server/persistence/relational/models.go
@@ -26,7 +26,7 @@ type Tombstone struct {
 	EventID   string  `gorm:"primary_key"`
 	AccountID string  `gorm:"size:36"`
 	SecretID  *string `gorm:"size:64"`
-	Sequence  string  `gorm:"size:24"`
+	Sequence  string  `gorm:"size:26"`
 }
 
 // Secret associates a hashed user id - which ties a user and account together


### PR DESCRIPTION
QAing the pending v0.1.8 release it appeared the Postgres migrations were broken by this simple typo.

This state migrates well on all database targets.