### PR TITLE
build: bump version of browser tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ commands:
 
 orbs:
   docker: circleci/docker@2.1.4
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.2
 
 x-docker-pull-creds: &docker-pull-creds
   username: offen


### PR DESCRIPTION
The build is currently broken because of https://github.com/CircleCI-Public/browser-tools-orb/issues/75