### PR TITLE
Use proper parsing approach for extracting translation strings from template files

### DIFF
--- a/server/cmd/extract-strings/main.go
+++ b/server/cmd/extract-strings/main.go
@@ -1,0 +1,77 @@
+// Copyright 2020 - Offen Authors <hioffen@posteo.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"text/scanner"
+)
+
+const (
+	translationFunc = "__"
+	opening         = '{'
+	closing         = '}'
+)
+
+type token struct {
+	token    string
+	line     int
+	filename string
+}
+
+func main() {
+	for _, file := range os.Args[1:] {
+		tokens, err := extractFromFile(file)
+		if err != nil {
+			panic(err)
+		}
+		for _, token := range tokens {
+			fmt.Printf("#~ line %d \"%s\"\n", token.line, token.filename)
+			fmt.Printf("gettext(%s)\n", token.token)
+			fmt.Printf("\n")
+		}
+	}
+}
+
+func extractFromFile(f string) ([]*token, error) {
+	var s scanner.Scanner
+	tpl, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("extract: error opening file %s: %w", f, err)
+	}
+	s.Init(bytes.NewBuffer(tpl))
+	s.Filename = f
+
+	var braces [][]token
+	for tok := s.Scan(); tok != scanner.EOF; tok = s.Scan() {
+		if tok == opening && s.Peek() == opening {
+			s.Scan()
+			// gobble up every token until the matching closing braces
+			braces = append(braces, []token{})
+			for enclosedToken := s.Scan(); enclosedToken != scanner.EOF; enclosedToken = s.Scan() {
+				if enclosedToken == closing && s.Peek() == closing {
+					break
+				}
+				braces[len(braces)-1] = append(braces[len(braces)-1], token{
+					token:    s.TokenText(),
+					filename: s.Position.Filename,
+					line:     s.Position.Line,
+				})
+			}
+		}
+	}
+
+	var translationStrings []*token
+	for _, brace := range braces {
+		for idx, token := range brace {
+			if token.token == translationFunc && len(brace) > idx+1 {
+				translationStrings = append(translationStrings, &brace[idx+1])
+			}
+		}
+	}
+	return translationStrings, nil
+}

--- a/server/extract-strings.sh
+++ b/server/extract-strings.sh
@@ -13,11 +13,9 @@ fi
 
 for locale in $locales
 do
-	for f in $(ls public/*.go.html)
-	do
-		touch locales/$locale.po
-		# Heads up: this does **not** match fmt args right now
-		sed 's/{{\([^}]*\)__ \("[^{^}]*"\) }}/{{\1gettext(\2) }}/g' $f | xgettext --from-code=UTF-8 --join-existing --language=c --output=locales/$locale.po -
-	done
+	touch locales/$locale.po
+	go run cmd/extract-strings/main.go public/*.go.html | xgettext -c~ --no-location --from-code=UTF-8 --language=python --output=locales/$locale-update.po -
+	msgmerge "locales/$locale.po" "locales/$locale-update.po" -o "locales/$locale.po"
+	rm "locales/$locale-update.po"
 	echo "Extracted strings for locale $locale"
 done

--- a/server/public/index.go.html
+++ b/server/public/index.go.html
@@ -14,8 +14,8 @@
   </head>
   <body class="bg-washed-yellow">
     <div id="app-host" role="main"></div>
-    <script src='{{ rev "/auditorium/vendor.js" }}'></script>
-    <script src='{{ rev "/auditorium/index.js" }}'></script>
+    <script src="{{ rev "/auditorium/vendor.js" }}"></script>
+    <script src="{{ rev "/auditorium/index.js" }}"></script>
     <noscript>
       <div class="f5 roboto dark-gray">
         <div class="w-100 h3 bg-black-05">
@@ -43,19 +43,19 @@
               </p>
             </div>
           </div>
-          <div class='mw8 center flex flex-wrap flex-column flex-row-ns justify-between f6 lh-title ph3 pb5 pb7-ns mid-gray'>
-            <div class='w-100'>
-              <p class='ma0 mb0'>
+          <div class="mw8 center flex flex-wrap flex-column flex-row-ns justify-between f6 lh-title ph3 pb5 pb7-ns mid-gray">
+            <div class="w-100">
+              <p class="ma0 mb0">
                 <a href="https://www.offen.dev/" class="b link dim mid-gray" target="_blank" rel="noreferer noopener">{{ __ "Offen" }}</a>
               </p>
             </div>
-            <div class='w-100 w-50-ns pr3-ns'>
-              <p class='ma0 mb3'>
+            <div class="w-100 w-50-ns pr3-ns">
+              <p class="ma0 mb3">
                 {{ __ "Fair web analytics" }}
               </p>
             </div>
-            <div class='w-100 w-50-ns'>
-              <p class='ma0 tl tr-ns'>
+            <div class="w-100 w-50-ns">
+              <p class="ma0 tl tr-ns">
                 {{ __ "Found an issue, need help or want to add something?" }}<br><a href="https://twitter.com/hioffen" class="b link dim mid-gray" target="_blank" rel="noreferer noopener">{{ __ "Tweet, " }}</a> <a href="mailto:hioffen@posteo.de" class="b link dim mid-gray" target="_blank">{{ __ "email " }}</a> {{ __ "or file an " }}<a href="https://github.com/offen/offen" class="b link dim mid-gray" target="_blank" rel="noreferer noopener">{{ __ "issue." }}</a>
               </p>
             </div>


### PR DESCRIPTION
Using `sed` to transform the templates before passing them to `xgettext` is very brittle and also disallows the use of string formatting in translations.

Instead, we can properly parse and transform the templates into something that is guaranteed to make sense for `xgettext`