### PR TITLE
Update error message when sharing accounts failed

### DIFF
--- a/auditorium/src/views/components/_shared/share.js
+++ b/auditorium/src/views/components/_shared/share.js
@@ -40,7 +40,7 @@ const Share = (props) => {
         grantAdminPrivileges: grantAdminPrivileges
       },
       __('An invite email has been sent to <em class="%s">%s</em>.', 'i tracked', invitee),
-      __('There was an error inviting the user, please try again.')
+      __('There was an error inviting the user. Could it be that the user already has access?')
     )
       .then(() => {
         setIsDisabled(false)


### PR DESCRIPTION
This likely is the most common error when sharing an account (it sent me hunting for inexistent bugs myself just yesterday) so it's probably a good idea to spell it out.