### PR TITLE
build: skip additional locales when building non-main branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           name: Build binaries
           command: |
             if [ -z "$CIRCLE_TAG" ] && [ "${CIRCLE_BRANCH}" != "development" ] && [ "${CIRCLE_BRANCH}" != "master" ]; then
-              make build
+              SKIP_LOCALES="1" make build
             else
               TARGETS=linux/amd64,windows/amd64,linux/arm-7,linux/arm64 make build
               # Darwin builds cannot be statically linked right now

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ build:
 		--build-arg ldflags=${LDFLAGS} \
 		--build-arg targets=${TARGETS} \
 		--build-arg rev=${OFFEN_GIT_REVISION} \
+		--build-arg skip_locales=${SKIP_LOCALES} \
 		-t offen/build -f build/Dockerfile.build .
 	@mkdir -p bin
 	@docker create --entrypoint=bash -it --name binary offen/build

--- a/auditorium/gulpfile.js
+++ b/auditorium/gulpfile.js
@@ -17,7 +17,9 @@ var linguasFile = require('linguas-file')
 var pkg = require('./package.json')
 
 var defaultLocale = 'en'
-var linguas = linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
+var linguas = !process.env.SKIP_LOCALES
+  ? linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
+  : []
 
 gulp.task('clean:pre', function () {
   return gulp

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -11,6 +11,8 @@ ENV DISABLE_OPENCOLLECTIVE true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
 FROM offen_node as auditorium
+ARG skip_locales
+ENV SKIP_LOCALES=$skip_locales
 COPY ./auditorium/package.json ./auditorium/package-lock.json /code/deps/
 WORKDIR /code/deps
 RUN npm ci
@@ -24,6 +26,8 @@ RUN npm run build
 RUN npm run licenses
 
 FROM offen_node as script
+ARG skip_locales
+ENV SKIP_LOCALES=$skip_locales
 COPY ./script/package.json ./script/package-lock.json /code/deps/
 WORKDIR /code/deps
 RUN npm ci
@@ -37,6 +41,8 @@ RUN npm run build
 RUN npm run licenses
 
 FROM offen_node as vault
+ARG skip_locales
+ENV SKIP_LOCALES=$skip_locales
 COPY ./vault/package.json ./vault/package-lock.json /code/deps/
 WORKDIR /code/deps
 RUN npm ci

--- a/script/gulpfile.js
+++ b/script/gulpfile.js
@@ -15,7 +15,9 @@ var linguasFile = require('linguas-file')
 var pkg = require('./package.json')
 
 var defaultLocale = 'en'
-var linguas = linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
+var linguas = !process.env.SKIP_LOCALES
+  ? linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
+  : []
 
 gulp.task('clean:pre', function () {
   return gulp

--- a/vault/gulpfile.js
+++ b/vault/gulpfile.js
@@ -18,7 +18,9 @@ var minifyStream = require('minify-stream')
 var linguasFile = require('linguas-file')
 
 var defaultLocale = 'en'
-var linguas = linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
+var linguas = !process.env.SKIP_LOCALES
+  ? linguasFile.parse(fs.readFileSync('./locales/LINGUAS', 'utf-8'))
+  : []
 
 var pkg = require('./package.json')
 


### PR DESCRIPTION
For PR builds, there is no need to include non-default locales in the build as the integration tests run against the English version anyways. This should shave around 6 to 7 minutes off such a build.