### PR TITLE
auditorium: cases where children of paragraph element are not strings are not considered

### DIFF
--- a/auditorium/src/views/components/_shared/paragraph.js
+++ b/auditorium/src/views/components/_shared/paragraph.js
@@ -5,9 +5,19 @@
 
 /** @jsx h */
 const { h } = require('preact')
+const _ = require('underscore')
 
 const Paragraph = (props) => {
   const { children, ...otherProps } = props
+  if (!_.isString(children)) {
+    return (
+      <p
+        {...otherProps}
+      >
+        {children}
+      </p>
+    )
+  }
   return (
     <p
       {...otherProps}


### PR DESCRIPTION
Fixes #839 