### PR TITLE
Enable Docker BuildKit when building binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
     working_directory: ~/offen
     environment:
       DOCKER_LOGIN: offen
+      DOCKER_BUILDKIT: '1'
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
This shaves ~2 minutes off the binary build.