### PR TITLE
use npm library for more robust handling of LINGUAS

### DIFF
--- a/auditorium/gulpfile.js
+++ b/auditorium/gulpfile.js
@@ -12,16 +12,12 @@ var rev = require('gulp-rev')
 var buffer = require('vinyl-buffer')
 var gap = require('gulp-append-prepend')
 var Readable = require('stream').Readable
+var linguasFile = require('linguas-file')
 
 var pkg = require('./package.json')
 
 var defaultLocale = 'en'
-var linguas = fs.readFileSync('./locales/LINGUAS', 'utf-8')
-  .split(' ')
-  .filter(Boolean)
-  .map(function (s) {
-    return s.trim()
-  })
+var linguas = linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
 
 gulp.task('clean:pre', function () {
   return gulp

--- a/auditorium/package-lock.json
+++ b/auditorium/package-lock.json
@@ -6107,6 +6107,12 @@
         "resolve": "^1.1.7"
       }
     },
+    "linguas-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/linguas-file/-/linguas-file-1.0.0.tgz",
+      "integrity": "sha512-gGUIyQsHTrn7jaeBJteO7CTGZTt7BHC1ad2d/tvNlyEq3Bj1BXgOsINcDzp9GDAMd5YW7UKlWAKeQf5kDbHQKA==",
+      "dev": true
+    },
     "listen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listen/-/listen-1.0.1.tgz",

--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -53,6 +53,7 @@
     "gulp-append-prepend": "^1.0.8",
     "gulp-clean": "^0.4.0",
     "gulp-rev": "^9.0.0",
+    "linguas-file": "^1.0.0",
     "mochify": "^6.3.0",
     "npm-license-crawler": "^0.2.1",
     "redux-mock-store": "^1.5.4",

--- a/script/gulpfile.js
+++ b/script/gulpfile.js
@@ -10,16 +10,12 @@ var gap = require('gulp-append-prepend')
 var buffer = require('vinyl-buffer')
 var source = require('vinyl-source-stream')
 var browserify = require('browserify')
+var linguasFile = require('linguas-file')
 
 var pkg = require('./package.json')
 
 var defaultLocale = 'en'
-var linguas = fs.readFileSync('./locales/LINGUAS', 'utf-8')
-  .split(' ')
-  .filter(Boolean)
-  .map(function (s) {
-    return s.trim()
-  })
+var linguas = linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
 
 gulp.task('clean:pre', function () {
   return gulp

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -5915,6 +5915,12 @@
         "resolve": "^1.1.7"
       }
     },
+    "linguas-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/linguas-file/-/linguas-file-1.0.0.tgz",
+      "integrity": "sha512-gGUIyQsHTrn7jaeBJteO7CTGZTt7BHC1ad2d/tvNlyEq3Bj1BXgOsINcDzp9GDAMd5YW7UKlWAKeQf5kDbHQKA==",
+      "dev": true
+    },
     "listen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listen/-/listen-1.0.1.tgz",

--- a/script/package.json
+++ b/script/package.json
@@ -29,6 +29,7 @@
     "gulp": "^4.0.2",
     "gulp-append-prepend": "^1.0.8",
     "gulp-clean": "^0.4.0",
+    "linguas-file": "^1.0.0",
     "local-web-server": "^4.0.0",
     "mochify": "^6.3.0",
     "npm-license-crawler": "^0.2.1",

--- a/vault/gulpfile.js
+++ b/vault/gulpfile.js
@@ -17,14 +17,10 @@ var gap = require('gulp-append-prepend')
 var to = require('flush-write-stream')
 var tinyify = require('tinyify')
 var minifyStream = require('minify-stream')
+var linguasFile = require('linguas-file')
 
 var defaultLocale = 'en'
-var linguas = fs.readFileSync('./locales/LINGUAS', 'utf-8')
-  .split(' ')
-  .filter(Boolean)
-  .map(function (s) {
-    return s.trim()
-  })
+var linguas = linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
 
 var pkg = require('./package.json')
 

--- a/vault/package-lock.json
+++ b/vault/package-lock.json
@@ -5809,6 +5809,12 @@
         "resolve": "^1.1.7"
       }
     },
+    "linguas-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/linguas-file/-/linguas-file-1.0.0.tgz",
+      "integrity": "sha512-gGUIyQsHTrn7jaeBJteO7CTGZTt7BHC1ad2d/tvNlyEq3Bj1BXgOsINcDzp9GDAMd5YW7UKlWAKeQf5kDbHQKA==",
+      "dev": true
+    },
     "listen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listen/-/listen-1.0.1.tgz",

--- a/vault/package.json
+++ b/vault/package.json
@@ -44,6 +44,7 @@
     "gulp-rev-replace": "^0.4.4",
     "gulp-sri-hash": "^2.2.0",
     "gulp-uglify": "^3.0.2",
+    "linguas-file": "^1.0.0",
     "minify-stream": "^2.1.0",
     "mochify": "^6.2.0",
     "npm-license-crawler": "^0.2.1",


### PR DESCRIPTION
As seen in #585 the handling of LINGUAS files we've done before wasn't 100% sound. Instead we can use the library just published for doing that.