### PR TITLE
Sysadmin ability to bypass CSS validation

### DIFF
--- a/server/css/sanitize.go
+++ b/server/css/sanitize.go
@@ -6,6 +6,7 @@ package css
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/aymerick/douceur/css"
@@ -98,6 +99,11 @@ func validateRule(rule *css.Rule) error {
 // ValidateCSS makes sure the given CSS does not contain any potentially
 // dangerous rules in the context of being used in the consent banner
 func ValidateCSS(input string) error {
+	validationPolicy := os.Getenv("OFFEN_UNSAFE_CSS")
+	if validationPolicy == "allow" {
+		return nil
+	}
+
 	s, err := parser.Parse(input)
 	if err != nil {
 		return fmt.Errorf("css: error parsing given CSS: %w", err)


### PR DESCRIPTION
This mini PR adds the ability to bypass CSS validation when the `OFFEN_UNSAFE_CSS` system environment variable[^note] is set to `allow`:

- Shell: `$ OFFEN_UNSAFE_CSS=allow offen` ;
- Systemd: `Environment="OFFEN_UNSAFE_CSS=allow"` .

Both directives temporarily disable[^warn] CSS validation, allowing to preview arbitrary consent banners.
The effect is totally reversible and only lasts as long as the execution environment.


[^warn]: keep CSS validation enabled in production.
[^note]: this feature is intended for testing and experimentation. It uses a system environment variable to prevent accidental activation when end users copy-paste the applicative configuration files.