### PR TITLE
build: update node version while sticking to npm 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,6 +319,7 @@ commands:
     steps:
       - browser-tools/install-browser-tools
       - checkout
+      - downgrade_npm
       - attach_workspace:
           at: ~/offen
       - run:
@@ -373,6 +374,7 @@ commands:
     steps:
       - checkout:
           path: << parameters.checkout >>
+      - downgrade_npm
       - run:
           name: Install dependencies
           command: npm ci
@@ -392,6 +394,13 @@ commands:
             sudo mv mc /usr/local/bin/mc
             command -v mc
 
+  downgrade_npm:
+    description: Downgrade npm to version 6
+    steps:
+      - run:
+          name: Install npm 6 globally
+          command: sudo npm i -g npm@6
+
 orbs:
   docker: circleci/docker@1.0.1
   browser-tools: circleci/browser-tools@1.1.0
@@ -407,11 +416,11 @@ executors:
         auth: *docker-pull-creds
   node:
     docker:
-      - image: cimg/node:14.17-browsers
+      - image: cimg/node:16.13-browsers
         auth: *docker-pull-creds
   node-postgres:
     docker:
-      - image: cimg/node:14.17-browsers
+      - image: cimg/node:16.13-browsers
         auth: *docker-pull-creds
       - image: circleci/postgres:11.2-alpine
         auth: *docker-pull-creds
@@ -420,7 +429,7 @@ executors:
           POSTGRES_PASSWORD: test
   node-mysql:
     docker:
-      - image: cimg/node:14.17-browsers
+      - image: cimg/node:16.13-browsers
         auth: *docker-pull-creds
       - image: circleci/mysql:5.7.32
         auth: *docker-pull-creds

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,7 +1,7 @@
 # Copyright 2020 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:14
+FROM node:16
 
 # Install these dependencies for using Headless Chrome inside the Container
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
@@ -58,9 +58,10 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
     fonts-thai-tlwg \
     fonts-wqy-zenhei \
     google-chrome-unstable \
-    ttf-freefont \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g npm@6
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV ADBLOCK true

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,9 +1,10 @@
 # Copyright 2020-2021 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:14-alpine as auditorium
+FROM node:16-alpine as auditorium
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -21,9 +22,10 @@ ENV NODE_ENV production
 RUN npm run build
 RUN npm run licenses
 
-FROM node:14-alpine as script
+FROM node:16-alpine as script
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./script/package.json ./script/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -41,9 +43,10 @@ ENV NODE_ENV production
 RUN npm run build
 RUN npm run licenses
 
-FROM node:14-alpine as vault
+FROM node:16-alpine as vault
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./vault/package.json ./vault/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -62,9 +65,10 @@ RUN npm run build
 RUN npm run licenses
 
 # packages does not have a build step but we need to derive license information
-FROM node:14-alpine as packages
+FROM node:16-alpine as packages
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./packages/package.json ./packages/package-lock.json /code/deps/
 COPY ./packages /code/packages

--- a/build/Dockerfile.messages
+++ b/build/Dockerfile.messages
@@ -1,9 +1,10 @@
 # Copyright 2020-2021 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:14-alpine as auditorium
+FROM node:16-alpine as auditorium
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -17,9 +18,10 @@ WORKDIR /code/auditorium
 RUN cp -a /code/deps/node_modules /code/auditorium/
 RUN npm run --silent extract-strings > auditorium.po
 
-FROM node:14-alpine as script
+FROM node:16-alpine as script
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./script/package.json ./script/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -35,9 +37,10 @@ WORKDIR /code/script
 RUN cp -a /code/deps/node_modules /code/script/
 RUN npm run --silent extract-strings > script.po
 
-FROM node:14-alpine as vault
+FROM node:16-alpine as vault
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./vault/package.json ./vault/package-lock.json /code/deps/
 COPY ./packages /code/packages
@@ -53,9 +56,10 @@ WORKDIR /code/vault
 RUN cp -a /code/deps/node_modules /code/vault/
 RUN npm run --silent extract-strings > vault.po
 
-FROM node:14-alpine as packages
+FROM node:16-alpine as packages
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
+RUN npm i -g npm@6
 
 COPY ./packages/package.json ./packages/package-lock.json /code/deps/
 WORKDIR /code/deps
@@ -70,7 +74,7 @@ WORKDIR /code/packages
 RUN cp -a /code/deps/node_modules /code/packages/
 RUN npm run --silent extract-strings > packages.po
 
-FROM golang:1.16
+FROM golang:1.17
 
 RUN apt-get update \
   && apt-get install -y gettext \


### PR DESCRIPTION
Updating npm to 7 or is later is currently not possible because of https://github.com/npm/cli/issues/2339