### PR TITLE
Prevent potential problems from a future colors@>1.4.0 upgrade

### DIFF
--- a/auditorium/package.json
+++ b/auditorium/package.json
@@ -70,6 +70,9 @@
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },
+  "overrides": {
+    "colors@>1.4.0": "1.4.0"
+  },
   "browserify": {
     "transform": [
       "babelify",

--- a/script/package.json
+++ b/script/package.json
@@ -38,6 +38,9 @@
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },
+  "overrides": {
+    "colors@>1.4.0": "1.4.0"
+  },
   "browserify": {
     "transform": [
       "envify",

--- a/vault/package.json
+++ b/vault/package.json
@@ -52,6 +52,9 @@
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },
+  "overrides": {
+    "colors@>1.4.0": "1.4.0"
+  },
   "browserify": {
     "transform": [
       "@offen/schemaify",


### PR DESCRIPTION
After reading https://snyk.io/blog/open-source-npm-packages-colors-faker/ and https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-vulnerability/, I decided to scan all JavaScript repositories on my hard drive for direct and indirect dependencies on the affected packages, using the following terminal command:

```
find . \( -name package-lock.json -or -name yarn.lock \) -exec grep -E 'colors|faker|node-ipc|js-queue|easy-stack|js-message|event-pubsub|node-cmd' '{}' ';' -print
```

(In case others want to run the same command, keep in mind that the path to the matching `package-lock.json` or `yarn.lock` comes *after* the matching lines output by `grep`.)

I found several projects that depended on `colors`, including offen. The patch should ensure that no affected version is installed by accident, even when upgrading intermediate dependencies.