### PR TITLE
build: use up to date Node and Golang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,15 +401,15 @@ x-docker-pull-creds: &docker-pull-creds
 executors:
   golang:
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.25
         auth: *docker-pull-creds
   node:
     docker:
-      - image: cimg/node:16.13-browsers
+      - image: cimg/node:22.21.0-browsers
         auth: *docker-pull-creds
   node-postgres:
     docker:
-      - image: cimg/node:16.13-browsers
+      - image: cimg/node:22.21.0-browsers
         auth: *docker-pull-creds
       - image: cimg/postgres:15.0
         auth: *docker-pull-creds
@@ -418,7 +418,7 @@ executors:
           POSTGRES_PASSWORD: test
   node-mysql:
     docker:
-      - image: cimg/node:16.13-browsers
+      - image: cimg/node:22.21.0-browsers
         auth: *docker-pull-creds
       - image: cimg/mysql:5.7.38
         auth: *docker-pull-creds
@@ -427,5 +427,5 @@ executors:
           MYSQL_ROOT_PASSWORD: test
   python:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
         auth: *docker-pull-creds

--- a/Dockerfile.golang
+++ b/Dockerfile.golang
@@ -1,7 +1,7 @@
 # Copyright 2020 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.22
+FROM golang:1.25
 
 RUN apt-get update \
   && apt-get install -y \

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,7 +1,7 @@
 # Copyright 2020 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:16
+FROM node:22
 
 # Install these dependencies for using Headless Chrome inside the Container
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
@@ -67,3 +67,4 @@ RUN npm install -g npm@6
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV ADBLOCK true
 ENV DISABLE_OPENCOLLECTIVE true
+ENV NODE_OPTIONS --no-experimental-fetch

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 RUN addgroup -g 10001 -S offen \
-	&& adduser -u 10000 -S -G offen -h /home/offen offen
+  && adduser -u 10000 -S -G offen -h /home/offen offen
 RUN apk add -U --no-cache ca-certificates libcap tini bind-tools
 
 COPY ./bin/offen-linux-$TARGETARCH${TARGETVARIANT:+-$TARGETVARIANT} /opt/offen/offen-linux-$TARGETARCH${TARGETVARIANT:+-$TARGETVARIANT}
@@ -16,9 +16,9 @@ RUN setcap CAP_NET_BIND_SERVICE=+eip /opt/offen/offen-linux-$TARGETARCH${TARGETV
 RUN ln -s /opt/offen/offen-linux-$TARGETARCH${TARGETVARIANT:+-$TARGETVARIANT} /sbin/offen
 
 RUN mkdir -p /var/opt/offen \
-	&& mkdir -p /var/www/.cache \
-	&& mkdir -p /etc/offen \
-	&& chown offen: /var/opt/offen /var/www/.cache /etc/offen
+  && mkdir -p /var/www/.cache \
+  && mkdir -p /etc/offen \
+  && chown offen: /var/opt/offen /var/www/.cache /etc/offen
 
 ENV OFFEN_SERVER_PORT 80
 EXPOSE 80 443

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,7 +1,7 @@
 # Copyright 2020-2021 - Offen Authors <hioffen@posteo.de>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:16-alpine as offen_node
+FROM node:22-alpine as offen_node
 RUN apk add git
 RUN apk add --no-cache --virtual .gyp python3 make g++
 RUN npm i -g npm@6
@@ -9,6 +9,7 @@ COPY ./packages /code/packages
 ENV ADBLOCK true
 ENV DISABLE_OPENCOLLECTIVE true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV NODE_OPTIONS --no-experimental-fetch
 
 FROM offen_node as auditorium
 ARG skip_locales
@@ -98,7 +99,7 @@ RUN python ./create_notice.py \
   --client auditorium.csv \
   --server server.csv >> NOTICE
 
-FROM techknowlogick/xgo:go-1.22.x as compiler
+FROM techknowlogick/xgo:go-1.25.x as compiler
 
 ARG rev
 ENV GIT_REVISION=$rev

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/offen/offen/server
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
This is prep work needed for getting the JS package setup working again without having to rely on ancient versions of npm.