### PR TITLE
Fix handling of special characters in account names

### DIFF
--- a/auditorium/package-lock.json
+++ b/auditorium/package-lock.json
@@ -3430,8 +3430,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "date-fns": "^1.30.1",
+    "escape-html": "^1.0.3",
     "offen": "file:./../packages",
     "plotly.js-basic-dist": "^1.51.2",
     "preact": "^10.3.1",

--- a/auditorium/src/views/components/console/create-account.js
+++ b/auditorium/src/views/components/console/create-account.js
@@ -6,6 +6,7 @@
 /** @jsx h */
 const { h, Fragment } = require('preact')
 const { useState } = require('preact/hooks')
+const escapeHtml = require('escape-html')
 
 const LabeledInput = require('./../_shared/labeled-input')
 const SubmitButton = require('./../_shared/submit-button')
@@ -21,7 +22,7 @@ const CreateAccount = (props) => {
         emailAddress: formData['email-address'],
         password: formData.password
       },
-      __('Log in again to use the newly created account <em class="%s">"%s"</em>.', 'i tracked', formData['account-name']),
+      __('Log in again to use the newly created account <em class="%s">"%s"</em>.', 'i tracked', escapeHtml(formData['account-name'])),
       __('There was an error creating the account, please try again.')
     )
       .then(() => {

--- a/server/cmd/offen/cmdsetup.go
+++ b/server/cmd/offen/cmdsetup.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"os"
 	"time"
@@ -86,10 +87,10 @@ func cmdSetup(subcommand string, flags []string) {
 			a.logger.WithError(err).Fatalf("Error parsing content of given source file %s", *source)
 		}
 		for idx, account := range conf.Accounts {
-			conf.Accounts[idx].Name = sanitizer.Sanitize(account.Name)
+			conf.Accounts[idx].Name = html.UnescapeString(sanitizer.Sanitize(account.Name))
 		}
 	} else {
-		sanitizedAccountName := sanitizer.Sanitize(*accountName)
+		sanitizedAccountName := html.UnescapeString(sanitizer.Sanitize(*accountName))
 		if *email == "" || pw == "" || sanitizedAccountName == "" {
 			a.logger.Fatal("Missing required parameters to create initial account, use the -help flag for reference on parameters")
 		}

--- a/server/router/accounts.go
+++ b/server/router/accounts.go
@@ -6,6 +6,7 @@ package router
 import (
 	"errors"
 	"fmt"
+	"html"
 	"net/http"
 	"time"
 
@@ -164,7 +165,7 @@ func (rt *router) postAccount(c *gin.Context) {
 		return
 	}
 
-	if err := rt.db.CreateAccount(rt.sanitizer.Sanitize(req.AccountName), req.EmailAddress, req.Password); err != nil {
+	if err := rt.db.CreateAccount(html.UnescapeString(rt.sanitizer.Sanitize(req.AccountName)), req.EmailAddress, req.Password); err != nil {
 		newJSONError(
 			fmt.Errorf("router: error creating account %s: %w", req.AccountName, err),
 			http.StatusInternalServerError,

--- a/server/router/setup.go
+++ b/server/router/setup.go
@@ -5,6 +5,7 @@ package router
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"time"
 
@@ -56,7 +57,7 @@ func (rt *router) postSetup(c *gin.Context) {
 	if err := rt.db.Bootstrap(persistence.BootstrapConfig{
 		Accounts: []persistence.BootstrapAccount{
 			{
-				Name:      rt.sanitizer.Sanitize(req.AccountName),
+				Name:      html.UnescapeString(rt.sanitizer.Sanitize(req.AccountName)),
 				AccountID: accountID.String(),
 			},
 		},


### PR DESCRIPTION
Right now, accounts names are sanitized on the server to prevent XSS and similar. This creates some scenarios in which the account names contain special characters like `<` or similar without being valid Markup. This PR fixes a few bugs in handling these cases in the UI.