### PR TITLE
Update heroku deploy button url in the docs

### DIFF
--- a/docs/docs/running-offen/tutorials/configuring-deploying-offen-heroku.md
+++ b/docs/docs/running-offen/tutorials/configuring-deploying-offen-heroku.md
@@ -49,7 +49,7 @@ To follow the steps in this tutorial you will need to have created an account wi
 
 You can automatically deploy our [template repository][template] to Heroku using this button:
 
-<a class="btn btn-outline" target="_blank" href="https://heroku.com/deploy?template=https://github.com/offen/heroku/tree/master">Deploy Offen on Heroku</a>
+<a class="btn btn-outline" target="_blank" href="https://heroku.com/deploy?template=https://github.com/offen/heroku">Deploy Offen on Heroku</a>
 
 [template]: https://github.com/offen/heroku
 


### PR DESCRIPTION
Clicking on the "Deploy Offen on Heroku" button on https://docs.offen.dev/running-offen/tutorials/configuring-deploying-offen-heroku results in in an error: "No app.json located in the repo URL provided" (see attached screenshot). The button on the README page of https://github.com/offen/heroku is correct and does work. 

This PR fixes the button on the tutorial page to match the working button on the README in the offen/heroku repo.

<img width="596" alt="Screenshot" src="https://user-images.githubusercontent.com/67701/154145812-cda26bf7-d12b-4a64-99c3-a80ac631e0c9.png">