### PR TITLE
Do not send unused nonce with content security policy

### DIFF
--- a/server/keys/keys.go
+++ b/server/keys/keys.go
@@ -10,5 +10,4 @@ const (
 	DefaultSaltLength        = 8
 	DefaultEncryptionKeySize = 32
 	DefaultPasswordHashSize  = 32
-	DefaultNonceSize         = 16
 )

--- a/server/router/index.go
+++ b/server/router/index.go
@@ -21,6 +21,5 @@ func (rt *router) getIndex(c *gin.Context) {
 	c.HTML(http.StatusOK, "index", map[string]interface{}{
 		"rootAccount": rt.config.App.RootAccount,
 		"lang":        rt.config.App.Locale,
-		"cspNonce":    c.GetString("csp-nonce"),
 	})
 }

--- a/server/router/middleware.go
+++ b/server/router/middleware.go
@@ -100,22 +100,6 @@ func headerMiddleware(valueProvider map[string]func() string) gin.HandlerFunc {
 	}
 }
 
-func cspMiddleware(getNonce func() (string, error)) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		nonce, err := getNonce()
-		if err != nil {
-			newJSONError(
-				fmt.Errorf("router: error generating csp nonce: %w", err),
-				http.StatusInternalServerError,
-			).Pipe(c)
-			return
-		}
-		c.Set("csp-nonce", nonce)
-		c.Header("Content-Security-Policy", fmt.Sprintf(indexCSP, nonce))
-		c.Next()
-	}
-}
-
 type bufferingGinWriter struct {
 	gin.ResponseWriter
 	buf bytes.Buffer

--- a/server/router/middleware_test.go
+++ b/server/router/middleware_test.go
@@ -273,28 +273,3 @@ func TestEtagMiddleware(t *testing.T) {
 		t.Errorf("Unexpected status code %v", w2.Code)
 	}
 }
-
-func TestCSPMiddleware(t *testing.T) {
-	m := gin.New()
-	m.GET("/", cspMiddleware(func() (string, error) {
-		return "a-nonce", nil
-	}), func(c *gin.Context) {
-		c.String(http.StatusOK, "nonce is %v", c.GetString("csp-nonce"))
-	})
-
-	t.Run("ok", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		m.ServeHTTP(w, r)
-		if w.Code != http.StatusOK {
-			t.Errorf("Unexpected status code %v", w.Code)
-		}
-		if w.Body.String() != "nonce is a-nonce" {
-			t.Errorf("Unexpected response body %v", w.Body.String())
-		}
-		if !strings.Contains(w.Header().Get("Content-Security-Policy"), "nonce-a-nonce") {
-			t.Errorf("Unexpected Content-Security-Policy header %v", w.Header().Get("Content-Security-Policy"))
-		}
-	})
-
-}

--- a/server/router/static.go
+++ b/server/router/static.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	defaultCSP             = "default-src 'self'; style-src 'self' 'unsafe-inline'"
-	indexCSP               = "default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+	defaultCSP             = "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
 	defaultSTS             = "max-age=15768000"
 	revisionedJSRe         = regexp.MustCompile("-[0-9a-z]{10}\\.js$")
 	webfontRe              = regexp.MustCompile("\\.(woff|woff2|ttf)$")


### PR DESCRIPTION
Sending a CSP nonce was introduced in #527 but made unused again by #547