### PR TITLE
Deprecate stable channel and master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
-# Copyright 2020 - Offen Authors <hioffen@posteo.de>
+# Copyright 2020-2022 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
-
 
 version: 2.1
 
@@ -82,7 +81,7 @@ jobs:
       - run:
           name: Build binaries
           command: |
-            if [ -z "$CIRCLE_TAG" ] && [ "${CIRCLE_BRANCH}" != "development" ] && [ "${CIRCLE_BRANCH}" != "master" ]; then
+            if [ -z "$CIRCLE_TAG" ] && [ "${CIRCLE_BRANCH}" != "development" ]; then
               SKIP_LOCALES="1" make build
             else
               TARGETS=linux/amd64,windows/amd64,linux/arm-7,linux/arm64 make build
@@ -154,11 +153,7 @@ jobs:
           name: Set image tag
           command: |
             if [ -z "$CIRCLE_TAG" ]; then
-              if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                echo 'export DOCKER_IMAGE_TAGS=(stable)' >> $BASH_ENV
-              else
-                echo 'export DOCKER_IMAGE_TAGS=(development)' >> $BASH_ENV
-              fi
+              echo 'export DOCKER_IMAGE_TAGS=(development)' >> $BASH_ENV
             else
               echo 'export DOCKER_IMAGE_TAGS=($CIRCLE_TAG latest)' >> $BASH_ENV
             fi
@@ -217,17 +212,10 @@ jobs:
           name: Build and deploy versioned docs site
           command: |
             if [ -z "$CIRCLE_TAG" ]; then
-              if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                echo "offen_version: stable" >> ./docs/_override.yml
-                echo "baseurl: v/stable" >> ./docs/_override.yml
-                make build-docs
-                mc mirror --remove --overwrite ./docs-site/ offen/docs/v/stable/
-              else
-                echo "offen_version: development" >> ./docs/_override.yml
-                echo "baseurl: v/development" >> ./docs/_override.yml
-                make build-docs
-                mc mirror --remove --overwrite ./docs-site/ offen/docs/v/development/
-              fi
+              echo "offen_version: development" >> ./docs/_override.yml
+              echo "baseurl: v/development" >> ./docs/_override.yml
+              make build-docs
+              mc mirror --remove --overwrite ./docs-site/ offen/docs/v/development/
             else
               mc cp ./docs/robots.txt offen/docs
 
@@ -279,11 +267,10 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v.*/ # tagged release from master branch
+              only: /^v.*/ # tagged release from any branch
             branches:
               only:
                 - development
-                - master
       - release_docs: *default_release_job
 
 commands:

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -6,6 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 <footer role="contentinfo">
   <p class="text-small text-grey-dk-000 mb-0">
     This doc refers to Offen at <a href="https://github.com/offen/offen/releases/">Version {{ site.offen_version }}</a><br>
-    Copyright &copy; Offen. Distributed by an <a href="https://github.com/offen/offen/tree/master/LICENSE">Apache 2.0 license.</a>
+    Copyright &copy; Offen. Distributed by an <a href="https://github.com/offen/offen/tree/development/LICENSE">Apache 2.0 license.</a>
   </p>
 </footer>

--- a/docs/docs/running-offen/downloads-distributions.md
+++ b/docs/docs/running-offen/downloads-distributions.md
@@ -54,11 +54,6 @@ Both for binaries and Docker images you can use one of these channels to pick yo
 
 In case you want to deploy Offen, this channel is what you are most likely going to use. When ready, we cut official releases and tag them with a version identifier (e.g. `v0.1.0`). These releases are immutable and will never change, so both a download and the Docker image are guaranteed to provide the exact same build every time.
 
-### Stable channel
-{: .no_toc }
-
-The `stable` channel gives you the most recent build from the `master` branch of our repository. These are usually stable and ready to use. Be aware that there is not necessarily an upgrade path in between `stable` versions. Only binaries and Docker images are available for this channel.
-
 ### Development channel
 {: .no_toc }
 
@@ -109,13 +104,13 @@ dpkg-sig --verify offen.deb
 
 ## Pulling the Docker image
 
-Docker images are available as `offen/offen` on [Docker Hub][docker-hub]. Tagged releases are available under the respective tag (e.g. `offen/offen:v0.1.0`). The `stable` and `development` channel are available as image tags as well. As per Docker convention `latest` maps to the latest tagged release.
+Docker images are available as `offen/offen` on [Docker Hub][docker-hub]. Tagged releases are available under the respective tag (e.g. `offen/offen:v0.1.0`). The `development` channel is available as an image tag as well. As per Docker convention `latest` maps to the latest tagged release.
 
 ```sh
 # {{ site.offen_version }} release
 docker pull offen/offen:{{ site.offen_version }}
-# stable channel
-docker pull offen/offen:stable
+# development channel
+docker pull offen/offen:development
 ```
 
 ---
@@ -123,7 +118,7 @@ docker pull offen/offen:stable
 __Heads Up__
 {: .label .label-red }
 
-While our version tags on Docker Hub are immutable and __will always return the same build__, it is important to note that `development`, `stable` and `latest` will be updated on a rolling basis. If you deploy Offen using Docker, make sure to use a version tag or pin your image's revision.
+While our version tags on Docker Hub are immutable and __will always return the same build__, it is important to note that `development` and `latest` will be updated on a rolling basis. If you deploy Offen using Docker, make sure to use a version tag or pin your image's revision.
 
 [docker-hub]: https://hub.docker.com/r/offen/offen
 


### PR DESCRIPTION
Solves #589 

This shouldn't be merged before either v0.6.0 or v1.0.0 are released.