### PR TITLE
Replace 'go-gomail/gomail' with 'wneessen/go-mail'

### DIFF
--- a/docs/docs/running-offen/configuring-the-application.md
+++ b/docs/docs/running-offen/configuring-the-application.md
@@ -211,6 +211,13 @@ Default value `no-reply@offen.dev`.
 
 The From address used when sending transactional email.
 
+### OFFEN_SMTP_AUTHTYPE
+{: .no_toc }
+
+Default value `LOGIN`.
+
+The SMTP authentication type used when sending transactional email. Supported types are: `LOGIN`, `PLAIN`, `CRAM-MD5`, `NOAUTH`.
+
 ---
 
 ### Secrets

--- a/server/cmd/offen/cmddemo.go
+++ b/server/cmd/offen/cmddemo.go
@@ -204,6 +204,11 @@ func cmdDemo(subcommand string, flags []string) {
 		a.logger.WithError(emailsErr).Fatal("Failed parsing template files, cannot continue")
 	}
 
+	mailer, err := a.config.NewMailer()
+	if err != nil {
+		a.logger.WithError(err).Fatal("Failed to initialize mailer")
+	}
+
 	srv := &http.Server{
 		Addr: fmt.Sprintf("0.0.0.0:%d", a.config.Server.Port),
 		Handler: router.New(
@@ -213,7 +218,7 @@ func cmdDemo(subcommand string, flags []string) {
 			router.WithEmails(emails),
 			router.WithConfig(a.config),
 			router.WithFS(fs),
-			router.WithMailer(a.config.NewMailer()),
+			router.WithMailer(mailer),
 		),
 	}
 	go func() {

--- a/server/cmd/offen/cmdserve.go
+++ b/server/cmd/offen/cmdserve.go
@@ -89,6 +89,11 @@ func cmdServe(subcommand string, flags []string) {
 		a.logger.WithError(emailErr).Fatal("Failed parsing template files, cannot continue")
 	}
 
+	mailer, err := a.config.NewMailer()
+	if err != nil {
+		a.logger.WithError(err).Fatal("Failed to initialize mailer")
+	}
+
 	srv := &http.Server{
 		Addr: fmt.Sprintf("0.0.0.0:%d", a.config.Server.Port),
 		Handler: router.New(
@@ -98,7 +103,7 @@ func cmdServe(subcommand string, flags []string) {
 			router.WithEmails(emails),
 			router.WithConfig(a.config),
 			router.WithFS(fs),
-			router.WithMailer(a.config.NewMailer()),
+			router.WithMailer(mailer),
 		),
 	}
 	go func() {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -65,7 +65,7 @@ func (c *Config) SMTPConfigured() bool {
 // NewMailer returns a new mailer that is suitable for the given config.
 // In development, mail content will be printed to stdout. In production,
 // SMTP is preferred and falls back to sendmail if no SMTP credentials are given.
-func (c *Config) NewMailer() mailer.Mailer {
+func (c *Config) NewMailer() (mailer.Mailer, error) {
 	if c.App.Development {
 		return localmailer.New()
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -70,7 +70,7 @@ func (c *Config) NewMailer() (mailer.Mailer, error) {
 		return localmailer.New()
 	}
 	if c.SMTPConfigured() {
-		return smtpmailer.New(c.SMTP.Host, c.SMTP.User, c.SMTP.Password, c.SMTP.Port)
+		return smtpmailer.New(c.SMTP.Host, c.SMTP.User, c.SMTP.Password, c.SMTP.Authtype, c.SMTP.Port)
 	}
 	return sendmailmailer.New()
 }

--- a/server/config/definition_unix.go
+++ b/server/config/definition_unix.go
@@ -36,6 +36,7 @@ type Config struct {
 	}
 	Secret Bytes
 	SMTP   struct {
+		Authtype string `default:"LOGIN"`
 		User     string
 		Password string
 		Host     string

--- a/server/config/definition_windows.go
+++ b/server/config/definition_windows.go
@@ -36,6 +36,7 @@ type Config struct {
 	}
 	Secret Bytes
 	SMTP   struct {
+		Authtype string `default:"LOGIN"`
 		User     string
 		Password string
 		Host     string

--- a/server/go.mod
+++ b/server/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.2
 	github.com/gin-contrib/location v0.0.2
 	github.com/gin-gonic/gin v1.9.1
-	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
@@ -32,12 +31,11 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/schollz/progressbar/v3 v3.8.3
 	github.com/sirupsen/logrus v1.8.1
+	github.com/wneessen/go-mail v0.4.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.18.0
 	golang.org/x/term v0.18.0 // indirect
-	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/mysql v1.1.2
 	gorm.io/driver/postgres v1.1.1

--- a/server/go.sum
+++ b/server/go.sum
@@ -41,8 +41,6 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg=
 github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
-github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df h1:Bao6dhmbTA1KFVxmJ6nBoMuOJit2yjEgLJpIMYpop0E=
-github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df/go.mod h1:GJr+FCSXshIwgHBtLglIg9M2l2kQSi6QjVAngtzI08Y=
 github.com/go-gormigrate/gormigrate/v2 v2.0.0 h1:e2A3Uznk4viUC4UuemuVgsNnvYZyOA8B3awlYk3UioU=
 github.com/go-gormigrate/gormigrate/v2 v2.0.0/go.mod h1:YuVJ+D/dNt4HWrThTBnjgZuRbt7AuwINeg4q52ZE3Jw=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -281,6 +279,8 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/wneessen/go-mail v0.4.1 h1:m2rSg/sc8FZQCdtrV5M8ymHYOFrC6KJAQAIcgrXvqoo=
+github.com/wneessen/go-mail v0.4.1/go.mod h1:zxOlafWCP/r6FEhAaRgH4IC1vg2YXxO0Nar9u0IScZ8=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -403,14 +403,10 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1N
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
-gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=
-gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server/mailer/localmailer/local.go
+++ b/server/mailer/localmailer/local.go
@@ -11,8 +11,8 @@ import (
 
 // New creates a new Mailer that prints the mail to stdout instead of sending
 // actual email. It is supposed to be used in development only.
-func New() mailer.Mailer {
-	return &localMailer{}
+func New() (mailer.Mailer, error) {
+	return &localMailer{}, nil
 }
 
 type localMailer struct{}

--- a/server/mailer/sendmailmailer/mailer.go
+++ b/server/mailer/sendmailmailer/mailer.go
@@ -16,8 +16,8 @@ import (
 )
 
 // New creates a new Mailer that sends email using a local sendmail installation
-func New() mailer.Mailer {
-	return &sendmailMailer{}
+func New() (mailer.Mailer, error) {
+	return &sendmailMailer{}, nil
 }
 
 type sendmailMailer struct{}

--- a/server/mailer/sendmailmailer/mailer.go
+++ b/server/mailer/sendmailmailer/mailer.go
@@ -7,12 +7,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 
-	"github.com/go-gomail/gomail"
 	"github.com/offen/offen/server/mailer"
+	"github.com/wneessen/go-mail"
 )
 
 // New creates a new Mailer that sends email using a local sendmail installation
@@ -23,49 +22,22 @@ func New() (mailer.Mailer, error) {
 type sendmailMailer struct{}
 
 func (s *sendmailMailer) Send(from, to, subject, body string) error {
-	m := gomail.NewMessage()
-	m.SetHeader("From", from)
-	m.SetHeader("To", to)
-	m.SetHeader("Subject", subject)
-	m.SetBody("text/plain", body)
-
-	if err := submitMail(m); err != nil {
-		return fmt.Errorf("sendmailmailer: error sending: %w", err)
+	msg := mail.NewMsg()
+	if err := msg.From(from); err != nil {
+		return fmt.Errorf("failed to set mail FROM: %w", err)
 	}
-	return nil
-}
+	if err := msg.To(to); err != nil {
+		return fmt.Errorf("failed to set mail TO: %w", err)
+	}
+	msg.Subject(subject)
+	msg.SetBodyString(mail.TypeTextPlain, body)
+	msg.SetUserAgent("Offen Fair Web Analytics")
 
-func submitMail(m *gomail.Message) error {
-	// see: https://stackoverflow.com/a/35521846/797194
 	bin, err := lookupSendmail()
 	if err != nil {
 		return fmt.Errorf("sendmailmailer: error looking up sendmail: %w", err)
 	}
-
-	cmd := exec.Command(bin, "-t")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	pw, err := cmd.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("sendmailmailer: error connecting to pipe: %w", err)
-	}
-
-	err = cmd.Start()
-	if err != nil {
-		return fmt.Errorf("sendmailmailer: error starting command: %w", err)
-	}
-
-	var errs [3]error
-	_, errs[0] = m.WriteTo(pw)
-	errs[1] = pw.Close()
-	errs[2] = cmd.Wait()
-	for _, err = range errs {
-		if err != nil {
-			return fmt.Errorf("sendmailmailer: error sending email: %w", err)
-		}
-	}
-	return nil
+	return msg.WriteToSendmailWithCommand(bin)
 }
 
 func lookupSendmail() (string, error) {

--- a/server/mailer/smtpmailer/smtpmailer.go
+++ b/server/mailer/smtpmailer/smtpmailer.go
@@ -4,7 +4,6 @@
 package smtpmailer
 
 import (
-	"errors"
 	"fmt"
 	"github.com/offen/offen/server/mailer"
 	"github.com/wneessen/go-mail"
@@ -29,7 +28,7 @@ func New(endpoint, user, password, authtype string, port int) (mailer.Mailer, er
 		c.SetSMTPAuth(mail.SMTPAuthCramMD5)
 	case "noauth":
 	default:
-		return nil, errors.New("configured SMTP auth type is not supported")
+		return nil, fmt.Errorf("configured SMTP auth type %s is not supported", authtype)
 	}
 
 	return &smtpMailer{c}, nil

--- a/server/mailer/smtpmailer/smtpmailer.go
+++ b/server/mailer/smtpmailer/smtpmailer.go
@@ -4,25 +4,51 @@
 package smtpmailer
 
 import (
-	"github.com/go-gomail/gomail"
+	"errors"
+	"fmt"
 	"github.com/offen/offen/server/mailer"
+	"github.com/wneessen/go-mail"
+	"strings"
 )
 
 // New creates a new Mailer that sends email using the given SMTP configuration
-func New(endpoint, user, password string, port int) (mailer.Mailer, error) {
-	d := gomail.NewDialer(endpoint, port, user, password)
-	return &smtpMailer{d}, nil
+func New(endpoint, user, password, authtype string, port int) (mailer.Mailer, error) {
+	c, err := mail.NewClient(endpoint, mail.WithPort(port), mail.WithUsername(user),
+		mail.WithPassword(password))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize SMTP client: %w", err)
+	}
+
+	// Set SMTP Auth type
+	switch strings.ToLower(authtype) {
+	case "login":
+		c.SetSMTPAuth(mail.SMTPAuthLogin)
+	case "plain":
+		c.SetSMTPAuth(mail.SMTPAuthPlain)
+	case "cram-md5":
+		c.SetSMTPAuth(mail.SMTPAuthCramMD5)
+	default:
+		return nil, errors.New("configured SMTP auth type is not supported")
+	}
+
+	return &smtpMailer{c}, nil
 }
 
 type smtpMailer struct {
-	*gomail.Dialer
+	*mail.Client
 }
 
 func (s *smtpMailer) Send(from, to, subject, body string) error {
-	m := gomail.NewMessage()
-	m.SetHeader("From", from)
-	m.SetHeader("To", to)
-	m.SetHeader("Subject", subject)
-	m.SetBody("text/plain", body)
-	return s.DialAndSend(m)
+	msg := mail.NewMsg()
+	if err := msg.From(from); err != nil {
+		return fmt.Errorf("failed to set mail FROM: %w", err)
+	}
+	if err := msg.To(to); err != nil {
+		return fmt.Errorf("failed to set mail TO: %w", err)
+	}
+	msg.Subject(subject)
+	msg.SetBodyString(mail.TypeTextPlain, body)
+	msg.SetUserAgent("Offen Fair Web Analytics")
+
+	return s.DialAndSend(msg)
 }

--- a/server/mailer/smtpmailer/smtpmailer.go
+++ b/server/mailer/smtpmailer/smtpmailer.go
@@ -9,9 +9,9 @@ import (
 )
 
 // New creates a new Mailer that sends email using the given SMTP configuration
-func New(endpoint, user, password string, port int) mailer.Mailer {
+func New(endpoint, user, password string, port int) (mailer.Mailer, error) {
 	d := gomail.NewDialer(endpoint, port, user, password)
-	return &smtpMailer{d}
+	return &smtpMailer{d}, nil
 }
 
 type smtpMailer struct {

--- a/server/mailer/smtpmailer/smtpmailer.go
+++ b/server/mailer/smtpmailer/smtpmailer.go
@@ -27,6 +27,7 @@ func New(endpoint, user, password, authtype string, port int) (mailer.Mailer, er
 		c.SetSMTPAuth(mail.SMTPAuthPlain)
 	case "cram-md5":
 		c.SetSMTPAuth(mail.SMTPAuthCramMD5)
+	case "noauth":
 	default:
 		return nil, errors.New("configured SMTP auth type is not supported")
 	}


### PR DESCRIPTION
This PR addresses https://github.com/offen/offen/issues/817. It replaces the legacy and not maintained 'go-gomail/gomail' package with 'wneessen/go-mail'.

* Generally this PR changes the signature of the `mailer` constructor to also return an error, since 'wneessen/go-mail' requires this. 
* Additionally it adds `Authtype` as config option. Be default this is set to `LOGIN`, but can be either of `LOGIN`, `PLAIN` or `CRAM-MD5`.
* Since 'wneessen/go-mail' supports local sendmail delivery out of the box, some of the pervious sendmail code has been thrown away.