### PR TITLE
Extract strings via github action

### DIFF
--- a/.github/workflows/extract_strings.yml
+++ b/.github/workflows/extract_strings.yml
@@ -1,0 +1,33 @@
+# Copyright 2020 - Offen Authors <hioffen@posteo.de>
+# SPDX-License-Identifier: Apache-2.0
+
+name: Extract translation strings
+
+on:
+  push:
+    branches: [development]
+
+jobs:
+  extract_strings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract strings
+        run: |
+          make extract-strings
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: development
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          commit-message: Update message files
+          committer: Offen Bot <hioffen@posteo.de>
+          author: ${{ github.actor }} <hioffen@posteo.de>
+          branch: extract-strings-${{ github.sha }}
+          title: Update message files
+          body: |
+            Pushing ${{ github.sha }} to `development` updated translation
+            strings. You can merge this PR to update known .po files to the
+            latest state.
+          draft: false

--- a/merge_messages.sh
+++ b/merge_messages.sh
@@ -5,12 +5,12 @@
 set -eo pipefail
 
 for pofile in *.po; do
-  msguniq $pofile --color=no --output $pofile
+  msguniq $pofile --no-wrap --color=no --output $pofile
 done
 
-msgcat *.po --output messages.po
+msgcat *.po --no-wrap --output messages.po
 
 for locale in $(cat ./locales/LINGUAS); do
   touch "./locales/${locale}.po"
-  msgmerge "./locales/${locale}.po" messages.po --output "./locales/${locale}.po"
+  msgmerge "./locales/${locale}.po" messages.po --no-wrap --output "./locales/${locale}.po"
 done


### PR DESCRIPTION
Pushing to development (i.e. merging to development) should automatically extract new strings from source code so that translators can act upon the changes.