### PR TITLE
build: update browser tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ commands:
 
 orbs:
   docker: circleci/docker@2.1.4
-  browser-tools: circleci/browser-tools@1.4.2
+  browser-tools: circleci/browser-tools@1.4.6
 
 x-docker-pull-creds: &docker-pull-creds
   username: offen


### PR DESCRIPTION
The build would currently fail because of an issue in the Orb used https://github.com/CircleCI-Public/browser-tools-orb/issues/95