### PR TITLE
build: update browser tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ commands:
 
 orbs:
   docker: circleci/docker@2.1.4
-  browser-tools: circleci/browser-tools@1.1.0
+  browser-tools: circleci/browser-tools@1.4.1
 
 x-docker-pull-creds: &docker-pull-creds
   username: offen


### PR DESCRIPTION
The old version would leave a non-empty directory behind, making a checkout to that destination fail.