### PR TITLE
Allow passing of now parameter via query string

### DIFF
--- a/auditorium/src/action-creators/model.js
+++ b/auditorium/src/action-creators/model.js
@@ -12,7 +12,6 @@ exports.query = (data, authenticatedUser, softFailureMessage, inBackground) => (
       payload: null
     })
   }
-
   const payload = data
     ? { query: data, authenticatedUser: authenticatedUser }
     : { authenticatedUser: authenticatedUser }

--- a/auditorium/src/views/auditorium-operator.js
+++ b/auditorium/src/views/auditorium-operator.js
@@ -37,7 +37,7 @@ const AuditoriumView = (props) => {
     matches, authenticatedUser, model, stale,
     handleQuery, handleShare, handleValidationError, handleRetire, handleCopy
   } = props
-  const { accountId, range, resolution } = matches
+  const { accountId, range, resolution, now } = matches
   const { adminLevel } = authenticatedUser
   const [focus, setFocus] = useState(true)
 
@@ -49,10 +49,10 @@ const AuditoriumView = (props) => {
     if (!focus) {
       return null
     }
-    handleQuery({ accountId, range, resolution }, authenticatedUser)
+    handleQuery({ accountId, range, resolution, now }, authenticatedUser)
 
     const tick = window.setInterval(() => {
-      handleQuery({ accountId, range, resolution }, authenticatedUser, softFailure, true)
+      handleQuery({ accountId, range, resolution, now }, authenticatedUser, softFailure, true)
     }, 15000)
     return function cancelAutoRefresh () {
       window.clearInterval(tick)

--- a/vault/src/queries.js
+++ b/vault/src/queries.js
@@ -84,7 +84,7 @@ function Queries (storage) {
       return Promise.reject(new Error('Unknown resolution value: ' + resolution))
     }
 
-    var now = (query && query.now) || new Date()
+    var now = (query && query.now && new Date(query.now)) || new Date()
     var lowerBound = toLowerBound(startOf[resolution](subtract[resolution](now, range - 1)))
     var upperBound = toUpperBound(endOf[resolution](now))
 


### PR DESCRIPTION
This prepares an overhaul of the time frame selector. Right now the feature is query string only, so it's probably best to not advertise it more than needed.

For anyone using this: take note that the UI you are seeing is using your local timezone when the query parameter expects a UTC time.