### PR TITLE
ci: pin mysql image version to work around broken update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ executors:
     docker:
       - image: circleci/node:14-browsers
         auth: *docker-pull-creds
-      - image: circleci/mysql:5.7
+      - image: circleci/mysql:5.7.32
         auth: *docker-pull-creds
         environment:
           MYSQL_DATABASE: circle_test


### PR DESCRIPTION
It seems a recent update broke the MySQL image provided by CircleCI and it needs to be pinned to the previous version for now.

https://discuss.circleci.com/t/circle-ci-image-5-7-ram-version-build-failed/39459
https://github.com/docker-library/mysql/issues/750