### PR TITLE
Support runtime secrets for all configuration values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
   integration_postgres:
     environment:
       <<: *integration_env
-      OFFEN_DATABASE_DIALECT: postgres
+      OFFEN_DATABASE_DIALECT_FILE: /tmp/dialect_secret
       OFFEN_DATABASE_CONNECTIONSTRING: postgres://circle:test@localhost:5432/circle_test?sslmode=disable
     executor: node-postgres
     working_directory: ~/offen
@@ -125,6 +125,9 @@ jobs:
       - wait_for:
           service: Postgres
           port: 5432
+      - run:
+          name: Populate secret file
+          command: echo -n "postgres" > /tmp/dialect_secret
       - run_integration_tests
 
   integration_mysql:

--- a/docs/docs/running-offen/configuring-the-application.md
+++ b/docs/docs/running-offen/configuring-the-application.md
@@ -62,6 +62,13 @@ OFFEN_DATABASE_CONNECTIONSTRING="/opt/offen/data/db.sqlite"
 
 ## Configuration options
 
+__Heads Up__
+{: .label .label-red }
+
+All values for options can also be read from files (e.g. using Docker secrets).
+To use this feature, use the option key suffixed with `_FILE` and set the path of the file containing the value,
+e.g. `OFFEN_DATABASE_CONNECTIONSTRING=/run/secrets/db_connection_string`.
+
 ### HTTP server
 
 The `SERVER` namespace collects settings that affect the behavior of the HTTP server that is serving the application.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/offen/envconfig"
 	"github.com/offen/offen/server/keys"
 	"github.com/offen/offen/server/mailer"
 	"github.com/offen/offen/server/mailer/localmailer"

--- a/server/config/overrides.go
+++ b/server/config/overrides.go
@@ -6,7 +6,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/kelseyhightower/envconfig"
+	"github.com/offen/envconfig"
 )
 
 type herokuRuntime struct {

--- a/server/go.mod
+++ b/server/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/jinzhu/gorm v1.9.16
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/leonelquinteros/gotext v1.5.0
 	github.com/lestrrat-go/jwx v1.2.29
@@ -45,6 +44,8 @@ require (
 	gorm.io/driver/sqlite v1.1.5
 	gorm.io/gorm v1.21.15
 )
+
+require github.com/offen/envconfig v1.5.0
 
 require (
 	github.com/bytedance/sonic v1.9.1 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -161,8 +161,6 @@ github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
-github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
-github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
@@ -226,6 +224,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/offen/envconfig v1.5.0 h1:LHL4wYIDVeoGxSDI40MShmWfss3gYUlCdstfSiSq4Fk=
+github.com/offen/envconfig v1.5.0/go.mod h1:L7ny7R+4JWH3VVnZ+ARHvZysWUiZ2eQcm3L0imU9ACY=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=


### PR DESCRIPTION
This replaces package envconfig with the offen-org fork and allows for using the `_FILE` convention when passing sensitive data to the application.