### PR TITLE
Update relative urls in the docs for the deploy docker page.

### DIFF
--- a/docs/docs/running-offen/tutorials/configuring-deploying-offen-docker.md
+++ b/docs/docs/running-offen/tutorials/configuring-deploying-offen-docker.md
@@ -42,7 +42,7 @@ If you get stuck or need help, [file an issue][gh-issues], [tweet (@hioffen)][tw
 
 Apart from having already installed Docker, this tutorial assumes the machine you are planning to run Offen on is connected to the internet and has DNS records for `offen.example.com` (or the domain you are actually planning to use) pointing to it. Ports 80 and 443 are expected to be accessible to the public. See the [documentation for subdomains][domain-doc] for further information on this topic.
 
-[domain-doc]: ./../setting-up-using-subdomains/
+[domain-doc]: ../../setting-up-using-subdomains/
 
 ## Storing your data
 
@@ -54,7 +54,7 @@ In the simple setup described in this tutorial Offen needs to read and persist t
 
 Keeping these files available at any time is required for running the application, so make sure they are not stored on ephemeral systems. If you plan to deploy to a ephemeral host (e.g. Heroku), check ["Configuring The Application At Runtime"][config-docs] for how to configure the application using environment variables and connecting to a remote Database.
 
-[config-docs]: ./../configuring-the-application/
+[config-docs]: ../../configuring-the-application/
 
 ---
 


### PR DESCRIPTION
While reviewing the documentation on https://docs.offen.dev/running-offen/tutorials/configuring-deploying-offen-docker/, I noticed that a couple of the links were broken:
- ["documentation for subdomains"](https://docs.offen.dev/running-offen/tutorials/setting-up-using-subdomains/) 
- [“Configuring The Application At Runtime”](https://docs.offen.dev/running-offen/tutorials/configuring-the-application/)

I think the Jekyll documentation just needs an extra `.` in the reference-style markdown relative links for both of these.