### PR TITLE
Use previous page as referrer in fake sessions for demo

### DIFF
--- a/server/cmd/offen/cmddemo.go
+++ b/server/cmd/offen/cmddemo.go
@@ -326,14 +326,21 @@ func newFakeSession(root string, length int) []*fakeEvent {
 	timestamp := time.Now().Add(-time.Duration(randomInRange(0, int(config.EventRetention))))
 	isMobileSession := randomBool(0.33)
 
+	var href string
 	for i := 0; i < length; i++ {
 		var referrer string
 		if i == 0 && randomBool(0.25) {
 			referrer = randomReferrer()
+		} else if i != 0 {
+			// a subsequent view will use the previously visited URL
+			// as the referrer
+			referrer = href
 		}
+
+		href := fmt.Sprintf("%s%s", root, randomPage())
 		result = append(result, &fakeEvent{
 			Type:      "PAGEVIEW",
-			Href:      fmt.Sprintf("%s%s", root, randomPage()),
+			Href:      href,
 			Title:     "Page Title",
 			Referrer:  referrer,
 			Pageload:  randomInRange(400, 1200),


### PR DESCRIPTION
I noticed over in https://github.com/offen/underscore-benchmark/pull/8 that the fake referrer data used for demos is not 100% in line with what is being collected in the real world. This PR adds the additional referrers that are created when navigating in a non-shallow session on a site.