### PR TITLE
Revert "Use go 1.16"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,14 @@ jobs:
       - checkout:
           path: ~/offen
       - restore_cache:
-          key: offen-server-v2-{{ checksum "go.mod" }}
+          key: offen-server-{{ checksum "go.mod" }}
       - run:
           name: Download modules
           command: go mod download
       - save_cache:
           paths:
             - /go/pkg/mod
-          key: offen-server-v2-{{ checksum "go.mod" }}
+          key: offen-server-{{ checksum "go.mod" }}
       - run:
           name: Run tests
           command: make test
@@ -410,7 +410,7 @@ x-docker-pull-creds: &docker-pull-creds
 executors:
   golang:
     docker:
-      - image: cimg/go:1.16
+      - image: circleci/golang:1.15
         auth: *docker-pull-creds
   node:
     docker:

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,7 +1,7 @@
 # Copyright 2020 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.16
+FROM golang:1.15
 
 RUN apt-get update \
   && apt-get install -y \

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -81,7 +81,7 @@ RUN npm run licenses
 
 FROM ruby:2.7-alpine AS server_licenses
 
-COPY --from=golang:1.16-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.15-alpine /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN gem install license_finder
@@ -112,7 +112,7 @@ RUN python ./create_notice.py \
   --client auditorium.csv \
   --server server.csv >> NOTICE
 
-FROM golang:1.16-alpine as statik
+FROM golang:1.15-alpine as statik
 
 WORKDIR /code/server
 COPY ./server /code/server
@@ -127,7 +127,7 @@ COPY ./locales/* /code/server/public/
 RUN go get github.com/rakyll/statik
 RUN statik -src public
 
-FROM techknowlogick/xgo:go-1.16.x as compiler
+FROM techknowlogick/xgo:go-1.15.x as compiler
 
 ARG rev
 ENV GIT_REVISION=$rev

--- a/build/Dockerfile.messages
+++ b/build/Dockerfile.messages
@@ -53,7 +53,7 @@ WORKDIR /code/vault
 RUN cp -a /code/deps/node_modules /code/vault/
 RUN npm run --silent extract-strings > vault.po
 
-FROM golang:1.16
+FROM golang:1.15
 
 RUN apt-get update \
   && apt-get install -y gettext \

--- a/docs/docs/developing-offen/programming-languages.md
+++ b/docs/docs/developing-offen/programming-languages.md
@@ -20,7 +20,7 @@ The server side application is written in [Go][golang] while the client is writt
 
 ## Go
 
-Go is currently at version 1.16 and all code in Offen can expect all features present in that version. Formatting happens using [`go fmt`][fmt] and [`go vet`][vet] is enforced in CI. In case you would like to contribute to Offen, but haven't used Go before don't be scared. It is easy to pick up and has great learning resources, head over to the [Go wiki][wiki] if you're interested.
+Go is currently at version 1.15 and all code in Offen can expect all features present in that version. Formatting happens using [`go fmt`][fmt] and [`go vet`][vet] is enforced in CI. In case you would like to contribute to Offen, but haven't used Go before don't be scared. It is easy to pick up and has great learning resources, head over to the [Go wiki][wiki] if you're interested.
 
 [fmt]: https://blog.golang.org/go-fmt-your-code
 [vet]: https://golang.org/cmd/vet/

--- a/server/README.md
+++ b/server/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 
 `server` exposes a HTTP API that can be used to record and query event data as well as static assets.
 
-`server` is a Go application built on top of the [gin-framework][] that uses Go modules for dependency management. The expected Go version is 1.16.
+`server` is a Go application built on top of the [gin-framework][] that uses Go modules for dependency management. The expected Go version is 1.15.
 
 [gin-framework]: https://github.com/gin-gonic/gin
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/offen/offen/server
 
-go 1.16
+go 1.15
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
Reverts offen/offen#559

This seems to break on non-Linux builds: https://app.circleci.com/pipelines/github/offen/offen/3175/workflows/3b51f00d-b045-436e-ab7d-0a4d67532b89/jobs/23392/parallel-runs/0/steps/0-104