### PR TITLE
Create new aggregation secret when decryption failed

### DIFF
--- a/vault/src/aggregating-storage.js
+++ b/vault/src/aggregating-storage.js
@@ -215,9 +215,9 @@ function ensureAggregationSecretWith (storage, cache) {
               // A secret might either not exist at all or its decryption failed
               // which means a new one will need to be created.
               var cryptoKey
-              return crypto.createSymmetricKey()
-                .then(function (_cryptoKey) {
-                  cryptoKey = _cryptoKey
+              return Promise.all([crypto.createSymmetricKey(), storage.purgeAggregates(accountId)])
+                .then(function (results) {
+                  cryptoKey = results[0]
                   return crypto.encryptAsymmetricWith(publicJwk)(cryptoKey)
                 })
                 .then(function (encryptedSecret) {

--- a/vault/src/aggregating-storage.test.js
+++ b/vault/src/aggregating-storage.test.js
@@ -183,7 +183,8 @@ describe('src/aggregating-storage.js', function () {
         getRawEvents: sinon.stub().resolves(encrpytedEvents),
         getAggregates: sinon.stub().resolves([]),
         getEncryptedSecrets: sinon.stub().resolves(encryptedSecrets),
-        putAggregate: sinon.stub().resolves(null)
+        putAggregate: sinon.stub().resolves(null),
+        purgeAggregates: sinon.stub().resolves(null)
       }
       var storage = new aggregatingStorage.AggregatingStorage(mockStorage)
       return storage.getEvents({ accountId: 'account-id', publicJwk: publicJwk, privateJwk: privateJwk })
@@ -238,7 +239,8 @@ describe('src/aggregating-storage.js', function () {
     it('creates, persists and returns secrets per accountId', function () {
       var mockStorage = {
         getAggregationSecret: sinon.stub().resolves(null),
-        putAggregationSecret: sinon.stub().resolves(null)
+        putAggregationSecret: sinon.stub().resolves(null),
+        purgeAggregates: sinon.stub().resolves(null)
       }
       var ensureAggregationSecret = aggregatingStorage.ensureAggregationSecretWith(mockStorage)
       return ensureAggregationSecret('account-id', publicJwk, privateJwk)


### PR DESCRIPTION
This gets rid of the "Operation Error" post-bootstrap in local development, but I have to think about the consequences in the real world further before merging it.